### PR TITLE
Fix RLS build with cargo metadata errors.

### DIFF
--- a/polar/build.rs
+++ b/polar/build.rs
@@ -19,6 +19,8 @@ fn main() {
             // Continue on syntax errors
             if let cbindgen::Error::ParseSyntaxError { .. } = err {
                 Ok(None)
+            } else if let cbindgen::Error::CargoMetadata { .. } = err {
+                Ok(None)
             } else {
                 Err(err)
             }


### PR DESCRIPTION
This error seems to need to pass through the cbindgen build
to the rest of the compiler instead of causing failure.

This makes RLS work for me in VIM locally.