### PR TITLE
PoC of unify not being a goal.

### DIFF
--- a/polar/src/formatting.rs
+++ b/polar/src/formatting.rs
@@ -40,9 +40,6 @@ pub mod display {
                     // value.to_polar(),
                 ),
                 Goal::Query { term } => write!(fmt, "Query({})", term.to_polar()),
-                Goal::Unify { left, right } => {
-                    write!(fmt, "Unify({}, {})", left.to_polar(), right.to_polar())
-                }
                 g => write!(fmt, "{:?}", g),
             }
         }


### PR DESCRIPTION
This thought hit me while I was doing some docs, and figured I would see if it was possible.

Basically: the only place where you _really_ need to push unify goals is when unifying args with rule params, since those you only want to do once you are in a particular choice branch. But it seems to me that pushing a `Query` goal with the term being a `Value::Expression { operator: Unify, ... }` achieves the same thing.

All other places, e.g. doing recursive unifies, doing list unifies, can just become regular calls.

The higher level question is: when do we _need_ there to be goals? Some goals that seem to me like the could go either way are:

- Bind (currently not a goal)
- Unify (currently a goal)
- Backtrack (currently a goal)
- ExternalCallResult (currently not a goal)