### PR TITLE
Deref variables before returning bindings.

### DIFF
--- a/polar/src/vm.rs
+++ b/polar/src/vm.rs
@@ -242,13 +242,7 @@ impl PolarVirtualMachine {
                 continue;
             }
 
-            bindings.insert(
-                var.clone(),
-                match &value.value {
-                    Value::Symbol(sym) => self.value(&sym).unwrap_or(value).clone(),
-                    _ => value.clone(),
-                },
-            );
+            bindings.insert(var.clone(), self.deref(value));
         }
         bindings
     }

--- a/polar/tests/integration_tests.rs
+++ b/polar/tests/integration_tests.rs
@@ -413,3 +413,12 @@ fn test_non_instance_specializers() {
     assert!(qeval(&mut polar, "h({y: 1}, 1)"));
     assert!(qnull(&mut polar, "h({y: 1}, 2)"));
 }
+
+#[test]
+fn test_bindings() {
+    let mut polar = Polar::new();
+    polar
+        .load_str("f(x) := x = y, g(y); g(y) := y = 1;")
+        .unwrap();
+    assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1)]);
+}


### PR DESCRIPTION
Included test case fails without patch, since `x` is bound to `_y_2`.