### PR TITLE
Leina/specializers review

### DIFF
--- a/languages/python/polar/api.py
+++ b/languages/python/polar/api.py
@@ -386,6 +386,8 @@ class Polar:
                 left_instance = self.id_to_instance[left_instance_id]
                 right_instance = self.id_to_instance[right_instance_id]
 
+                # COMMENT (leina): does this get used? This isn't super useful behavior for instances because it only
+                # works predictably if they have `eq()` defined
                 unify = left_instance == right_instance
 
                 result = lib.polar_external_question_result(

--- a/languages/python/tests/parity/test_polar.py
+++ b/languages/python/tests/parity/test_polar.py
@@ -196,7 +196,6 @@ def test_external_classes(tell, qeval, qvar, externals):
     assert qeval('Bar{}.foo = "Bar!"')
 
 
-@pytest.mark.xfail(EXPECT_XFAIL_PASS, reason="isa doesn't check fields.")
 def test_unify_class_fields(tell, qeval, qvar, externals):
     tell("check(name, Foo{name: name})")
 

--- a/polar/src/types.rs
+++ b/polar/src/types.rs
@@ -79,9 +79,7 @@ impl Dictionary {
             fields: BTreeMap::new(),
         }
     }
-}
 
-impl Dictionary {
     fn map<F>(&self, f: &mut F) -> Dictionary
     where
         F: FnMut(&Value) -> Value,
@@ -93,6 +91,10 @@ impl Dictionary {
                 .map(|(k, v)| (k.clone(), v.map(f)))
                 .collect(),
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
     }
 }
 


### PR DESCRIPTION
So far:
- added some more python-side tests for class specializers
- updated `isa` for `left: ExternalInstance, right: InstanceLiteral` case to check fields in addition to class
- added dictionary case to `is_subspecializer`
- updated `is_subspecializer` for `ExternalInstance`s to check fields if the instance type is the same

Questions:
- What should be the ordering for the following rules:
  ```prolog
  test(sub: Sub{c: "c"});
  test(sub: Sub{a: "a", b: "b"});
  ```
  - i.e., specializers are the same class, but different number of fields with no intersection
  - UPDATE: we need to sort these to maintain transitive property. 
    - E.g., 
    ```prolog
    test(sub: Sub{b: "b"};
    test(sub: Sub{c: "c"});
    test(sub: Sub{a: "a", b: "b"});
    ```
    - In the above case,
      - R1 < R2 (order of appearance, since neither is more specific than the other)
      - R3 < R1 (R3 is a superset of R1, and therefore more specific)
      - R2 < R3 (order of appearance, since neither is more specific than the other)
      - By the transitive property, R3 < R2, so we broke it
      - Solution: ordering for the same class but different number of fields ⇒ more fields is more specific, doesn't depend on subset