### PR TITLE
Unify instance literals.

### DIFF
--- a/languages/python/tests/parity/test_polar.py
+++ b/languages/python/tests/parity/test_polar.py
@@ -188,7 +188,6 @@ def test_dictionaries(tell, qeval, qvar):
     assert qvar("x(d), d.a.(k).c = value", "value") == [123, 456]
 
 
-@pytest.mark.xfail(EXPECT_XFAIL_PASS, reason="isa(Bar{}, Foo{}) fails")
 def test_external_classes(tell, qeval, qvar, externals):
     assert qeval("isa(Bar{}, Foo{})")
     assert not qeval("isa(Qux{}, Foo{})")
@@ -224,7 +223,6 @@ def test_keys_are_confusing(tell, qeval, qvar, externals):
     assert not qeval("MyClass{x: 1, y: 2} = MyClass{y: 2}")
 
 
-@pytest.mark.xfail(EXPECT_XFAIL_PASS, reason="isa not yet implemented")
 def test_isa(qeval, qvar, externals):
     assert qeval("isa({}, {})")
     assert qeval("isa({x: 1}, {})")

--- a/polar/src/vm.rs
+++ b/polar/src/vm.rs
@@ -895,6 +895,17 @@ impl PolarVirtualMachine {
                 }
             }
 
+            (Value::InstanceLiteral(left), Value::InstanceLiteral(right)) => {
+                if left.tag == right.tag {
+                    self.push_goal(Goal::Unify {
+                        left: Term::new(Value::Dictionary(left.fields.clone())),
+                        right: Term::new(Value::Dictionary(right.fields.clone())),
+                    });
+                } else {
+                    self.push_goal(Goal::Backtrack)
+                }
+            }
+
             // external instances can unify if they are exactly the same type, i.e. have
             // the same instance ID
             // this is necessary for the case that an instance appears multiple times


### PR DESCRIPTION
Unfortunately also needed to make isa work on two literals,
because you get isa(Foo{}, y, Foo{}), so it wants to check that
arg1 = Foo{} = arg3

(See the now passing tests).