### PR TITLE
convert instance literals to external instances in to_python

### DIFF
--- a/languages/python/polar/api.py
+++ b/languages/python/polar/api.py
@@ -329,7 +329,6 @@ class Polar:
 
         return instance
 
-
     def _do_query(self, q):
         """Method which performs the query loop over an already contructed query"""
         with CleanupQuery(q) as query:


### PR DESCRIPTION
Fix for: https://www.notion.so/osohq/Have-a-different-type-for-returning-class-tags-to-ExternalIsa-so-that-to_python-doesn-t-need-to-retu-e921e7000232467ab73aba5304764bbf

Turns out that `ExternalIsa` did NOT depend on us converting instance literals to python classes, so this didn't impact anything but now the behavior makes much more sense.