### PR TITLE
Expose low level query interface in python.

### DIFF
--- a/languages/python/oso/__init__.py
+++ b/languages/python/oso/__init__.py
@@ -59,7 +59,7 @@ class Oso(api.Polar):
         audit.log(actor, action, resource, result)
         return result.success
 
-    def query(self, name, *args, debug=False) -> QueryResult:
+    def query_predicate(self, name, *args, debug=False) -> QueryResult:
         """Query for predicate with name ``name`` and args ``args``.
 
         :param name: The name of the predicate to query.

--- a/languages/python/oso/test_oso.py
+++ b/languages/python/oso/test_oso.py
@@ -132,11 +132,11 @@ def test_allow(test_oso):
     assert test_oso.allow(token("president"), action, resource)
 
 
-def test_query(test_oso):
+def test_query_predicate(test_oso):
     actor = Actor(name="guest")
     resource = Widget(id="1")
     action = "get"
-    assert test_oso.query("allow", actor, action, resource).success
+    assert test_oso.query_predicate("allow", actor, action, resource).success
 
 
 def test_fail(test_oso):


### PR DESCRIPTION
This adds a new query method on the Oso object that queries any predicate.

If we are happy with this interface, I will add the same for Ruby.

An alternative would be to expose _query_pred directly (without the underscore).