### PR TITLE
Example using is_checked predicate to select between old & new auth code.

### DIFF
--- a/languages/python/docs/examples/transition/policy.polar
+++ b/languages/python/docs/examples/transition/policy.polar
@@ -1,0 +1,8 @@
+is_checked(_: OsoModel);
+
+allow(actor, action, resource: OsoModel) := 1 = 1;
+
+
+is_checked(_: OsoModel2);
+
+allow(actor, action, resource: OsoModel2) := 1 = 0;

--- a/languages/python/docs/examples/transition/policy.py
+++ b/languages/python/docs/examples/transition/policy.py
@@ -1,0 +1,25 @@
+import oso
+
+from pathlib import Path
+
+class OsoModel:
+    pass
+
+class OsoModel2:
+    pass
+
+class NotOsoModel:
+    pass
+
+def setup(oso):
+    oso.load_file(Path(__file__).parent / 'policy.polar')
+
+    oso.register_class(OsoModel)
+    oso.register_class(OsoModel2)
+    oso.register_class(NotOsoModel)
+
+def auth(oso, actor, action, resource, next):
+    if not oso.query_predicate("is_checked", resource).success:
+        return next(actor, action, resource)
+    else:
+        return oso.allow(actor, action, resource)

--- a/languages/python/docs/examples/transition/test_example.py
+++ b/languages/python/docs/examples/transition/test_example.py
@@ -1,0 +1,23 @@
+import pytest
+import functools
+
+from oso import Oso
+
+import policy
+from policy import OsoModel, OsoModel2, NotOsoModel
+
+@pytest.fixture
+def auth():
+    oso_ = Oso()
+    policy.setup(oso_)
+
+    return functools.partial(policy.auth, oso_)
+
+def test_correct(auth):
+    called = object()
+    def next(*args):
+        return called
+
+    assert auth("a", "a", OsoModel(), next) is True
+    assert auth("a", "a", OsoModel2(), next) is False
+    assert auth("a", "a", NotOsoModel(), next) is called


### PR DESCRIPTION
Use `is_checked` predicate and `query_predicate` to select whether to use oso or an old auth system (referenced in this example as `next`).