### PR TITLE
Policy with explicit deny & deny reason.

### DIFF
--- a/languages/python/docs/examples/explicit-deny/policy.polar
+++ b/languages/python/docs/examples/explicit-deny/policy.polar
@@ -1,0 +1,17 @@
+# Deny all mallories
+_deny(actor, action, resource, reason) := actor.name = "Mallory",
+    reason = "Actor in blacklist";
+
+_allow(actor, action, resource: {name: "allowed"});
+_allow(actor, action, resource: {name: "allowed2"});
+
+# Deny rules take precedence due to cut().
+decide(actor, action, resource, "deny", reason) :=
+    _deny(actor, action, resource, reason), cut();
+
+# If there was no deny, this branch will be evaluated.
+decide(actor, action, resource, "allow", _) :=
+    _allow(actor, action, resource), cut();
+
+# If neither matched, then deny
+decide(actor, action, resource, "deny", "Default deny");

--- a/languages/python/docs/examples/explicit-deny/policy.py
+++ b/languages/python/docs/examples/explicit-deny/policy.py
@@ -1,0 +1,18 @@
+import pathlib
+
+import oso
+from polar import Variable
+
+
+def setup(oso):
+    oso.load_file(pathlib.Path(__file__).parent / "policy.polar")
+
+def auth(oso, actor, action, resource):
+    results = oso.query_predicate(
+        "decide", actor, action, resource, Variable("result"), Variable("reason"))
+
+    try:
+        result = results.results[0]
+        return result['result'] == 'allow', result['reason']
+    except IndexError:
+        return False, "No result"

--- a/languages/python/docs/examples/explicit-deny/test_example.py
+++ b/languages/python/docs/examples/explicit-deny/test_example.py
@@ -1,0 +1,32 @@
+import functools
+import pytest
+
+import oso
+
+import policy
+
+@pytest.fixture
+def auth():
+    oso_ = oso.Oso()
+    policy.setup(oso_)
+    return functools.partial(policy.auth, oso_)
+
+
+def test_policy(auth):
+    alice = {'name': "Alice"}
+    bob = {'name': "Bob"}
+    mallory = {'name': "Mallory"}
+
+    allowed = {'name': "allowed"}
+    allowed2 = {'name': "allowed2"}
+    unknown = {'name': "unknown"}
+
+    assert auth(alice, "a", allowed)[0] is True
+    assert auth(alice, "a", allowed2)[0] is True
+    assert auth(bob, "a", allowed)[0] is True
+
+    assert auth(mallory, "a", allowed2) == (False, "Actor in blacklist")
+    assert auth(mallory, "a", allowed) == (False, "Actor in blacklist")
+    assert auth(mallory, "a", unknown) == (False, "Actor in blacklist")
+
+    assert auth(alice, "a", unknown) == (False, "Default deny")

--- a/languages/python/polar/api.py
+++ b/languages/python/polar/api.py
@@ -166,9 +166,12 @@ class Polar:
                 args=[self._to_python(v) for v in value[tag]["args"]],
             )
         elif tag == "Symbol":
-            raise PolarRuntimeException(
-                f"variable: {value} is unbound. make sure the value is set before using it in a method call"
-            )
+            # TODO (dhatch): Temp change so I can return unbound values to Python (this should be
+            # allowed but maybe the API needs to be different)
+            return Variable(value[tag])
+            # raise PolarRuntimeException(
+            #     f"variable: {value} is unbound. make sure the value is set before using it in a method call"
+            # )
         raise PolarRuntimeException(f"cannot convert: {value} to Python")
 
     def _to_polar_term(self, v):


### PR DESCRIPTION
This policy uses a top level `decide(actor, action, resource, result, reason)` rule to allow for explicit results (deny or allow) to be returned with a reason for why a certain result was returned.

In the process I hit on a limitation of our API.  We cannot return unbound variables to the host language.  Temporarily fixed this & will write down a task for next time.