### PR TITLE
Allow unbound variables to be returned from queries

### DIFF
--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -306,6 +306,8 @@ public class Host implements Cloneable {
             case "Call":
                 List<Object> args = polarListToJava(value.getJSONObject(tag).getJSONArray("args"));
                 return new Predicate(value.getJSONObject(tag).getString("name"), args);
+            case "Variable":
+                return new Variable(value.getString(tag));
             default:
                 throw new Exceptions.UnexpectedPolarTypeError(tag);
         }

--- a/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
+++ b/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
@@ -417,6 +417,15 @@ public class PolarTest {
                 "Expected error.");
     }
 
+    @Test
+    public void testUnboundVariable() throws Exception {
+      p.loadStr("rule(x, y) if y = 1;");
+      List<HashMap<String, Object>> results = p.query("rule(x, y)").results();
+      HashMap<String, Object> result = results.get(0);
+      assertTrue(result.get("x") instanceof Variable);
+      assertEquals(result.get("y"), 1);
+    }
+
     /*** TEST OSO ***/
     @Test
     public void testPathMapper() throws Exception {

--- a/languages/python/polar/host.py
+++ b/languages/python/polar/host.py
@@ -182,7 +182,6 @@ class Host:
                 args=[self.to_python(v) for v in value[tag]["args"]],
             )
         elif tag == "Variable":
-            raise PolarRuntimeException(
-                f"variable: {value} is unbound. make sure the value is set before using it in a method call"
-            )
+            return Variable(value[tag])
+
         raise PolarRuntimeException(f"cannot convert {value} to Python")

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -599,7 +599,6 @@ def test_host_methods(polar, qeval):
     assert qeval("l = [1, 2, 3] and l.index(3) = 2 and l.copy() = [1, 2, 3]")
     assert qeval('d = {a: 1} and d.get("a") = 1 and d.get("b", 2) = 2')
 
-
 def test_register_constants_with_decorator():
     @polar_class
     class RegisterDecoratorTest:
@@ -626,3 +625,16 @@ def test_register_constants_with_decorator():
         == 1
     )
     assert p.query_predicate("foo_class_attr", Variable("y")).results[0]["y"] == 1
+
+def test_unbound_variable(polar):
+    """Test that unbound variable is returned."""
+    polar.load_str("rule(x, y) if y = 1;")
+
+    results = polar._query_str("rule(x, y)")
+    first = next(results)
+
+    # y will be bound to 1
+    first['y'] = 1
+
+    # x should be unbound
+    assert isinstance(first['x'], Variable)

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -599,6 +599,7 @@ def test_host_methods(polar, qeval):
     assert qeval("l = [1, 2, 3] and l.index(3) = 2 and l.copy() = [1, 2, 3]")
     assert qeval('d = {a: 1} and d.get("a") = 1 and d.get("b", 2) = 2')
 
+
 def test_register_constants_with_decorator():
     @polar_class
     class RegisterDecoratorTest:
@@ -625,6 +626,7 @@ def test_register_constants_with_decorator():
         == 1
     )
     assert p.query_predicate("foo_class_attr", Variable("y")).results[0]["y"] == 1
+
 
 def test_unbound_variable(polar, query):
     """Test that unbound variable is returned."""

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -626,12 +626,11 @@ def test_register_constants_with_decorator():
     )
     assert p.query_predicate("foo_class_attr", Variable("y")).results[0]["y"] == 1
 
-def test_unbound_variable(polar):
+def test_unbound_variable(polar, query):
     """Test that unbound variable is returned."""
     polar.load_str("rule(x, y) if y = 1;")
 
-    results = polar._query_str("rule(x, y)")
-    first = next(results)
+    first = query("rule(x, y)")[0]
 
     # y will be bound to 1
     first["y"] = 1

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -634,7 +634,7 @@ def test_unbound_variable(polar):
     first = next(results)
 
     # y will be bound to 1
-    first['y'] = 1
+    first["y"] = 1
 
     # x should be unbound
-    assert isinstance(first['x'], Variable)
+    assert isinstance(first["x"], Variable)

--- a/languages/ruby/expense.rb
+++ b/languages/ruby/expense.rb
@@ -1,0 +1,15 @@
+class Expense
+  attr_reader :amount, :description, :submitted_by
+
+  def initialize(amount, description, submitted_by)
+    @amount = amount
+    @description = description
+    @submitted_by = submitted_by
+  end
+end
+
+EXPENSES = {
+  1 => Expense.new(500,   'coffee',   'alice@example.com'),
+  2 => Expense.new(5000,  'software', 'alice@example.com'),
+  3 => Expense.new(50_000, 'flight', 'bhavik@example.com')
+}.freeze

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -226,6 +226,8 @@ module Oso
           get_instance(value['instance_id'])
         when 'Call'
           Predicate.new(value['name'], args: value['args'].map { |a| to_ruby(a) })
+        when 'Variable'
+          Variable.new(value['name'])
         else
           raise UnexpectedPolarTypeError, tag
         end

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -624,4 +624,16 @@ EOM
         expect(e).to be_an Oso::Polar::PolarRuntimeError
       end
     end
+
+  context 'unbound variable' do
+    it 'returns unbound properly' do
+      subject.load_str("rule(x, y) if y = 1;")
+
+      results = query(subject, "rule(x, y)")
+      first = results[0]
+
+      expect(first['y']).to be 1
+      expect(first['x']).to be_instance_of(Oso::Polar::Variable)
+    end
+  end
 end


### PR DESCRIPTION
- An unbound variable is returned as the `Variable` type.  Does this seem like the correct implementation? Other options could be returning nil or none, or not including the key in the bindings map.

PR checklist:

- [ ] Add to java implementation
- [ ] Added changelog entry.
