### PR TITLE
Host language debugger

### DIFF
--- a/docs/more/dev-tools/debugger.rst
+++ b/docs/more/dev-tools/debugger.rst
@@ -5,39 +5,40 @@ Debugger
 The Polar debugger allows debugging of policy rules. It can be helpful to see
 why a rule is behaving differently than expected.
 
-.. highlight:: polar
-
 ********************
 Running the debugger
 ********************
 
-The debugger can be entered through two mechanisms:
+The debugger is entered through the ``debug()`` predicate. It acts like
+a break point: when the VM tries to query for that predicate, it stops
+instead and enters the debugger. You may put it anywhere in the body of
+a rule:
 
-  1. Add the ``debug()`` predicate in the body of the rule you want to debug in
-     your Polar file. The debugger will be entered when that rule body is
-     evaluated by the Polar VM. For example::
+.. code-block:: polar
 
-       myRule() if debug() and 1 = 0;
+     some_rule(x) if debug(x) and 1 = 0;
 
-  2. In the REPL, issue a query of the form: ``debug() and <query>``. This will
-     enter the debugger before starting the query.
+You can also query for it directly from the REPL:
 
-Entering the debugger will pause evaluation of the policy, and a command prompt
-will appear:
+.. code-block:: console
+
+    query> debug()
+
+When evaluation hits a ``debug()``, the ``debug>`` prompt will appear:
 
 .. code-block:: console
 
   Welcome to the debugger!
-  >
+  debug>
 
-Since Polar is declarative, execution does not always flow sequentially through
-a rule's body. Entering the debugger allows us to navigate through the
-evaluation of a policy and interrogate the current state of the engine at every
-step along the way.
+The debugger operates as a simple command-driven REPL, much like other
+low-level debuggers such as GDB, LLDB, or JDB. You can exit the debugger
+at any time by typing ``continue`` or ``quit`` followed by ``Enter``,
+or by typing ``Ctrl-D`` (EOF).
 
-************************
-Available debug commands
-************************
+*****************
+Debugger Commands
+*****************
 
 Help
 ====
@@ -49,7 +50,7 @@ Print the debugger command reference.
 
 .. code-block:: console
 
-  > help
+  debug> help
   Debugger Commands
     bindings                Print current binding stack.
     c[ontinue]              Continue evaluation.
@@ -71,6 +72,9 @@ Print the debugger command reference.
 Navigation
 ==========
 
+The debugger allows you to navigate through the evaluation of a policy and
+interrogate the current state of the engine at every step along the way.
+
 The Polar file used in the following examples looks like this:
 
 .. code-block:: polar
@@ -87,28 +91,28 @@ Evaluate one goal (one instruction on the Polar VM). This is *very* low level.
 
 .. code-block:: console
 
-  > line
+  debug> line
   003: c() if debug();
               ^
-  > step
+  debug> step
   PopQuery(debug)
-  > step
+  debug> step
   PopQuery(debug)
-  > line
+  debug> line
   001: a() if debug() and b() and c() and d();
                                   ^
 
 ``c[ontinue]`` or ``q[uit]``
 ----------------------------
 
-Continue evaluation.
+Continue evaluation after the ``debug()`` predicate.
 
 .. code-block:: console
 
-  > line
+  debug> line
   001: a() if debug() and b() and c() and d();
                                   ^
-  > continue
+  debug> continue
   [exit]
 
 ``over`` or ``n[ext]``
@@ -119,24 +123,24 @@ Continue evaluation until the next query.
 .. code-block:: console
 
   Welcome to the debugger!
-  > line
+  debug> line
   001: a() if debug() and b() and c() and d();
               ^
-  > over
+  debug> over
   001: a() if debug() and b() and c() and d();
                           ^
-  > over
+  debug> over
   001: a() if debug() and b() and c() and d();
                                   ^
-  > over
+  debug> over
   Welcome to the debugger!
-  > line
+  debug> line
   003: c() if debug();
               ^
-  > over
+  debug> over
   001: a() if debug() and b() and c() and d();
                                           ^
-  > over
+  debug> over
   [exit]
 
 ``out``
@@ -148,18 +152,18 @@ sibling of the parent query (if one exists).
 .. code-block:: console
 
   Welcome to the debugger!
-  > line
+  debug> line
   001: a() if debug() and b() and c() and d();
               ^
-  > out
+  debug> out
   Welcome to the debugger!
-  > line
+  debug> line
   003: c() if debug();
               ^
-  > out
+  debug> out
   001: a() if debug() and b() and c() and d();
                                           ^
-  > out
+  debug> out
   [exit]
 
 Context
@@ -182,10 +186,10 @@ Print current stack of goals.
 .. code-block:: console
 
   Welcome to the debugger!
-  > line
+  debug> line
   001: a() if debug() and b() and c() and d();
               ^
-  > goals
+  debug> goals
   PopQuery(a())
   PopQuery(debug(), b(), c(), d())
   Query(d())
@@ -201,10 +205,10 @@ lines of additional context above and below it.
 
 .. code-block:: console
 
-  > line
+  debug> line
   003: c() if debug();
               ^
-  > line 2
+  debug> line 2
   001: a() if debug() and b() and c() and d();
   002: b();
   003: c() if debug();
@@ -218,10 +222,10 @@ Print current stack of queries.
 
 .. code-block:: console
 
-  > line
+  debug> line
   001: a() if debug() and b() and c() and d();
               ^
-  > queries
+  debug> queries
   a()
   debug() and b() and c() and d()
   debug()
@@ -248,15 +252,15 @@ the current scope, print ``<unbound>``.
 
 .. code-block:: console
 
-  > line
+  debug> line
   001: a() if x = y and y = z and z = 3 and debug();
                                    ^
-  > var
+  debug> var
   _y_22, _x_21, _z_23
-  > var _x_21 _z_23
+  debug> var _x_21 _z_23
   _x_21 = 3
   _z_23 = 3
-  > var foo
+  debug> var foo
   foo = <unbound>
 
 
@@ -267,10 +271,10 @@ Print all variable bindings in the current scope.
 
 .. code-block:: console
 
-  > line
+  debug> line
   001: a() if x = y and y = z and z = 3 and debug();
                                             ^
-  > bindings
+  debug> bindings
   _x_21 = _y_22
   _y_22 = _z_23
   _z_23 = 3

--- a/docs/more/dev-tools/index.rst
+++ b/docs/more/dev-tools/index.rst
@@ -2,8 +2,6 @@
 Developer Tools
 ===============
 
-.. todo:: REPL page is out of date.
-
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/more/dev-tools/repl.rst
+++ b/docs/more/dev-tools/repl.rst
@@ -62,6 +62,8 @@ the response is ``true``. Otherwise, each set of bindings that *makes*
 it true is printed; e.g., the third example above has one such set,
 the fourth has two.
 
+To exit the REPL, type ``Ctrl-D`` (EOF).
+
 Loading Policy and Application Code
 ===================================
 

--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -198,7 +198,10 @@ public class Host implements Cloneable {
         } else if (value instanceof Variable) {
             jVal.put("Variable", value);
         } else {
-            jVal.put("ExternalInstance", new JSONObject().put("instance_id", cacheInstance(value, null)));
+            JSONObject attrs = new JSONObject();
+            attrs.put("instance_id", cacheInstance(value, null));
+            attrs.put("repr", value.toString());
+            jVal.put("ExternalInstance", attrs);
         }
 
         // Build Polar term

--- a/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
@@ -1,5 +1,6 @@
 package com.osohq.oso;
 
+import java.io.IOException;
 import java.util.*;
 
 public class Oso extends Polar {
@@ -21,5 +22,9 @@ public class Oso extends Polar {
      */
     public boolean isAllowed(Object actor, Object action, Object resource) throws Exceptions.OsoException {
         return query("allow", List.of(actor, action, resource)).hasMoreElements();
+    }
+
+    public static void main(String[] args) throws Exceptions.OsoException, IOException {
+        new Oso().repl(args);
     }
 }

--- a/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
@@ -1,7 +1,6 @@
 package com.osohq.oso;
 
 import java.io.BufferedReader;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
@@ -112,6 +111,18 @@ public class Polar {
      * @throws Exceptions.OsoException
      */
     public void repl() throws Exceptions.OsoException, IOException {
+        repl(new String[0]);
+    }
+
+    /**
+     * Load the given files and start the Polar REPL.
+     *
+     * @throws Exceptions.OsoException
+     */
+    public void repl(String[] files) throws Exceptions.OsoException, IOException {
+        for (String file : files) {
+            loadFile(file);
+        }
         loadQueuedFiles();
 
         BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
@@ -154,11 +165,7 @@ public class Polar {
     }
 
     public static void main(String[] args) throws Exceptions.OsoException, IOException {
-        Polar polar = new Polar();
-        for (String file : args) {
-            polar.loadFile(file);
-        }
-        polar.repl();
+        new Polar().repl(args);
     }
 
     /**

--- a/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
@@ -119,7 +119,7 @@ public class Polar {
         Query query;
         String input;
         while (true) {
-            System.out.print("> ");
+            System.out.print("query> ");
             input = in.readLine();
             if (input == null) {
                 return;

--- a/languages/java/oso/src/main/java/com/osohq/oso/Query.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Query.java
@@ -145,11 +145,11 @@ public class Query implements Enumeration<HashMap<String, Object>> {
                         System.out.println(message);
                     }
                     BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-                    System.out.print("> ");
+                    System.out.print("debug> ");
                     try {
                         String input = br.readLine();
-                        if (input == "")
-                            input = " ";
+                        if (input == null)
+                            break;
                         String command = host.toPolarTerm(input).toString();
                         ffiQuery.debugCommand(command);
                     } catch (IOException e) {

--- a/languages/python/polar/host.py
+++ b/languages/python/polar/host.py
@@ -153,7 +153,12 @@ class Host:
         elif isinstance(v, Variable):
             val = {"Variable": v}
         else:
-            val = {"ExternalInstance": {"instance_id": self.cache_instance(v)}}
+            val = {
+                "ExternalInstance": {
+                    "instance_id": self.cache_instance(v),
+                    "repr": repr(v),
+                }
+            }
         term = {"value": val}
         return term
 

--- a/languages/python/polar/polar.py
+++ b/languages/python/polar/polar.py
@@ -110,7 +110,7 @@ class Polar:
 
         while True:
             try:
-                query = input("> ").strip(";")
+                query = input("query> ").strip(";")
             except EOFError:
                 return
             ffi_query = lib.polar_new_query(self.ffi_polar, to_c_str(query))

--- a/languages/python/polar/query.py
+++ b/languages/python/polar/query.py
@@ -157,6 +157,9 @@ class Query:
     def handle_debug(self, query, data):
         if data["message"]:
             print(data["message"])
-        command = input("> ")
+        try:
+            command = input("debug> ").strip(";")
+        except EOFError:
+            command = "continue"
         stringified = ffi_serialize(self.host.to_polar_term(command))
         check_result(lib.polar_debug_command(query, stringified))

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -198,7 +198,7 @@ module Oso
                   # This is supported so that we can query for unbound variables
                   { 'Variable' => value }
                 else
-                  { 'ExternalInstance' => { 'instance_id' => cache_instance(value) } }
+                  { 'ExternalInstance' => { 'instance_id' => cache_instance(value), 'repr' => value.to_s } }
                 end
         { 'value' => value }
       end

--- a/languages/ruby/lib/oso/polar/polar.rb
+++ b/languages/ruby/lib/oso/polar/polar.rb
@@ -90,7 +90,7 @@ module Oso
         load_queued_files
 
         loop do
-          print('> ')
+          print('query> ')
           begin
             query = STDIN.readline.chomp.chomp(';')
           rescue EOFError

--- a/languages/ruby/lib/oso/polar/query.rb
+++ b/languages/ruby/lib/oso/polar/query.rb
@@ -150,8 +150,12 @@ module Oso
               question_result(answer, call_id: event.data['call_id'])
             when 'Debug'
               puts event.data['message'] if event.data['message']
-              print '> '
-              input = $stdin.gets.chomp!
+              print 'debug> '
+              begin
+                input = STDIN.readline.chomp.chomp(';')
+              rescue EOFError
+                next
+              end
               command = JSON.dump(host.to_polar_term(input))
               ffi_query.debug_command(command)
             else

--- a/polar/benches/bench.rs
+++ b/polar/benches/bench.rs
@@ -222,6 +222,7 @@ impl Runner {
         Term::new_from_test(Value::ExternalInstance(ExternalInstance {
             instance_id,
             literal: Some(literal),
+            repr: None,
         }))
     }
 }

--- a/polar/src/formatting.rs
+++ b/polar/src/formatting.rs
@@ -299,7 +299,11 @@ pub mod to_polar {
 
     impl ToPolarString for ExternalInstance {
         fn to_polar(&self) -> String {
-            format!("^{{id: {}}}", self.instance_id)
+            if let Some(ref repr) = self.repr {
+                repr.clone()
+            } else {
+                format!("^{{id: {}}}", self.instance_id)
+            }
         }
     }
 

--- a/polar/src/types.rs
+++ b/polar/src/types.rs
@@ -90,6 +90,7 @@ impl InstanceLiteral {
 pub struct ExternalInstance {
     pub instance_id: u64,
     pub literal: Option<InstanceLiteral>,
+    pub repr: Option<String>,
 }
 
 // Context stored somewhere by id.
@@ -848,6 +849,7 @@ mod tests {
         let external = Term::new_from_test(Value::ExternalInstance(ExternalInstance {
             instance_id: 12345,
             literal: None,
+            repr: None,
         }));
         let list_of = Term::new_from_test(Value::List(vec![external]));
         eprintln!("{}", serde_json::to_string(&list_of).unwrap());

--- a/polar/src/vm.rs
+++ b/polar/src/vm.rs
@@ -1174,6 +1174,7 @@ impl PolarVirtualMachine {
                 literal_term.replace_value(Value::ExternalInstance(ExternalInstance {
                     instance_id,
                     literal: Some(literal_value.clone()),
+                    repr: Some(literal_value.to_polar()),
                 }));
 
                 // A goal is used here in case the result is already bound to some external
@@ -2609,6 +2610,7 @@ mod tests {
         let external_instance = Value::ExternalInstance(ExternalInstance {
             literal: None,
             instance_id: 1,
+            repr: None,
         });
 
         let mut vm = PolarVirtualMachine::new(
@@ -2666,6 +2668,7 @@ mod tests {
         let arg = term!(Value::ExternalInstance(ExternalInstance {
             instance_id: 1,
             literal: None,
+            repr: None,
         }));
         let left = term!(value!(Pattern::Instance(InstanceLiteral {
             tag: sym!("Any"),


### PR DESCRIPTION
Debugger works in all three host languages. Displays application instances using their native string representations:
```
>>> from oso import Oso, Http
>>> o = Oso()
>>> o.load_str("d(x) if debug(x);")
>>> o.query_predicate("d", Http(hostname="foo")).success
Welcome to the debugger!
debug(Http(hostname="foo"))
debug> bindings
Http = <class 'oso.extras.Http'>
Datetime = <class 'datetime.datetime'>
Timedelta = <class 'datetime.timedelta'>
PathMapper = <class 'oso.extras.PathMapper'>
_x_1 = Http(hostname="foo")
_x_2 = Http(hostname="foo")
debug> continue
True
```

PR checklist:
- [x] Docs
