### PR TITLE
Update python query API

### DIFF
--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -10,6 +10,14 @@ Breaking changes
 .. warning:: This release contains breaking changes. Be sure
    to follow migration steps before upgrading.
 
+oso.query_predicate() renamed in oso libraries
+----------------------------------------------
+
+To improve our API & better match documentation, ``oso.query_predicate()``
+has been renamed ``oso.query_rule()``. The Python API now returns
+a generator instead of a ``QueryResult`` object to improve consistency
+across libraries.
+
 allow() method renamed in oso libraries
 ---------------------------------------
 

--- a/docs/examples/abac/java/TestAbac.java
+++ b/docs/examples/abac/java/TestAbac.java
@@ -26,7 +26,7 @@ public class TestAbac {
         Oso oso = setupOso();
         for (String policy : policies) {
             oso.loadFile(policy);
-            oso.query("test", null); // just to force the load
+            oso.queryRule("test", null); // just to force the load
         }
     }
 

--- a/docs/examples/abac/java/TestAbac.java
+++ b/docs/examples/abac/java/TestAbac.java
@@ -26,7 +26,7 @@ public class TestAbac {
         Oso oso = setupOso();
         for (String policy : policies) {
             oso.loadFile(policy);
-            oso.queryRule("test", null); // just to force the load
+            oso.queryRule("test"); // just to force the load
         }
     }
 

--- a/docs/getting-started/application/patterns.rst
+++ b/docs/getting-started/application/patterns.rst
@@ -264,7 +264,7 @@ We can combine this access control with our record level access control
             for field, value in expense.items():
                 # Check if each field in the expense is allowed, and only
                 # include those that are in authorized_data.
-                if oso.query_predicate("allow_field", actor, "view", expense, field):
+                if oso.query_rule("allow_field", actor, "view", expense, field):
                     authorized_data[field] = value
 
             # Return only authorized_data to the user.
@@ -293,7 +293,7 @@ control to only load the columns the user can access:
 
     def get_expense(user, expense_id):
         # Query oso for all fields allowed for this user.
-        allowed_fields = oso.query_predicate("allow_field",
+        allowed_fields = oso.query_rule("allow_field",
                                    user, "view", expense, Variable("field"))
         # Convert the returned query response into a list of fields
         allowed_fields = [r["field"] for r in allowed_fields]
@@ -463,8 +463,8 @@ request filter.
             ("location_id", "=", user.location_id)
         ]
 
-        # Use ``query_predicate`` to evaluate a rule that authorizes the filter.
-        if not oso.query_predicate("allow_filter", user, "view", Expense, auth_filters):
+        # Use ``query_rule`` to evaluate a rule that authorizes the filter.
+        if not oso.query_rule("allow_filter", user, "view", Expense, auth_filters):
             return NotAuthorizedResponse()
 
         # This function converts our structured filter into a SQL WHERE statement
@@ -543,7 +543,7 @@ Now, in our app:
 
     def get_expenses(user):
         # Get authorization filters from oso
-        filters = oso.query_predicate(
+        filters = oso.query_rule(
             "allow_with_filter", actor, "view", resource, Variable("filters"))
 
         # There may be multiple allow rules that matched, so we iterate over all

--- a/docs/getting-started/policies/index.rst
+++ b/docs/getting-started/policies/index.rst
@@ -168,7 +168,7 @@ in Polar. Any time a rule body contains a **predicate** like this, it is perform
 another query. I.e. it will try and find all *matching* rules called "role" with
 two inputs.
 
-You can also either use the :doc:`/more/dev-tools/repl` or the ``oso.query_predicate``
+You can also either use the :doc:`/more/dev-tools/repl` or the ``oso.query_rule``
 method to interact with this directly. For example:
 
 .. code-block:: python
@@ -186,7 +186,7 @@ method to interact with this directly. For example:
   oso.load_str("role(user, role_name) if user.role = role_name;")
 
   alice = User("alice", "accountant")
-  assert oso.query_predicate("role", alice, "accountant")
+  assert oso.query_rule("role", alice, "accountant")
 
 Summary
 =======

--- a/examples/expenses-py/app.py
+++ b/examples/expenses-py/app.py
@@ -135,14 +135,11 @@ def load_oso():
 
 if __name__ == "__main__":
     """Loads and checks the policy.
-    
+
     Run example with `python app.py repl` to run the REPL after loading
     the policy.
     """
     oso = load_oso()
-    # WOWHACK until API stabilizes.
-    if os.getenv("OSO_COMPAT"):
-        setattr(oso, "_load_queued_files", oso._kb_load)
     oso._load_queued_files()
     print("Policy loaded OK")
 

--- a/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
@@ -21,7 +21,7 @@ public class Oso extends Polar {
      * @throws Exceptions.OsoException
      */
     public boolean isAllowed(Object actor, Object action, Object resource) throws Exceptions.OsoException {
-        return queryRule("allow", List.of(actor, action, resource)).hasMoreElements();
+        return queryRule("allow", actor, action, resource).hasMoreElements();
     }
 
     public static void main(String[] args) throws Exceptions.OsoException, IOException {

--- a/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
@@ -21,7 +21,7 @@ public class Oso extends Polar {
      * @throws Exceptions.OsoException
      */
     public boolean isAllowed(Object actor, Object action, Object resource) throws Exceptions.OsoException {
-        return query("allow", List.of(actor, action, resource)).hasMoreElements();
+        return queryRule("allow", List.of(actor, action, resource)).hasMoreElements();
     }
 
     public static void main(String[] args) throws Exceptions.OsoException, IOException {

--- a/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
@@ -85,23 +85,23 @@ public class Polar {
      * @param query String string
      * @return Query object (Enumeration of resulting variable bindings).
      */
-    public Query query(String query) throws Exceptions.OsoException {
+    public Query queryStr(String query) throws Exceptions.OsoException {
         loadQueuedFiles();
         return new Query(ffiPolar.newQueryFromStr(query), host.clone());
     }
 
     /**
-     * Query for a predicate.
+     * Query for a rule.
      *
-     * @param predicate Predicate name, e.g. "f" for predicate "f(x)".
-     * @param args List of predicate arguments.
+     * @param rule Rule name, e.g. "f" for rule "f(x)".
+     * @param args List of rule arguments.
      * @return Query object (Enumeration of resulting variable bindings).
      * @throws Exceptions.OsoException
      */
-    public Query query(String predicate, List<Object> args) throws Exceptions.OsoException {
+    public Query queryRule(String rule, List<Object> args) throws Exceptions.OsoException {
         loadQueuedFiles();
         Host new_host = host.clone();
-        String pred = new_host.toPolarTerm(new Predicate(predicate, args)).toString();
+        String pred = new_host.toPolarTerm(new Predicate(rule, args)).toString();
         return new Query(ffiPolar.newQueryFromTerm(pred), new_host);
     }
 

--- a/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
@@ -85,23 +85,36 @@ public class Polar {
      * @param query String string
      * @return Query object (Enumeration of resulting variable bindings).
      */
-    public Query queryStr(String query) throws Exceptions.OsoException {
+    public Query query(String query) throws Exceptions.OsoException {
         loadQueuedFiles();
         return new Query(ffiPolar.newQueryFromStr(query), host.clone());
+    }
+
+    /**
+     * Query for a predicate.
+     *
+     * @param query as a Predicate
+     * @return Query object (Enumeration of resulting variable bindings).
+     */
+    public Query query(Predicate query) throws Exceptions.OsoException {
+        loadQueuedFiles();
+        Host new_host = host.clone();
+        String pred = new_host.toPolarTerm(query).toString();
+        return new Query(ffiPolar.newQueryFromTerm(pred), new_host);
     }
 
     /**
      * Query for a rule.
      *
      * @param rule Rule name, e.g. "f" for rule "f(x)".
-     * @param args List of rule arguments.
+     * @param args Variable list of rule arguments.
      * @return Query object (Enumeration of resulting variable bindings).
      * @throws Exceptions.OsoException
      */
-    public Query queryRule(String rule, List<Object> args) throws Exceptions.OsoException {
+    public Query queryRule(String rule, Object... args) throws Exceptions.OsoException {
         loadQueuedFiles();
         Host new_host = host.clone();
-        String pred = new_host.toPolarTerm(new Predicate(rule, args)).toString();
+        String pred = new_host.toPolarTerm(new Predicate(rule, Arrays.asList(args))).toString();
         return new Query(ffiPolar.newQueryFromTerm(pred), new_host);
     }
 
@@ -190,8 +203,8 @@ public class Polar {
      * @param fromPolar lambda function to convert from a
      *                  {@code Map<String, Object>} of parameters to an instance of
      *                  the Java class.
-     * @param name     name to register the class under, which is how the class is
-     *                 accessed from Polar.
+     * @param name      name to register the class under, which is how the class is
+     *                  accessed from Polar.
      * @throws Exceptions.DuplicateClassAliasError if a class has already been
      *                                             registered with the given alias.
      */

--- a/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
+++ b/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
@@ -19,12 +19,9 @@ public class PolarTest {
         return p.queryStr(query);
     }
 
-
     public Query query(String rule, List<Object> args) throws Exceptions.OsoException {
-        retrun p.queryRule(rule, args);
+        return p.queryRule(rule, args);
     }
-
-
 
     public static class MyClass {
         public String name;
@@ -103,8 +100,7 @@ public class PolarTest {
         // test basic query
         p.loadStr("f(a, b) if a = b;");
         assertFalse(query("f", List.of(1, 1)).results().isEmpty(), "Basic predicate query failed.");
-        assertTrue(query("f", List.of(1, 2)).results().isEmpty(),
-                "Basic predicate query expected to fail but didn't.");
+        assertTrue(query("f", List.of(1, 2)).results().isEmpty(), "Basic predicate query expected to fail but didn't.");
     }
 
     @Test
@@ -292,8 +288,7 @@ public class PolarTest {
     @Test
     public void testExternalIsa() throws Exception {
         p.loadStr("f(a: MyClass, x) if x = a.id;");
-        List<HashMap<String, Object>> result = query("f", List.of(new MyClass("test", 1), new Variable("x")))
-                .results();
+        List<HashMap<String, Object>> result = query("f", List.of(new MyClass("test", 1), new Variable("x"))).results();
         assertTrue(result.equals(List.of(Map.of("x", 1))));
         p.clear();
 
@@ -383,8 +378,7 @@ public class PolarTest {
         w.write(";");
         w.close();
         p.loadFile(tempFile.getPath());
-        assertThrows(Exceptions.ParseError.class, () -> query("f(1)"),
-                "Failed to pass filename across FFI boundary.");
+        assertThrows(Exceptions.ParseError.class, () -> query("f(1)"), "Failed to pass filename across FFI boundary.");
         tempFile.deleteOnExit();
     }
 
@@ -424,8 +418,7 @@ public class PolarTest {
     public void testLookupErrors() throws Exception {
         p.registerClass(Foo.class, m -> new Foo(), "Foo");
         assertEquals(List.of(), query("new Foo{} = {bar: \"bar\"}").results());
-        assertThrows(Exceptions.PolarRuntimeException.class, () -> query("new Foo{}.bar = \"bar\""),
-                "Expected error.");
+        assertThrows(Exceptions.PolarRuntimeException.class, () -> query("new Foo{}.bar = \"bar\""), "Expected error.");
     }
 
     @Test

--- a/languages/python/oso/flask.py
+++ b/languages/python/oso/flask.py
@@ -29,8 +29,11 @@ class OsoFlask(Oso):
             credentials = {}
         action = request.method.lower()
         resource = Http(path=request.path, hostname=hostname)
-        query = Predicate(name="allow", args=(credentials, action, resource))
-        return list(f(r) for r in self.query(query, single=True).results if f(r))
+        return list(
+            f(r)
+            for r in self.query_rule("allow", credentials, action, resource)
+            if f(r)
+        )
 
     def verify_flask_request(
         self,
@@ -49,5 +52,4 @@ class OsoFlask(Oso):
             credentials = {}
         action = request.method.lower()
         resource = Http(path=request.path, hostname=hostname)
-        query = Predicate(name="allow", args=(credentials, action, resource))
-        return self.query(query, single=True).success
+        return len(list(self.query("allow", credentials, action, resource))) > 0

--- a/languages/python/oso/oso.py
+++ b/languages/python/oso/oso.py
@@ -51,5 +51,8 @@ class Oso(Polar):
 
         :return: ``True`` if the request is allowed, ``False`` otherwise.
         """
-        result = self.query_rule("allow", actor, action, resource, single=True)
-        return result.success
+        try:
+            next(self.query_rule("allow", actor, action, resource))
+            return True
+        except StopIteration:
+            return False

--- a/languages/python/oso/oso.py
+++ b/languages/python/oso/oso.py
@@ -51,5 +51,5 @@ class Oso(Polar):
 
         :return: ``True`` if the request is allowed, ``False`` otherwise.
         """
-        result = self.query_predicate("allow", actor, action, resource, single=True)
+        result = self.query_rule("allow", actor, action, resource, single=True)
         return result.success

--- a/languages/python/oso/test_oso.py
+++ b/languages/python/oso/test_oso.py
@@ -85,9 +85,7 @@ def test_decorators(test_oso):
     actor = Actor(name="president")
     action = "create"
     resource = Company(id="1")
-    assert test_oso.query(
-        Predicate(name="allow", args=(actor, action, resource))
-    ).success
+    assert list(test_oso.query(Predicate(name="allow", args=(actor, action, resource))))
 
 
 @polar_class
@@ -129,7 +127,7 @@ def test_query_rule(test_oso):
     actor = Actor(name="guest")
     resource = Widget(id="1")
     action = "get"
-    assert test_oso.query_rule("allow", actor, action, resource).success
+    assert list(test_oso.query_rule("allow", actor, action, resource))
 
 
 def test_fail(test_oso):

--- a/languages/python/oso/test_oso.py
+++ b/languages/python/oso/test_oso.py
@@ -125,11 +125,11 @@ def test_is_allowed(test_oso):
     assert test_oso.is_allowed(token("president"), action, resource)
 
 
-def test_query_predicate(test_oso):
+def test_query_rule(test_oso):
     actor = Actor(name="guest")
     resource = Widget(id="1")
     action = "get"
-    assert test_oso.query_predicate("allow", actor, action, resource).success
+    assert test_oso.query_rule("allow", actor, action, resource).success
 
 
 def test_fail(test_oso):

--- a/languages/python/polar/ffi.py
+++ b/languages/python/polar/ffi.py
@@ -63,22 +63,11 @@ def ffi_deserialize(string):
             lib.string_free(string)
 
 
-def load_str(polar, string, filename, do_query):
+def load_str(polar, string, filename):
     """Load a Polar string, checking that all inline queries succeed."""
     string = to_c_str(string)
     filename = to_c_str(str(filename)) if filename else ffi.NULL
     check_result(lib.polar_load(polar, string, filename))
-
-    # check inline queries
-    while True:
-        query = lib.polar_next_inline_query(polar)
-        if is_null(query):  # Load is done
-            break
-        else:
-            try:
-                next(do_query(query))
-            except StopIteration:
-                raise PolarRuntimeException("Inline query in file failed.")
 
 
 def new_id(polar):

--- a/languages/python/polar/polar.py
+++ b/languages/python/polar/polar.py
@@ -72,11 +72,7 @@ class Polar:
         if isinstance(query, str):
             query = check_result(lib.polar_new_query(self.ffi_polar, to_c_str(query)))
         elif isinstance(query, Predicate):
-            query = check_result(
-                lib.polar_new_query_from_term(
-                    self.ffi_polar, ffi_serialize(host.to_polar_term(query))
-                )
-            )
+
         else:
             raise PolarApiException(f"Can not query for {query}")
 
@@ -87,15 +83,19 @@ class Polar:
                 break
         return QueryResult(results)
 
-    def query_predicate(self, name, *args, **kwargs):
-        """Query for predicate with name ``name`` and args ``args``.
+    def query_rule(self, name, *args, **kwargs):
+        """Query for rule with name ``name`` and args ``args``.
 
         :param name: The name of the predicate to query.
         :param args: Arguments for the predicate.
 
         :return: The result of the query.
         """
-        return self.query(Predicate(name=name, args=args), **kwargs)
+        return check_result(
+            lib.polar_new_query_from_term(
+                self.ffi_polar, ffi_serialize(host.to_polar_term(Predicate(name=name, args=args))
+            )
+        )
 
     def run(self, query, host=None):
         """Send an FFI query object to a new Query object for evaluation."""

--- a/languages/python/polar/polar.py
+++ b/languages/python/polar/polar.py
@@ -94,7 +94,7 @@ class Polar:
         for res in Query(query, host=host).run():
             yield res["bindings"]
 
-    def query_rule(self, name, *args, **kwargs):
+    def query_rule(self, name, *args):
         """Query for rule with name ``name`` and args ``args``.
 
         :param name: The name of the predicate to query.

--- a/languages/python/polar/query.py
+++ b/languages/python/polar/query.py
@@ -44,13 +44,9 @@ class Query:
 
     def run(self):
         """Run the event loop and yield results."""
-        if ffi_query is None:
-            ffi_query = self.ffi_query
-        else:
-            self.ffi_query = ffi_query
-        assert ffi_query, "no query to run"
+        assert self.ffi_query, "no query to run"
         while True:
-            event_s = lib.polar_next_query_event(ffi_query)
+            event_s = lib.polar_next_query_event(self.ffi_query)
             event = ffi_deserialize(event_s)
             if event == "Done":
                 break
@@ -60,17 +56,17 @@ class Query:
             if kind == "MakeExternal":
                 self.handle_make_external(data)
             if kind == "ExternalCall":
-                self.handle_external_call(ffi_query, data)
+                self.handle_external_call(self.ffi_query, data)
             if kind == "ExternalOp":
-                self.handle_external_op(ffi_query, data)
+                self.handle_external_op(self.ffi_query, data)
             if kind == "ExternalIsa":
-                self.handle_external_isa(ffi_query, data)
+                self.handle_external_isa(self.ffi_query, data)
             if kind == "ExternalUnify":
-                self.handle_external_unify(ffi_query, data)
+                self.handle_external_unify(self.ffi_query, data)
             if kind == "ExternalIsSubSpecializer":
-                self.handle_external_is_subspecializer(ffi_query, data)
+                self.handle_external_is_subspecializer(self.ffi_query, data)
             if kind == "Debug":
-                self.handle_debug(ffi_query, data)
+                self.handle_debug(self.ffi_query, data)
             if kind == "Result":
                 bindings = {
                     k: self.host.to_python(v) for k, v in data["bindings"].items()

--- a/languages/python/polar/query.py
+++ b/languages/python/polar/query.py
@@ -56,17 +56,17 @@ class Query:
             if kind == "MakeExternal":
                 self.handle_make_external(data)
             if kind == "ExternalCall":
-                self.handle_external_call(self.ffi_query, data)
+                self.handle_external_call(data)
             if kind == "ExternalOp":
-                self.handle_external_op(self.ffi_query, data)
+                self.handle_external_op(data)
             if kind == "ExternalIsa":
-                self.handle_external_isa(self.ffi_query, data)
+                self.handle_external_isa(data)
             if kind == "ExternalUnify":
-                self.handle_external_unify(self.ffi_query, data)
+                self.handle_external_unify(data)
             if kind == "ExternalIsSubSpecializer":
-                self.handle_external_is_subspecializer(self.ffi_query, data)
+                self.handle_external_is_subspecializer(data)
             if kind == "Debug":
-                self.handle_debug(self.ffi_query, data)
+                self.handle_debug(data)
             if kind == "Result":
                 bindings = {
                     k: self.host.to_python(v) for k, v in data["bindings"].items()
@@ -81,7 +81,7 @@ class Query:
         fields = {k: self.host.to_python(v) for k, v in fields.items()}
         self.host.make_instance(cls_name, fields, id)
 
-    def handle_external_call(self, query, data):
+    def handle_external_call(self, data):
         call_id = data["call_id"]
         if call_id not in self.calls:
             value = data["instance"]["value"]
@@ -98,8 +98,8 @@ class Query:
             try:
                 attr = getattr(instance, attribute)
             except AttributeError as e:
-                application_error(query, str(e))
-                external_call(query, call_id, None)
+                application_error(self.ffi_query, str(e))
+                external_call(self.ffi_query, call_id, None)
                 return
 
             if callable(attr):  # If it's a function, call it with the args.
@@ -119,38 +119,38 @@ class Query:
         try:
             value = next(self.calls[call_id])
             stringified = ffi_serialize(self.host.to_polar_term(value))
-            external_call(query, call_id, stringified)
+            external_call(self.ffi_query, call_id, stringified)
         except StopIteration:
-            external_call(query, call_id, None)
+            external_call(self.ffi_query, call_id, None)
 
-    def handle_external_op(self, query, data):
+    def handle_external_op(self, data):
         op = data["operator"]
         args = [self.host.to_python(arg) for arg in data["args"]]
         answer = self.host.operator(op, args)
-        external_answer(query, data["call_id"], answer)
+        external_answer(self.ffi_query, data["call_id"], answer)
 
-    def handle_external_isa(self, query, data):
+    def handle_external_isa(self, data):
         instance_id = data["instance_id"]
         class_tag = data["class_tag"]
         isa = self.host.isa(instance_id, class_tag)
-        external_answer(query, data["call_id"], isa)
+        external_answer(self.ffi_query, data["call_id"], isa)
 
-    def handle_external_unify(self, query, data):
+    def handle_external_unify(self, data):
         left_instance_id = data["left_instance_id"]
         right_instance_id = data["right_instance_id"]
         unify = self.host.unify(left_instance_id, right_instance_id)
-        external_answer(query, data["call_id"], unify)
+        external_answer(self.ffi_query, data["call_id"], unify)
 
-    def handle_external_is_subspecializer(self, query, data):
+    def handle_external_is_subspecializer(self, data):
         instance_id = data["instance_id"]
         left_tag = data["left_class_tag"]
         right_tag = data["right_class_tag"]
         is_subspecializer = self.host.is_subspecializer(
             instance_id, left_tag, right_tag
         )
-        external_answer(query, data["call_id"], is_subspecializer)
+        external_answer(self.ffi_query, data["call_id"], is_subspecializer)
 
-    def handle_debug(self, query, data):
+    def handle_debug(self, data):
         if data["message"]:
             print(data["message"])
         try:
@@ -158,4 +158,4 @@ class Query:
         except EOFError:
             command = "continue"
         stringified = ffi_serialize(self.host.to_polar_term(command))
-        check_result(lib.polar_debug_command(query, stringified))
+        check_result(lib.polar_debug_command(self.ffi_query, stringified))

--- a/languages/python/polar/query.py
+++ b/languages/python/polar/query.py
@@ -42,7 +42,7 @@ class Query:
         del self.host
         lib.query_free(self.ffi_query)
 
-    def run(self, ffi_query=None):
+    def run(self):
         """Run the event loop and yield results."""
         if ffi_query is None:
             ffi_query = self.ffi_query

--- a/languages/python/polar/test_helpers.py
+++ b/languages/python/polar/test_helpers.py
@@ -52,7 +52,13 @@ def query(polar):
     """ Query something and return the results as a list """
 
     def _query(q):
-        return polar.query(q).results
+        if isinstance(q, str):
+            res = polar.query_str(q)
+        elif isinstance(q, Predicate):
+            res = polar.query_rule(q.name, q.args)
+        else:
+            raise PolarApiException(f"Can not query for {query}")
+        return res.results
 
     return _query
 

--- a/languages/python/polar/test_helpers.py
+++ b/languages/python/polar/test_helpers.py
@@ -52,13 +52,7 @@ def query(polar):
     """ Query something and return the results as a list """
 
     def _query(q):
-        if isinstance(q, str):
-            res = polar.query_str(q)
-        elif isinstance(q, Predicate):
-            res = polar.query_rule(q.name, q.args)
-        else:
-            raise PolarApiException(f"Can not query for {query}")
-        return res.results
+        return list(polar.query(q))
 
     return _query
 
@@ -68,7 +62,7 @@ def qeval(polar, query):
     """ Query something and return if there's exactly 1 result """
 
     def _qeval(q):
-        result = query(q)
+        result = list(query(q))
         return len(result) == 1
 
     return _qeval

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -604,23 +604,17 @@ def test_register_constants_with_decorator():
     p.load_str("foo_rule(x: RegisterDecoratorTest, y) if y = 1;")
     p.load_str("foo_class_attr(y) if y = RegisterDecoratorTest.x;")
     assert (
-        p.query_rule("foo_rule", RegisterDecoratorTest(), Variable("y")).results[
-            0
-        ]["y"]
-        == 1
+        next(p.query_rule("foo_rule", RegisterDecoratorTest(), Variable("y")))["y"] == 1
     )
-    assert p.query_rule("foo_class_attr", Variable("y")).results[0]["y"] == 1
+    assert next(p.query_rule("foo_class_attr", Variable("y")))["y"] == 1
 
     p = Polar()
     p.load_str("foo_rule(x: RegisterDecoratorTest, y) if y = 1;")
     p.load_str("foo_class_attr(y) if y = RegisterDecoratorTest.x;")
     assert (
-        p.query_rule("foo_rule", RegisterDecoratorTest(), Variable("y")).results[
-            0
-        ]["y"]
-        == 1
+        next(p.query_rule("foo_rule", RegisterDecoratorTest(), Variable("y")))["y"] == 1
     )
-    assert p.query_rule("foo_class_attr", Variable("y")).results[0]["y"] == 1
+    assert next(p.query_rule("foo_class_attr", Variable("y")))["y"] == 1
 
 def test_unbound_variable(polar, query):
     """Test that unbound variable is returned."""

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -604,24 +604,23 @@ def test_register_constants_with_decorator():
     p.load_str("foo_rule(x: RegisterDecoratorTest, y) if y = 1;")
     p.load_str("foo_class_attr(y) if y = RegisterDecoratorTest.x;")
     assert (
-        p.query_predicate("foo_rule", RegisterDecoratorTest(), Variable("y")).results[
+        p.query_rule("foo_rule", RegisterDecoratorTest(), Variable("y")).results[
             0
         ]["y"]
         == 1
     )
-    assert p.query_predicate("foo_class_attr", Variable("y")).results[0]["y"] == 1
+    assert p.query_rule("foo_class_attr", Variable("y")).results[0]["y"] == 1
 
     p = Polar()
     p.load_str("foo_rule(x: RegisterDecoratorTest, y) if y = 1;")
     p.load_str("foo_class_attr(y) if y = RegisterDecoratorTest.x;")
     assert (
-        p.query_predicate("foo_rule", RegisterDecoratorTest(), Variable("y")).results[
+        p.query_rule("foo_rule", RegisterDecoratorTest(), Variable("y")).results[
             0
         ]["y"]
         == 1
     )
-    assert p.query_predicate("foo_class_attr", Variable("y")).results[0]["y"] == 1
-
+    assert p.query_rule("foo_class_attr", Variable("y")).results[0]["y"] == 1
 
 def test_unbound_variable(polar, query):
     """Test that unbound variable is returned."""

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -504,7 +504,7 @@ def test_instance_cache(polar, qeval):
     assert Counter.count == 0
     c = Counter()
     assert Counter.count == 1
-    assert polar.query_predicate("f", c).success
+    assert polar.query_rule("f", c).success
     assert Counter.count == 1
     assert c not in polar.host.instances.values()
 

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -616,6 +616,7 @@ def test_register_constants_with_decorator():
     )
     assert next(p.query_rule("foo_class_attr", Variable("y")))["y"] == 1
 
+
 def test_unbound_variable(polar, query):
     """Test that unbound variable is returned."""
     polar.load_str("rule(x, y) if y = 1;")

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -9,14 +9,13 @@ from polar.exceptions import ParserException
 import pytest
 
 
-def test_anything_works():
-    p = Polar()
-    p.load_str("f(1);")
-    results = p.query("f(x)").results
+def test_anything_works(polar, query):
+    polar.load_str("f(1);")
+    results = query("f(x)")
     assert results[0]["x"] == 1
-    results = p.query("f(y)").results
+
+    results = query("f(y)")
     assert results[0]["y"] == 1
-    del p
 
 
 def test_helpers(polar, load_file, query, qeval, qvar):
@@ -25,7 +24,7 @@ def test_helpers(polar, load_file, query, qeval, qvar):
     assert qvar("f(x)", "x") == [1, 2, 3]
 
 
-def test_data_conversions(polar, qvar):
+def test_data_conversions(polar, qvar, query):
     polar.load_str('a(1);b("two");c(true);d([1,"two",true]);')
     assert qvar("a(x)", "x", one=True) == 1
     assert qvar("b(x)", "x", one=True) == "two"
@@ -377,13 +376,13 @@ def test_parser_errors(polar):
     # ExtraToken -- not sure what causes this
 
 
-def test_runtime_errors(polar):
+def test_runtime_errors(polar, query):
     rules = """
     foo(a,b) := a in b;
     """
     polar.load_str(rules)
     with pytest.raises(exceptions.PolarRuntimeException) as e:
-        list(polar.query("foo(1,2)"))
+        query("foo(1,2)")
     assert (
         str(e.value)
         == """trace (most recent evaluation last):
@@ -397,7 +396,7 @@ Type error: can only use `in` on a list, this is Variable(Symbol("_a_3")) at lin
     )
 
 
-def test_lookup_errors(polar):
+def test_lookup_errors(polar, query):
     class Foo:
         def foo(self):
             return "foo"
@@ -405,24 +404,22 @@ def test_lookup_errors(polar):
     polar.register_class(Foo)
 
     # Unify with an invalid field doesn't error.
-    assert polar.query('new Foo{} = {bar: "bar"}').results == []
+    assert query('new Foo{} = {bar: "bar"}') == []
     # Dot op with an invalid field does error.
     with pytest.raises(exceptions.PolarRuntimeException) as e:
-        polar.query('new Foo{}.bar = "bar"').results == []
+        query('new Foo{}.bar = "bar"') == []
     assert "Application error: 'Foo' object has no attribute 'bar'" in str(e.value)
 
 
-def test_predicate(polar, qvar):
+def test_predicate(polar, qvar, query):
     """Test that predicates can be converted to and from python."""
     polar.load_str("f(x) if x = pred(1, 2);")
     assert qvar("f(x)", "x") == [Predicate("pred", [1, 2])]
 
-    assert polar.query(
-        Predicate(name="f", args=[Predicate("pred", [1, 2])])
-    ).results == [{}]
+    assert query(Predicate(name="f", args=[Predicate("pred", [1, 2])])) == [{}]
 
 
-def test_return_list(polar):
+def test_return_list(polar, query):
     class Actor:
         def groups(self):
             return ["engineering", "social", "admin"]
@@ -432,16 +429,16 @@ def test_return_list(polar):
     # for testing lists
     polar.load_str('allow(actor: Actor, "join", "party") if "social" in actor.groups;')
 
-    assert polar.query(Predicate(name="allow", args=[Actor(), "join", "party"])).success
+    assert query(Predicate(name="allow", args=[Actor(), "join", "party"]))
 
 
-def test_query(load_file, polar):
+def test_query(load_file, polar, query):
     """Test that queries work with variable arguments"""
 
     load_file(Path(__file__).parent / "test_file.polar")
     # plaintext polar query: query("f(x)") == [{"x": 1}, {"x": 2}, {"x": 3}]
 
-    assert polar.query(Predicate(name="f", args=[Variable("a")])).results == [
+    assert query(Predicate(name="f", args=[Variable("a")])) == [
         {"a": 1},
         {"a": 2},
         {"a": 3},
@@ -491,7 +488,7 @@ def test_constructor(polar, qvar):
     )
 
 
-def test_instance_cache(polar, qeval):
+def test_instance_cache(polar, qeval, query):
     class Counter:
         count = 0
 
@@ -504,7 +501,7 @@ def test_instance_cache(polar, qeval):
     assert Counter.count == 0
     c = Counter()
     assert Counter.count == 1
-    assert polar.query_rule("f", c).success
+    assert query(Predicate(name="f", args=[c]))
     assert Counter.count == 1
     assert c not in polar.host.instances.values()
 
@@ -533,7 +530,7 @@ def test_unify(polar, qeval):
     assert qeval("foo()")
 
 
-def test_external_op(polar):
+def test_external_op(polar, query):
     class A:
         def __init__(self, a):
             self.a = a
@@ -554,12 +551,12 @@ def test_external_op(polar):
 
     polar.load_str("lt(a, b) if a < b;")
     polar.load_str("gt(a, b) if a > b;")
-    assert polar.query(Predicate("lt", [a1, a2])).success
-    assert not polar.query(Predicate("lt", [a2, a1])).success
-    assert polar.query(Predicate("gt", [a2, a1])).success
+    assert query(Predicate("lt", [a1, a2]))
+    assert not query(Predicate("lt", [a2, a1]))
+    assert query(Predicate("gt", [a2, a1]))
 
 
-def test_datetime(polar):
+def test_datetime(polar, query):
 
     # test datetime comparison
     t1 = datetime(2020, 5, 25)
@@ -568,31 +565,29 @@ def test_datetime(polar):
     t4 = datetime(2020, 5, 26)
 
     polar.load_str("lt(a, b) if a < b;")
-    assert polar.query(Predicate("lt", [t1, t2])).success
-    assert not polar.query(Predicate("lt", [t2, t1])).success
+    assert query(Predicate("lt", [t1, t2]))
+    assert not query(Predicate("lt", [t2, t1]))
 
     # test creating datetime from polar
     polar.load_str("dt(x) if x = new Datetime{year: 2020, month: 5, day: 25};")
-    assert polar.query(Predicate("dt", [Variable("x")])).results == [
-        {"x": datetime(2020, 5, 25)}
-    ]
+    assert query(Predicate("dt", [Variable("x")])) == [{"x": datetime(2020, 5, 25)}]
     polar.load_str("ltnow(x) if x < Datetime.now();")
-    assert polar.query(Predicate("ltnow", [t1])).success
-    assert not polar.query(Predicate("ltnow", [t3])).success
+    assert query(Predicate("ltnow", [t1]))
+    assert not query(Predicate("ltnow", [t3]))
 
     polar.load_str(
         "timedelta(a: Datetime, b: Datetime) if a.__sub__(b) == new Timedelta{days: 1};"
     )
-    assert polar.query(Predicate("timedelta", [t4, t1])).success
+    assert query(Predicate("timedelta", [t4, t1]))
 
 
-def test_other_constants(polar, qvar):
+def test_other_constants(polar, qvar, query):
     d = {"a": 1}
     polar.register_constant("d", d)
     assert qvar("x = d.a", "x") == [1]
 
 
-def test_host_methods(polar, qeval):
+def test_host_methods(polar, qeval, query):
     assert qeval('x = "abc" and x.startswith("a") = true and x.find("bc") = 1')
     assert qeval("i = 4095 and i.bit_length() = 12")
     assert qeval('f = 3.14159 and f.hex() = "0x1.921f9f01b866ep+1"')

--- a/languages/ruby/lib/oso/oso.rb
+++ b/languages/ruby/lib/oso/oso.rb
@@ -12,7 +12,7 @@ module Oso
     end
 
     def allowed?(actor:, action:, resource:)
-      query_predicate('allow', actor, action, resource).next
+      query_rule('allow', actor, action, resource).next
       true
     rescue StopIteration
       false

--- a/languages/ruby/lib/oso/polar/polar.rb
+++ b/languages/ruby/lib/oso/polar/polar.rb
@@ -59,6 +59,10 @@ module Oso
       end
 
       # Query for a predicate, parsing it if necessary.
+      #
+      # @param query [String or Predicate]
+      # @return Enumerator of resulting bindings
+      # @raise [Error] if the FFI call raises one.
       def query(query)
         load_queued_files
         new_host = host.dup

--- a/languages/ruby/lib/oso/polar/polar.rb
+++ b/languages/ruby/lib/oso/polar/polar.rb
@@ -73,12 +73,12 @@ module Oso
         Query.new(ffi_query, host: new_host).results
       end
 
-      # Query for a predicate.
+      # Query for a rule.
       #
       # @param name [String]
       # @param args [Array<Object>]
       # @raise [Error] if the FFI call raises one.
-      def query_predicate(name, *args)
+      def query_rule(name, *args)
         query(Predicate.new(name, args: args))
       end
 

--- a/languages/ruby/spec/oso/language_parity_spec.rb
+++ b/languages/ruby/spec/oso/language_parity_spec.rb
@@ -55,21 +55,21 @@ rescue Oso::Polar::ParseError::UnrecognizedEOF => e
 end
 raise unless exception_thrown
 
-oso.query_predicate('specializers', D.new(x: 'hello'), B::C.new('hello')).next
-oso.query_predicate('floatLists').next
-oso.query_predicate('intDicts').next
-oso.query_predicate('comparisons').next
-oso.query_predicate('testForall').next
-oso.query_predicate('testRest').next
-oso.query_predicate('testMatches', A.new(x: 'hello')).next
-oso.query_predicate('testMethodCalls', A.new(x: 'hello'), B::C.new('hello')).next
-oso.query_predicate('testOr').next
-oso.query_predicate('testHttpAndPathMapper').next
+oso.query_rule('specializers', D.new(x: 'hello'), B::C.new('hello')).next
+oso.query_rule('floatLists').next
+oso.query_rule('intDicts').next
+oso.query_rule('comparisons').next
+oso.query_rule('testForall').next
+oso.query_rule('testRest').next
+oso.query_rule('testMatches', A.new(x: 'hello')).next
+oso.query_rule('testMethodCalls', A.new(x: 'hello'), B::C.new('hello')).next
+oso.query_rule('testOr').next
+oso.query_rule('testHttpAndPathMapper').next
 
 # Test that cut doesn't return anything.
 exception_thrown = false
 begin
-  oso.query_predicate('testCut').next
+  oso.query_rule('testCut').next
 rescue StopIteration
   exception_thrown = true
 end

--- a/languages/ruby/spec/oso/oso_spec.rb
+++ b/languages/ruby/spec/oso/oso_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe Oso::Oso do
     end
   end
 
-  context '#query_predicate' do
+  context '#query_rule' do
     it 'calls through to the allow rule' do
       subject.load_str('allow(1, 2, 3);')
-      result = subject.query_predicate('allow', 1, 2, 3)
+      result = subject.query_rule('allow', 1, 2, 3)
       expect(result.next).to eq({})
     end
   end

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Oso::Polar::Polar do
     it 'converts predicates in both directions' do
       subject.load_str('f(x) if x = pred(1, 2);')
       expect(qvar(subject, 'f(x)', 'x')).to eq([Oso::Polar::Predicate.new('pred', args: [1, 2])])
-      expect(subject.query_predicate('f', Oso::Polar::Predicate.new('pred', args: [1, 2])).to_a).to eq([{}])
+      expect(subject.query_rule('f', Oso::Polar::Predicate.new('pred', args: [1, 2])).to_a).to eq([{}])
     end
 
     it 'converts Ruby instances in both directions' do
@@ -63,13 +63,13 @@ RSpec.describe Oso::Polar::Polar do
       actor = Actor.new('sam')
       widget = Widget.new(1)
       subject.load_str('allow(actor, resource) if actor.widget.id = resource.id;')
-      expect(subject.query_predicate('allow', actor, widget).to_a.length).to eq 1
+      expect(subject.query_rule('allow', actor, widget).to_a.length).to eq 1
     end
 
     it 'handles enumerator external call results' do
       actor = Actor.new('sam')
       subject.load_str('widgets(actor, x) if x = actor.widgets.id;')
-      expect(subject.query_predicate('widgets', actor, Oso::Polar::Variable.new('x')).to_a).to eq([{ 'x' => 2 }, { 'x' => 3 }])
+      expect(subject.query_rule('widgets', actor, Oso::Polar::Variable.new('x')).to_a).to eq([{ 'x' => 2 }, { 'x' => 3 }])
     end
 
     it 'caches instances and does not leak them' do
@@ -88,7 +88,7 @@ RSpec.describe Oso::Polar::Polar do
       expect(Counter.count).to be 0
       c = Counter.new
       expect(Counter.count).to be 1
-      expect(subject.query_predicate('f', c).to_a).to eq([{}])
+      expect(subject.query_rule('f', c).to_a).to eq([{}])
       expect(Counter.count).to be 1
       expect(subject.host.instance?(c)).to be false
     end
@@ -143,7 +143,7 @@ RSpec.describe Oso::Polar::Polar do
     it 'is able to make basic queries' do
       subject.load_str('f(1);');
       expect(subject.query('f(1)').to_a).to eq([{}])
-      expect(subject.query_predicate('f', 1).to_a).to eq([{}])
+      expect(subject.query_rule('f', 1).to_a).to eq([{}])
     end
 
     it 'raises an error when given an invalid query' do
@@ -578,12 +578,12 @@ RSpec.describe Oso::Polar::Polar do
 
     it 'can return a list' do
       subject.load_str('allow(actor: Actor, "join", "party") if "social" in actor.groups;')
-      expect(subject.query_predicate('allow', Actor.new, 'join', 'party').to_a).to eq([{}])
+      expect(subject.query_rule('allow', Actor.new, 'join', 'party').to_a).to eq([{}])
     end
 
     it 'can handle variables as arguments' do
       subject.load_file(test_file)
-      expect(subject.query_predicate('f', Oso::Polar::Variable.new('a')).to_a).to eq(
+      expect(subject.query_rule('f', Oso::Polar::Variable.new('a')).to_a).to eq(
         [{ 'a' => 1 }, { 'a' => 2 }, { 'a' => 3 }]
       )
     end

--- a/test/Test.java
+++ b/test/Test.java
@@ -57,18 +57,16 @@ class Test {
             }
             if (!throwsException)
                 throw new Exception();
-            boolean passes = !o.queryRule("specializers", List.of(new D("hello"), new BC("hello"))).results().isEmpty()
-                    && !o.queryRule("floatLists", null).results().isEmpty()
-                    && !o.queryRule("intDicts", null).results().isEmpty()
-                    && !o.queryRule("comparisons", null).results().isEmpty()
-                    && !o.queryRule("testForall", null).results().isEmpty()
-                    && !o.queryRule("testRest", null).results().isEmpty()
-                    && !o.queryRule("testMatches", List.of(new A("hello"))).results().isEmpty()
-                    && !o.queryRule("testMethodCalls", List.of(new A("hello"), new BC("hello"))).results().isEmpty()
-                    && !o.queryRule("testOr", null).results().isEmpty()
+            boolean passes = !o.queryRule("specializers", new D("hello"), new BC("hello")).results().isEmpty()
+                    && !o.queryRule("floatLists").results().isEmpty() && !o.queryRule("intDicts").results().isEmpty()
+                    && !o.queryRule("comparisons").results().isEmpty() && !o.queryRule("testForall").results().isEmpty()
+                    && !o.queryRule("testRest").results().isEmpty()
+                    && !o.queryRule("testMatches", new A("hello")).results().isEmpty()
+                    && !o.queryRule("testMethodCalls", new A("hello"), new BC("hello")).results().isEmpty()
+                    && !o.queryRule("testOr").results().isEmpty()
                     // Test that cut doesn't return anything.
-                    && o.queryRule("testCut", null).results().isEmpty()
-                    && !o.queryRule("testHttpAndPathMapper", null).results().isEmpty();
+                    && o.queryRule("testCut").results().isEmpty()
+                    && !o.queryRule("testHttpAndPathMapper").results().isEmpty();
             if (!passes)
                 throw new Exception();
 

--- a/test/Test.java
+++ b/test/Test.java
@@ -57,18 +57,18 @@ class Test {
             }
             if (!throwsException)
                 throw new Exception();
-            boolean passes = !o.query("specializers", List.of(new D("hello"), new BC("hello"))).results().isEmpty()
-                    && !o.query("floatLists", null).results().isEmpty()
-                    && !o.query("intDicts", null).results().isEmpty()
-                    && !o.query("comparisons", null).results().isEmpty()
-                    && !o.query("testForall", null).results().isEmpty()
-                    && !o.query("testRest", null).results().isEmpty()
-                    && !o.query("testMatches", List.of(new A("hello"))).results().isEmpty()
-                    && !o.query("testMethodCalls", List.of(new A("hello"), new BC("hello"))).results().isEmpty()
-                    && !o.query("testOr", null).results().isEmpty()
+            boolean passes = !o.queryRule("specializers", List.of(new D("hello"), new BC("hello"))).results().isEmpty()
+                    && !o.queryRule("floatLists", null).results().isEmpty()
+                    && !o.queryRule("intDicts", null).results().isEmpty()
+                    && !o.queryRule("comparisons", null).results().isEmpty()
+                    && !o.queryRule("testForall", null).results().isEmpty()
+                    && !o.queryRule("testRest", null).results().isEmpty()
+                    && !o.queryRule("testMatches", List.of(new A("hello"))).results().isEmpty()
+                    && !o.queryRule("testMethodCalls", List.of(new A("hello"), new BC("hello"))).results().isEmpty()
+                    && !o.queryRule("testOr", null).results().isEmpty()
                     // Test that cut doesn't return anything.
-                    && o.query("testCut", null).results().isEmpty()
-                    && !o.query("testHttpAndPathMapper", null).results().isEmpty();
+                    && o.queryRule("testCut", null).results().isEmpty()
+                    && !o.queryRule("testHttpAndPathMapper", null).results().isEmpty();
             if (!passes)
                 throw new Exception();
 

--- a/test/test.py
+++ b/test/test.py
@@ -61,19 +61,19 @@ except UnrecognizedEOF as e:
     )
 assert exception_thrown
 
-assert oso.query_rule("specializers", D("hello"), B.C("hello")).success
-assert oso.query_rule("floatLists").success
-assert oso.query_rule("intDicts").success
-assert oso.query_rule("comparisons").success
-assert oso.query_rule("testForall").success
-assert oso.query_rule("testRest").success
-assert oso.query_rule("testMatches", A("hello")).success
-assert oso.query_rule("testMethodCalls", A("hello"), B.C("hello")).success
-assert oso.query_rule("testOr").success
-assert oso.query_rule("testHttpAndPathMapper").success
+assert list(oso.query_rule("specializers", D("hello"), B.C("hello")))
+assert list(oso.query_rule("floatLists"))
+assert list(oso.query_rule("intDicts"))
+assert list(oso.query_rule("comparisons"))
+assert list(oso.query_rule("testForall"))
+assert list(oso.query_rule("testRest"))
+assert list(oso.query_rule("testMatches", A("hello")))
+assert list(oso.query_rule("testMethodCalls", A("hello"), B.C("hello")))
+assert list(oso.query_rule("testOr"))
+assert list(oso.query_rule("testHttpAndPathMapper"))
 
 # Test that cut doesn't return anything.
-assert oso.query_rule("testCut").success is False
+assert not list(oso.query_rule("testCut"))
 
 import math
 

--- a/test/test.py
+++ b/test/test.py
@@ -61,19 +61,19 @@ except UnrecognizedEOF as e:
     )
 assert exception_thrown
 
-assert oso.query_predicate("specializers", D("hello"), B.C("hello")).success
-assert oso.query_predicate("floatLists").success
-assert oso.query_predicate("intDicts").success
-assert oso.query_predicate("comparisons").success
-assert oso.query_predicate("testForall").success
-assert oso.query_predicate("testRest").success
-assert oso.query_predicate("testMatches", A("hello")).success
-assert oso.query_predicate("testMethodCalls", A("hello"), B.C("hello")).success
-assert oso.query_predicate("testOr").success
-assert oso.query_predicate("testHttpAndPathMapper").success
+assert oso.query_rule("specializers", D("hello"), B.C("hello")).success
+assert oso.query_rule("floatLists").success
+assert oso.query_rule("intDicts").success
+assert oso.query_rule("comparisons").success
+assert oso.query_rule("testForall").success
+assert oso.query_rule("testRest").success
+assert oso.query_rule("testMatches", A("hello")).success
+assert oso.query_rule("testMethodCalls", A("hello"), B.C("hello")).success
+assert oso.query_rule("testOr").success
+assert oso.query_rule("testHttpAndPathMapper").success
 
 # Test that cut doesn't return anything.
-assert oso.query_predicate("testCut").success is False
+assert oso.query_rule("testCut").success is False
 
 import math
 


### PR DESCRIPTION
`query()` and `query_rule()` are now generators in Python, to match the other language libraries.

**Implications**
- These methods used to return `QueryResult`, which had the method `success()`. Success must now be determined by converting the result to a list. E.g., `assert list(polar.query("foo(x)"))
- `QueryResult` has the `results` attribute, which gives a list. Now to get a list of results, convert to a list directly as above
- We are not doing anything with `trace()`... the infrastructure is still there but we simply never create a `QueryResult` anymore

In Java: `query()` now accepts either a String or a Predicate, and `queryRule()` accepts variable args to match the other libraries.

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
