### PR TITLE
Handle None/nil/null returns from host methods

### DIFF
--- a/docs/examples/context/python/02-context.py
+++ b/docs/examples/context/python/02-context.py
@@ -1,6 +1,7 @@
 import os
 from oso import polar_class
 
+
 @polar_class
 class Env:
     def var(self, variable):

--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -48,7 +48,8 @@ public class Host implements Cloneable {
      * Store a Java class in the cache by name.
      *
      * @param name
-     * @throws Exceptions.DuplicateClassAliasError If the class is already registered.
+     * @throws Exceptions.DuplicateClassAliasError If the class is already
+     *                                             registered.
      */
     public String cacheClass(Class cls, Function<Map, Object> constructor, String name)
             throws Exceptions.DuplicateClassAliasError {
@@ -100,7 +101,8 @@ public class Host implements Cloneable {
     }
 
     /**
-     * Make an instance of a Java class from a {@code Map<String, Object>} of fields.
+     * Make an instance of a Java class from a {@code Map<String, Object>} of
+     * fields.
      *
      * @param clsName
      * @param fields
@@ -170,37 +172,38 @@ public class Host implements Cloneable {
      * Convert Java Objects to Polar (JSON) terms.
      *
      * @param value Java Object to be converted to Polar.
-     * @return JSONObject Polar term of form: {@code {"id": _, "offset": _, "value": _}}.
+     * @return JSONObject Polar term of form: {@code {"id": _, "offset": _, "value":
+     *         _}}.
      */
     public JSONObject toPolarTerm(Object value) throws Exceptions.OsoException {
         // Build Polar value
         JSONObject jVal = new JSONObject();
-        if (value.getClass() == Boolean.class) {
+        if (value != null && value.getClass() == Boolean.class) {
             jVal.put("Boolean", value);
-        } else if (value.getClass() == Integer.class) {
+        } else if (value != null && value.getClass() == Integer.class) {
             jVal.put("Number", Map.of("Integer", value));
-        } else if (value.getClass() == Float.class || value.getClass() == Double.class) {
+        } else if (value != null && (value.getClass() == Float.class || value.getClass() == Double.class)) {
             jVal.put("Number", Map.of("Float", value));
-        } else if (value.getClass() == String.class) {
+        } else if (value != null && value.getClass() == String.class) {
             jVal.put("String", value);
-        } else if (value.getClass().isArray()) {
+        } else if (value != null && value.getClass().isArray()) {
             jVal.put("List", javaArrayToPolar(value));
-        } else if (value instanceof List) {
+        } else if (value != null && value instanceof List) {
             jVal.put("List", javaListToPolar((List<Object>) value));
-        } else if (value instanceof Map) {
+        } else if (value != null && value instanceof Map) {
             Map<String, JSONObject> jMap = javaMaptoPolar((Map<Object, Object>) value);
             jVal.put("Dictionary", new JSONObject().put("fields", jMap));
-        } else if (value instanceof Predicate) {
+        } else if (value != null && value instanceof Predicate) {
             Predicate pred = (Predicate) value;
             if (pred.args == null)
                 pred.args = new ArrayList<Object>();
             jVal.put("Call", new JSONObject(Map.of("name", pred.name, "args", javaListToPolar(pred.args))));
-        } else if (value instanceof Variable) {
+        } else if (value != null && value instanceof Variable) {
             jVal.put("Variable", value);
         } else {
             JSONObject attrs = new JSONObject();
             attrs.put("instance_id", cacheInstance(value, null));
-            attrs.put("repr", value.toString());
+            attrs.put("repr", value == null ? "null" : value.toString());
             jVal.put("ExternalInstance", attrs);
         }
 

--- a/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
+++ b/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
@@ -428,12 +428,11 @@ public class PolarTest {
     }
 
     public void testReturnNull() throws Exception {
-        p.registerClass(Foo.class, m -> new Foo(), "Foo");
         p.loadStr("f(x) if x.myReturnNull = 1;");
-        assertTrue(p.queryRule("f", new Foo()).results().isEmpty());
+        assertTrue(p.queryRule("f", new MyClass("test", 1)).results().isEmpty());
 
         p.loadStr("f(x) if x.myReturnNull.badCall = 1;");
-        assertThrows(Exceptions.PolarRuntimeException.class, () -> p.queryRule("f", new Foo()).results());
+        assertThrows(Exceptions.PolarRuntimeException.class, () -> p.queryRule("f", new MyClass("test", 1)).results());
 
     }
 

--- a/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
+++ b/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
@@ -43,6 +43,10 @@ public class PolarTest {
         public static String myStaticMethod() {
             return "hello world";
         }
+
+        public String myReturnNull() {
+            return null;
+        }
     }
 
     public static class MySubClass extends MyClass {
@@ -416,11 +420,21 @@ public class PolarTest {
 
     @Test
     public void testUnboundVariable() throws Exception {
-      p.loadStr("rule(x, y) if y = 1;");
-      List<HashMap<String, Object>> results = p.query("rule(x, y)").results();
-      HashMap<String, Object> result = results.get(0);
-      assertTrue(result.get("x") instanceof Variable);
-      assertEquals(result.get("y"), 1);
+        p.loadStr("rule(x, y) if y = 1;");
+        List<HashMap<String, Object>> results = p.query("rule(x, y)").results();
+        HashMap<String, Object> result = results.get(0);
+        assertTrue(result.get("x") instanceof Variable);
+        assertEquals(result.get("y"), 1);
+    }
+
+    public void testReturnNull() throws Exception {
+        p.registerClass(Foo.class, m -> new Foo(), "Foo");
+        p.loadStr("f(x) if x.myReturnNull = 1;");
+        assertTrue(p.queryRule("f", new Foo()).results().isEmpty());
+
+        p.loadStr("f(x) if x.myReturnNull.badCall = 1;");
+        assertThrows(Exceptions.PolarRuntimeException.class, () -> p.queryRule("f", new Foo()).results());
+
     }
 
     /*** TEST OSO ***/
@@ -441,4 +455,5 @@ public class PolarTest {
         Http http13 = new Http(null, "/myclass/13", null);
         assertFalse(oso.isAllowed("sam", "get", http13), "Failed to correctly map HTTP resource");
     }
+
 }

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -646,4 +646,3 @@ def test_return_none(polar, qeval):
     assert str(e.value).find(
         "Application error: 'NoneType' object has no attribute 'bad_call'"
     )
-

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -245,6 +245,22 @@ RSpec.describe Oso::Polar::Polar do
     it 'on dicts' do
       expect(query(subject, 'd = {a: 1} and d.fetch("a") = 1 and d.fetch("b", 2) = 2').length).to be 1
     end
+
+    it 'that return nil' do
+        stub_const('Foo', Class.new do
+          def this_is_nil
+            nil
+          end
+        end)
+
+        subject.register_class(Foo, from_polar: -> { Foo.new })
+        subject.load_str("f(x) if x.this_is_nil = 1;")
+        expect(subject.query_predicate('f', Foo.new).to_a).to eq([])
+
+        subject.load_str("f(x) if x.this_is_nil.bad_call = 1;")
+        expect { subject.query_predicate('f', Foo.new).to_a }.to raise_error Oso::Polar::PolarRuntimeError
+    end
+
   end
 
   context '#register_class' do

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -255,10 +255,10 @@ RSpec.describe Oso::Polar::Polar do
 
         subject.register_class(Foo, from_polar: -> { Foo.new })
         subject.load_str("f(x) if x.this_is_nil = 1;")
-        expect(subject.query_predicate('f', Foo.new).to_a).to eq([])
+        expect(subject.query_rule('f', Foo.new).to_a).to eq([])
 
         subject.load_str("f(x) if x.this_is_nil.bad_call = 1;")
-        expect { subject.query_predicate('f', Foo.new).to_a }.to raise_error Oso::Polar::PolarRuntimeError
+        expect { subject.query_rule('f', Foo.new).to_a }.to raise_error Oso::Polar::PolarRuntimeError
     end
 
   end

--- a/test/test.py
+++ b/test/test.py
@@ -80,4 +80,3 @@ import math
 # Test that a constant can be called.
 oso.register_constant("Math", math)
 oso.load_str("?= Math.factorial(5) == 120;")
-


### PR DESCRIPTION
How we handle None returns:
- Stored as a host instance

What this means:
- unification with something that returns `None` will simply fail, but not error
- lookups on `None` will throw Application Errors

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
