### PR TITLE
Don't loop on a variable bound to itself

### DIFF
--- a/polar/src/vm.rs
+++ b/polar/src/vm.rs
@@ -515,7 +515,13 @@ impl PolarVirtualMachine {
     pub fn deref(&self, term: &Term) -> Term {
         match &term.value() {
             Value::Variable(symbol) | Value::RestVariable(symbol) => {
-                self.value(&symbol).map_or(term.clone(), |t| self.deref(t))
+                self.value(&symbol).map_or(term.clone(), |t| {
+                    if t == term {
+                        t.clone()
+                    } else {
+                        self.deref(t)
+                    }
+                })
             }
             _ => term.clone(),
         }

--- a/polar/tests/integration_tests.rs
+++ b/polar/tests/integration_tests.rs
@@ -621,6 +621,9 @@ fn test_non_instance_specializers() {
 #[test]
 fn test_bindings() {
     let mut polar = Polar::new(None);
+    assert_eq!(qvar(&mut polar, "x=1", "x"), vec![value!(1)]);
+    assert_eq!(qvar(&mut polar, "x=x", "x"), vec![value!(sym!("x"))]);
+
     polar
         .load("f(x) if x = y and g(y); g(y) if y = 1;")
         .unwrap();

--- a/polar/tests/integration_tests.rs
+++ b/polar/tests/integration_tests.rs
@@ -623,6 +623,10 @@ fn test_bindings() {
     let mut polar = Polar::new(None);
     assert_eq!(qvar(&mut polar, "x=1", "x"), vec![value!(1)]);
     assert_eq!(qvar(&mut polar, "x=x", "x"), vec![value!(sym!("x"))]);
+    assert_eq!(
+        qvar(&mut polar, "x=y and y=x", "x"),
+        vec![value!(sym!("y"))]
+    );
 
     polar
         .load("f(x) if x = y and g(y); g(y) if y = 1;")


### PR DESCRIPTION
Before:
```console
$ python -m oso
query> x = x
[1]    6778 segmentation fault  python -m oso
```

After:
```console
$ python -m oso
query> x = x
{'x': 'x'}
```