### PR TITLE
Fix labels in syntax doc

### DIFF
--- a/docs/using/polar-syntax.rst
+++ b/docs/using/polar-syntax.rst
@@ -39,13 +39,15 @@ For example::
 are all parsed as numbers.
 
 You can also perform basic arithmetic on numbers with the operators
-``+,-,*,/``.
+``+``, ``-``, ``*``, and ``/``.
 
-.. _strings:
+.. _booleans:
 
 Boolean
 -------
 Polar parses the keywords ``true`` and ``false`` as boolean values.
+
+.. _strings:
 
 Strings
 -------


### PR DESCRIPTION
Fixes "Ruby strings are mapped to Polar Boolean." on Ruby page.