### PR TITLE
Assignment Operator

### DIFF
--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -24,14 +24,12 @@ Link to migration guide
 New features
 ==============
 
-Feature 1
-=========
-
-- summary
-- of
-- user facing changes
-
-Link to relevant documentation section
+Assignment Operator
+===================
+- The operator ``:=`` may now be used to assign values to unbound variables. Unlike the unify operator (``=``),
+the assignment operator will NOT evaluate equality.
+- Attempting to assign to a non-variable will result in a parse error.
+- Attempting to assign to a bound variable will result in a runtime error.
 
 
 Other bugs & improvements

--- a/docs/using/polar-syntax.rst
+++ b/docs/using/polar-syntax.rst
@@ -224,7 +224,7 @@ said to *unify* if they are equal or if there is a consistent set of
 variable bindings that makes them equal. Unification is defined
 recursively over compound types (e.g., lists and dictionaries):
 two compound values unify if all of their corresponding elements
-unify.
+unify.:warn
 
 Unification may be performed explicitly with the unification operator
 (``=``), which is true if its two operands unify; e.g., ``1 = 1``,
@@ -237,6 +237,16 @@ We will cover unification further in :ref:`search-procedure`.
 
 .. todo::
    add a little table with unification examples, esp. w/dictionaries.
+
+Assignment
+^^^^^^^^^^
+
+Assigning a value to an unbound variable can be done using the unification operator.
+However, the assignment operator (``:=``) may also be used, and will only succeed if the
+left-hand side oeprand is an unbound variable. For example, ``foo := 1``.
+This operator can be used to improve readability and predictability
+by indicating explicit assignment. Attempting to assign to a non-variable will result in a parse error,
+while attempting to assign to a bound variable will result in a runtime error.
 
 Conjunction (and)
 ^^^^^^^^^^^^^^^^^

--- a/docs/using/polar-syntax.rst
+++ b/docs/using/polar-syntax.rst
@@ -243,7 +243,7 @@ Assignment
 
 Assigning a value to an unbound variable can be done using the unification operator.
 However, the assignment operator (``:=``) may also be used, and will only succeed if the
-left-hand side oeprand is an unbound variable. For example, ``foo := 1``.
+left-hand side operand is an unbound variable. For example, ``foo := 1``.
 This operator can be used to improve readability and predictability
 by indicating explicit assignment. Attempting to assign to a non-variable will result in a parse error,
 while attempting to assign to a bound variable will result in a runtime error.

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -378,7 +378,7 @@ def test_parser_errors(polar):
 
 def test_runtime_errors(polar, query):
     rules = """
-    foo(a,b) := a in b;
+    foo(a,b) if a in b;
     """
     polar.load_str(rules)
     with pytest.raises(exceptions.PolarRuntimeException) as e:

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -608,7 +608,7 @@ RSpec.describe Oso::Polar::Polar do
   context 'runtime errors' do
     it 'include a stack trace' do
         rule = <<~POLAR
-        foo(a,b) := a in b;
+        foo(a,b) if a in b;
         POLAR
         subject.load_str(rule)
         expect { query(subject, 'foo(1,2)') }.to raise_error do |e|

--- a/polar-core/src/debugger.rs
+++ b/polar-core/src/debugger.rs
@@ -40,7 +40,7 @@ enum Step {
     /// is evaluated in the following snippet of Polar...
     ///
     /// ```polar
-    /// a() := debug(), b();
+    /// a() if debug() and b();
     /// b();
     /// ?= a()
     /// ```
@@ -72,8 +72,8 @@ enum Step {
     /// polar:
     ///
     /// ```text
-    /// a() := b(), c();
-    /// b() := debug(), d();
+    /// a() if b() and c();
+    /// b() if debug() and d();
     /// c();
     /// d();
     /// ?= a()

--- a/polar-core/src/formatting.rs
+++ b/polar-core/src/formatting.rs
@@ -353,6 +353,7 @@ pub mod to_polar {
                 New => "new",
                 Dot => ".",
                 Unify => "=",
+                Assign => ":=",
                 In => "in",
                 Cut => "cut",
                 ForAll => "forall",
@@ -409,14 +410,13 @@ pub mod to_polar {
                     to_polar_parens(self.operator, &self.args[0])
                 ),
                 // Binary operators
-                Mul | Div | Add | Sub | Eq | Geq | Leq | Neq | Gt | Lt | Unify | Isa | In => {
-                    format!(
-                        "{} {} {}",
-                        to_polar_parens(self.operator, &self.args[0]),
-                        self.operator.to_polar(),
-                        to_polar_parens(self.operator, &self.args[1])
-                    )
-                }
+                Mul | Div | Add | Sub | Eq | Geq | Leq | Neq | Gt | Lt | Unify | Isa | In
+                | Assign => format!(
+                    "{} {} {}",
+                    to_polar_parens(self.operator, &self.args[0]),
+                    self.operator.to_polar(),
+                    to_polar_parens(self.operator, &self.args[1])
+                ),
                 // n-ary operators
                 And => format_args(
                     self.operator,

--- a/polar-core/src/formatting.rs
+++ b/polar-core/src/formatting.rs
@@ -273,7 +273,7 @@ pub mod display {
                     } else {
                         write!(
                             fmt,
-                            "{}({}) := {};",
+                            "{}({}) if {};",
                             self.name.to_polar(),
                             format_params(&self.params, ", "),
                             format_args(Operator::And, &args, ",\n  "),

--- a/polar-core/src/lexer.rs
+++ b/polar-core/src/lexer.rs
@@ -48,31 +48,31 @@ pub enum Token {
     String(String),
     Boolean(bool),
     Symbol(Symbol),
-    Colon,     // :
-    Comma,     // ,
-    LB,        // [
-    RB,        // ]
-    LP,        // (
-    RP,        // )
-    LCB,       // {
-    RCB,       // }
-    Dot,       // .
-    New,       // new
-    Bang,      // !
-    Mul,       // *
-    Div,       // /
-    Add,       // +
-    Sub,       // -
-    Eq,        // ==
-    Neq,       // !=
-    Leq,       // <=
-    Geq,       // >=
-    Lt,        // <
-    Gt,        // >
-    Unify,     // =
+    Colon, // :
+    Comma, // ,
+    LB,    // [
+    RB,    // ]
+    LP,    // (
+    RP,    // )
+    LCB,   // {
+    RCB,   // }
+    Dot,   // .
+    New,   // new
+    Bang,  // !
+    Mul,   // *
+    Div,   // /
+    Add,   // +
+    Sub,   // -
+    Eq,    // ==
+    Neq,   // !=
+    Leq,   // <=
+    Geq,   // >=
+    Lt,    // <
+    Gt,    // >
+    Unify, // =
+    Assign,
     Pipe,      // |
     SemiColon, // ;
-    Define,    // :=
     Query,     // ?=
     In,        // in
     Cut,       // cut
@@ -116,10 +116,10 @@ impl ToString for Token {
             Token::Geq => ">=".to_owned(),          // >=
             Token::Lt => "<".to_owned(),            // <
             Token::Gt => ">".to_owned(),            // >
-            Token::Unify => "-".to_owned(),         // =
+            Token::Unify => "=".to_owned(),         // =
+            Token::Assign => ":=".to_owned(),       // :=
             Token::Pipe => "|".to_owned(),          // |
             Token::SemiColon => ";".to_owned(),     // ;
-            Token::Define => ":=".to_owned(),       // :=
             Token::Query => "?=".to_owned(),        // ?=
             Token::In => "in".to_owned(),           // in
             Token::Cut => "cut".to_owned(),         // cut
@@ -448,7 +448,7 @@ impl<'input> Iterator for Lexer<'input> {
                 }
                 '"' => self.scan_string(i),
                 '0'..='9' => self.scan_number(i, char),
-                ':' => self.scan_1c_or_2c_op(i, Token::Colon, '=', Token::Define),
+                ':' => self.scan_1c_or_2c_op(i, Token::Colon, '=', Token::Assign),
                 '=' => self.scan_1c_or_2c_op(i, Token::Unify, '=', Token::Eq),
                 '<' => self.scan_1c_or_2c_op(i, Token::Lt, '=', Token::Leq),
                 '>' => self.scan_1c_or_2c_op(i, Token::Gt, '=', Token::Geq),

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -345,18 +345,17 @@ Exp5<T>: Term = {
 }
 
 // =, :=
-Exp4<T>: Term = {
+UnifyExp<T>: Value = {
     <exp4:Exp4<T>> "=" <exp5:Exp5<T>> => {
         let args = vec![exp4, exp5];
         let op = Operation{operator: Operator::Unify, args};
         Value::Expression(op)
     },
-    <start:@L> <name:Name> ":=" <exp5:Exp5<T>> => {
-        let args = vec![Term::new_from_parser(src_id, start, Value::Variable(name)), exp5];
+    <variable:Spanned<Variable>> ":=" <exp5:Exp5<T>> => {
+        let args = vec![variable, exp5];
         let op = Operation{operator: Operator::Assign, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
+        Value::Expression(op)
     },
-    <exp5:Exp5<T>> => exp5
 }
 
 Exp4<T>: Term = {

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -46,9 +46,9 @@ extern {
         "<" => lexer::Token::Lt,        // <
         ">" => lexer::Token::Gt,        // >
         "=" => lexer::Token::Unify,     // =
+        ":=" => lexer::Token::Assign,    // :=
         "|" => lexer::Token::Pipe,      // |
         ";" => lexer::Token::SemiColon, // ;
-        ":=" => lexer::Token::Define,   // :=
         "?=" => lexer::Token::Query,    // ?=
         "cut" => lexer::Token::Cut,
         "debug" => lexer::Token::Debug,
@@ -344,19 +344,26 @@ Exp5<T>: Term = {
     <Exp6<T>>,
 }
 
-// =
-UnifyExp<T>: Value = {
+// =, :=
+Exp4<T>: Term = {
     <exp4:Exp4<T>> "=" <exp5:Exp5<T>> => {
         let args = vec![exp4, exp5];
         let op = Operation{operator: Operator::Unify, args};
         Value::Expression(op)
     },
+    <start:@L> <name:Name> ":=" <exp5:Exp5<T>> => {
+        let args = vec![Term::new_from_parser(src_id, start, Value::Variable(name)), exp5];
+        let op = Operation{operator: Operator::Assign, args};
+        Term::new_from_parser(src_id, start, Value::Expression(op))
+    },
+    <exp5:Exp5<T>> => exp5
 }
 
 Exp4<T>: Term = {
     <Spanned<UnifyExp<T>>>,
     <Exp5<T>>,
 }
+
 
 
  // !
@@ -525,7 +532,7 @@ RuleHead: (Symbol, Vec<Parameter>) = {
     }
 };
 
-Define = {":=", "if"};
+Define = {"if"};
 
 pub Rule: Rule = {
     <head:RuleHead> <start:@L> <end:@R> ";" => {

--- a/polar-core/src/types.rs
+++ b/polar-core/src/types.rs
@@ -149,6 +149,7 @@ pub enum Operator {
     Or,
     And,
     ForAll,
+    Assign,
 }
 
 impl Operator {
@@ -173,6 +174,7 @@ impl Operator {
             Operator::Gt => 5,
             Operator::Lt => 5,
             Operator::Unify => 4,
+            Operator::Assign => 4,
             Operator::Not => 3,
             Operator::Or => 2,
             Operator::And => 1,

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -757,9 +757,9 @@ impl PolarVirtualMachine {
     /// Comparison operator that essentially performs partial unification.
     pub fn isa(&mut self, left: &Term, right: &Term) -> PolarResult<()> {
         // TODO (dhatch): These errors could potentially be caused by the user.
-        // rule(foo) :=
-        //    x = {a: 1},
-        //    foo isa x
+        // rule(foo) if
+        //    x = {a: 1} and
+        //    foo matches x
         assert!(
             !matches!(&right.value(), Value::InstanceLiteral(_)),
             "Called isa with bare instance lit!"
@@ -1599,8 +1599,8 @@ impl PolarVirtualMachine {
             //
             // External instances can unify if they are the same instance, i.e., have the same
             // instance ID. This is necessary for the case where an instance appears multiple times
-            // in the same rule head. For example, `f(foo, foo) := ...` or `isa(x, y, x: y) := ...`
-            // or `max(x, y, x) := x > y;`.
+            // in the same rule head. For example, `f(foo, foo) if ...` or `isa(x, y, x: y) if ...`
+            // or `max(x, y, x) if x > y;`.
             (
                 Value::ExternalInstance(ExternalInstance {
                     instance_id: left_instance,

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -1113,6 +1113,26 @@ impl PolarVirtualMachine {
                 ];
                 self.choose(alternatives)?;
             }
+            Operator::Assign => {
+                assert_eq!(args.len(), 2);
+                let right = args.pop().unwrap();
+                let left = args.pop().unwrap();
+                match (left.value(), right.value()) {
+                    (Value::Variable(var), _) => match self.value(var) {
+                        None => self.push_goal(Goal::Unify { left, right })?,
+                        Some(value) => {
+                            return Err(self.type_error( &left, format!("Can only assign to unbound variables, {} is bound to value {}.", var.to_polar(), value.to_polar())));
+                        }
+                    },
+                    _ => {
+                        return Err(self.type_error(
+                            &left,
+                            format!("Cannot assign to type {}.", left.to_polar()),
+                        ))
+                    }
+                }
+            }
+
             Operator::Unify => {
                 // Push a `Unify` goal
                 assert_eq!(args.len(), 2);

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1052,7 +1052,7 @@ fn test_rest_vars() {
     polar
         .load(
             r#"member(x, [x, *_rest]);
-               member(x, [_first, *rest]) := member(x, rest);"#,
+               member(x, [_first, *rest]) if member(x, rest);"#,
         )
         .unwrap();
     assert!(qeval(&mut polar, "member(1, [1,2,3])"));
@@ -1066,7 +1066,7 @@ fn test_rest_vars() {
     polar
         .load(
             r#"append([], x, x);
-               append([first, *rest], x, [first, *tail]) := append(rest, x, tail);"#,
+               append([first, *rest], x, [first, *tail]) if append(rest, x, tail);"#,
         )
         .unwrap();
     assert!(qeval(&mut polar, "append([], [], [])"));


### PR DESCRIPTION
Introduced `:=` as assignment operator. 
Currently, assignment is only valid when the LHS is an unbound variable. Open to input on that.

PR checklist:

<!-- Delete if no entry is required. -->
- [x] Added changelog entry.
