### PR TITLE
Improve integer/floating-point comparisons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,16 +642,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "ordered-float"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
-dependencies = [
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "ordermap"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,7 +724,6 @@ dependencies = [
  "lalrpop-util",
  "lazy_static",
  "maplit",
- "ordered-float",
  "permute",
  "pipe",
  "pretty_assertions",

--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -37,7 +37,5 @@ Link to relevant documentation section
 Other bugs & improvements
 =========================
 
-- bulleted list
-- improvements
-- of smaller
-- potentially with doc links
+- fixed float parsing
+- improved integer/float comparisons

--- a/polar/Cargo.toml
+++ b/polar/Cargo.toml
@@ -16,7 +16,6 @@ harness = false
 anyhow = "1.0.31"
 lalrpop-util = "0.18.1"
 lazy_static = "1.4.0"
-ordered-float = { version = "1.0.2", default-features=false, features=["serde"] }
 regex = "1.3.7"
 serde = { version = "1.0", features = ["derive", "rc"]}
 serde_json = "1.0"

--- a/polar/src/lexer.rs
+++ b/polar/src/lexer.rs
@@ -340,9 +340,17 @@ impl<'input> Lexer<'input> {
 
         last = self.match_digits(last);
 
+        if let Some((i, '.')) = self.c {
+            self.push_char('.');
+            last = i;
+            parse_as_float = true;
+
+            last = self.match_digits(last);
+        }
+
         if let Some((i, char)) = self.c {
             match char {
-                '.' | 'e' | 'E' => {
+                'e' | 'E' => {
                     self.push_char(char);
                     last = i;
                     parse_as_float = true;
@@ -351,22 +359,14 @@ impl<'input> Lexer<'input> {
 
                     if let Some((i, char)) = self.c {
                         match char {
-                            'e' | 'E' => {
+                            '+' | '-' => {
                                 self.push_char(char);
                                 last = i;
+
+                                last = self.match_digits(last);
                             }
                             _ => (),
                         }
-                        if let Some((i, char)) = self.c {
-                            match char {
-                                '+' | '-' => {
-                                    self.push_char(char);
-                                    last = i;
-                                }
-                                _ => (),
-                            }
-                        }
-                        last = self.match_digits(last);
                     }
                 }
                 _ => (),

--- a/polar/src/lexer.rs
+++ b/polar/src/lexer.rs
@@ -340,19 +340,23 @@ impl<'input> Lexer<'input> {
 
         last = self.match_digits(last);
 
-        if let Some((i, '.')) = self.c {
-            self.push_char('.');
-            last = i;
-            parse_as_float = true;
+        if let Some((i, char)) = self.c {
+            match char {
+                '.' | 'e' | 'E' => {
+                    self.push_char(char);
+                    last = i;
+                    parse_as_float = true;
 
-            last = self.match_digits(last);
+                    last = self.match_digits(last);
 
-            if let Some((i, char)) = self.c {
-                match char {
-                    'e' | 'E' => {
-                        self.push_char(char);
-                        last = i;
-
+                    if let Some((i, char)) = self.c {
+                        match char {
+                            'e' | 'E' => {
+                                self.push_char(char);
+                                last = i;
+                            }
+                            _ => (),
+                        }
                         if let Some((i, char)) = self.c {
                             match char {
                                 '+' | '-' => {
@@ -362,11 +366,10 @@ impl<'input> Lexer<'input> {
                                 _ => (),
                             }
                         }
-
                         last = self.match_digits(last);
                     }
-                    _ => (),
                 }
+                _ => (),
             }
         }
 

--- a/polar/src/lexer.rs
+++ b/polar/src/lexer.rs
@@ -362,12 +362,12 @@ impl<'input> Lexer<'input> {
                             '+' | '-' => {
                                 self.push_char(char);
                                 last = i;
-
-                                last = self.match_digits(last);
                             }
                             _ => (),
                         }
                     }
+
+                    last = self.match_digits(last);
                 }
                 _ => (),
             }
@@ -690,5 +690,28 @@ mod tests {
             lexer.next(),
             Some(Ok((0, Token::Integer(123), 4)))
         ));
+
+        let f = "1.ee1";
+        let mut lexer = Lexer::new(&f);
+        assert!(matches!(
+            lexer.next(),
+            Some(Err(ParseError::InvalidFloat{ .. }))
+        ));
+
+        let f = "1.1";
+        let mut lexer = Lexer::new(&f);
+        assert!(matches!(lexer.next(), Some(Ok((_, Token::Float(f), _))) if f == 1.1));
+
+        let f = "1e1";
+        let mut lexer = Lexer::new(&f);
+        assert!(matches!(lexer.next(), Some(Ok((_, Token::Float(f), _))) if f == 1e1));
+
+        let f = "1e-1";
+        let mut lexer = Lexer::new(&f);
+        assert!(matches!(lexer.next(), Some(Ok((_, Token::Float(f), _))) if f == 1e-1));
+
+        let f = "1.1e-1";
+        let mut lexer = Lexer::new(&f);
+        assert!(matches!(lexer.next(), Some(Ok((_, Token::Float(f), _))) if f == 1.1e-1));
     }
 }

--- a/polar/src/lexer.rs
+++ b/polar/src/lexer.rs
@@ -677,6 +677,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_numbers() {
         let f = "1+2";
         let mut lexer = Lexer::new(&f);

--- a/polar/src/lib.rs
+++ b/polar/src/lib.rs
@@ -9,6 +9,7 @@ mod debugger;
 pub mod error;
 mod formatting;
 mod lexer;
+mod numerics;
 pub mod parser;
 mod polar;
 mod rewrites;

--- a/polar/src/numerics.rs
+++ b/polar/src/numerics.rs
@@ -166,7 +166,7 @@ mod tests {
         assert!(Numeric::Integer(1 << 52) == Numeric::Float((2.0 as f64).powi(52)));
         assert!(Numeric::Integer(1 << 53) == Numeric::Float((2.0 as f64).powi(53)));
         assert!(Numeric::Integer((1 << 52) + 1) == Numeric::Float((2.0 as f64).powi(52) + 1.0));
-        assert!(Numeric::Integer((1 << 52)) < Numeric::Float((2.0 as f64).powi(52) + 1.0));
+        assert!(Numeric::Integer(1 << 52) < Numeric::Float((2.0 as f64).powi(52) + 1.0));
         assert!(Numeric::Integer((1 << 52) + 1) > Numeric::Float((2.0 as f64).powi(52)));
         assert!(Numeric::Integer(-(1 << 52) - 1) < Numeric::Float(-(2.0 as f64).powi(52)));
 

--- a/polar/src/numerics.rs
+++ b/polar/src/numerics.rs
@@ -47,34 +47,10 @@ impl Div for Numeric {
 
     fn div(self, other: Self) -> Option<Self> {
         match (self, other) {
-            (Numeric::Integer(a), Numeric::Integer(b)) => {
-                if b == 0 {
-                    None
-                } else {
-                    Some(Numeric::Float(a as f64 / b as f64))
-                }
-            }
-            (Numeric::Integer(a), Numeric::Float(b)) => {
-                if b == 0.0 {
-                    None
-                } else {
-                    Some(Numeric::Float(a as f64 / b))
-                }
-            }
-            (Numeric::Float(a), Numeric::Integer(b)) => {
-                if b == 0 {
-                    None
-                } else {
-                    Some(Numeric::Float(a / b as f64))
-                }
-            }
-            (Numeric::Float(a), Numeric::Float(b)) => {
-                if b == 0.0 {
-                    None
-                } else {
-                    Some(Numeric::Float(a / b))
-                }
-            }
+            (Numeric::Integer(a), Numeric::Integer(b)) => Some(Numeric::Float(a as f64 / b as f64)),
+            (Numeric::Integer(a), Numeric::Float(b)) => Some(Numeric::Float(a as f64 / b)),
+            (Numeric::Float(a), Numeric::Integer(b)) => Some(Numeric::Float(a / b as f64)),
+            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(a / b)),
         }
     }
 }
@@ -137,6 +113,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
     /// Test mixed comparison of longs & doubles.
     fn test_mixed_comparison() {
         // NaN to int -- Nothing compares equal to NaN.

--- a/polar/src/numerics.rs
+++ b/polar/src/numerics.rs
@@ -85,8 +85,6 @@ impl PartialEq for Numeric {
     }
 }
 
-impl Eq for Numeric {}
-
 /// There are 53 bits of mantissa in an IEEE 754 double precision float.
 const MOST_POSITIVE_EXACT_FLOAT: i64 = 1 << 53;
 
@@ -131,5 +129,72 @@ impl From<i64> for Numeric {
 impl From<f64> for Numeric {
     fn from(other: f64) -> Self {
         Self::Float(other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// Test mixed comparison of longs & doubles.
+    fn test_mixed_comparison() {
+        // NaN to int -- Nothing compares equal to NaN.
+        assert!(Numeric::Integer(1) != Numeric::Float(f64::NAN));
+        assert!(Numeric::Integer(-1) != Numeric::Float(f64::NAN));
+        assert!(!(Numeric::Integer(1) < Numeric::Float(f64::NAN)));
+        assert!(!(Numeric::Integer(1) > Numeric::Float(f64::NAN)));
+        assert!(!(Numeric::Integer(-1) > Numeric::Float(f64::NAN)));
+
+        // All zeros equal.
+        assert!(Numeric::Integer(0) == Numeric::Float(0.0));
+        assert!(Numeric::Integer(0) == Numeric::Float(-0.0));
+
+        // Infinity to int compares greater than all ints.
+        assert!(Numeric::Integer(1) < Numeric::Float(f64::INFINITY));
+        assert!(Numeric::Integer(i64::MAX) < Numeric::Float(f64::INFINITY));
+        assert!(Numeric::Integer(i64::MIN) < Numeric::Float(f64::INFINITY));
+        assert!(Numeric::Integer(i64::MIN) > Numeric::Float(f64::NEG_INFINITY));
+        assert!(Numeric::Integer(0) > Numeric::Float(f64::NEG_INFINITY));
+        assert!(Numeric::Integer(i64::MAX) > Numeric::Float(f64::NEG_INFINITY));
+
+        // Float representable as long compares correctly.
+        assert!(Numeric::Integer(1) == Numeric::Float(1.0));
+        assert!(Numeric::Integer(-1) != Numeric::Float(1.0));
+        assert!(Numeric::Integer(2) > Numeric::Float(1.0));
+        assert!(Numeric::Integer(-2) < Numeric::Float(1.0));
+        assert!(Numeric::Integer(1 << 52) == Numeric::Float((2.0 as f64).powi(52)));
+        assert!(Numeric::Integer(1 << 53) == Numeric::Float((2.0 as f64).powi(53)));
+        assert!(Numeric::Integer((1 << 52) + 1) == Numeric::Float((2.0 as f64).powi(52) + 1.0));
+        assert!(Numeric::Integer((1 << 52)) < Numeric::Float((2.0 as f64).powi(52) + 1.0));
+        assert!(Numeric::Integer((1 << 52) + 1) > Numeric::Float((2.0 as f64).powi(52)));
+        assert!(Numeric::Integer(-(1 << 52) - 1) < Numeric::Float(-(2.0 as f64).powi(52)));
+
+        // Long not exactly representable as float compares correctly.
+        assert!(Numeric::Integer((1 << 53) + 1) > Numeric::Float((2.0 as f64).powi(53)));
+        assert!(Numeric::Integer((1 << 53) - 1) == Numeric::Float((2.0 as f64).powi(53) - 1.0));
+        assert!(Numeric::Integer(-(1 << 53) - 1) < Numeric::Float(-(2.0 as f64).powi(53)));
+        assert!(Numeric::Integer(-(1 << 54)) < Numeric::Float(-(2.0 as f64).powi(53)));
+        assert!(Numeric::Integer(1 << 54) > Numeric::Float((2.0 as f64).powi(53)));
+        assert!(Numeric::Integer(1 << 56) > Numeric::Float((2.0 as f64).powi(54)));
+
+        // Float larger than max long compares correctly
+        assert!(Numeric::Integer(1 << 56) < Numeric::Float((2.0 as f64).powi(70)));
+
+        // Float smaller than min long compares correctly.
+        assert!(Numeric::Integer(1 << 56) > Numeric::Float(-(2.0 as f64).powi(70)));
+        assert!(Numeric::Integer(-(1 << 56)) > Numeric::Float(-(2.0 as f64).powi(70)));
+        assert!(Numeric::Integer(i64::MIN) > Numeric::Float(-(2.0 as f64).powi(70)));
+        assert!(Numeric::Integer(i64::MAX) < Numeric::Float((2.0 as f64).powi(65) + 3.1));
+
+        // Long exactly representable as float compares correctly
+        assert!(Numeric::Integer(2) == Numeric::Float(2.0));
+        assert!(Numeric::Integer(2) < Numeric::Float(2.1));
+        // 2 * epsilon here since 2 takes up 2 bits of the mantissa, so 2.0 + e == 2.0.
+        assert!(Numeric::Integer(2) < Numeric::Float(2.0 + 2.0 * f64::EPSILON));
+        assert!(Numeric::Integer(2) > Numeric::Float(2.0 - 2.0 * f64::EPSILON));
+        assert!(Numeric::Integer(1) < Numeric::Float(1.0 + f64::EPSILON));
+        assert!(Numeric::Integer(1) > Numeric::Float(1.0 - f64::EPSILON));
+        assert!(Numeric::Integer(2) < Numeric::Float(3.0));
     }
 }

--- a/polar/src/numerics.rs
+++ b/polar/src/numerics.rs
@@ -1,0 +1,146 @@
+use std::cmp::Ordering;
+use std::ops::{Add, Div, Mul, Sub};
+
+use super::types::*;
+use ordered_float::OrderedFloat;
+
+impl Add for Numeric {
+    type Output = Option<Self>;
+
+    fn add(self, other: Self) -> Option<Self> {
+        match (self, other) {
+            (Numeric::Integer(a), Numeric::Integer(b)) => a.checked_add(b).map(Numeric::Integer),
+            (Numeric::Integer(a), Numeric::Float(b)) => {
+                Some(Numeric::Float(OrderedFloat(a as f64 + b.0)))
+            }
+            (Numeric::Float(a), Numeric::Integer(b)) => {
+                Some(Numeric::Float(OrderedFloat(a.0 + b as f64)))
+            }
+            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(OrderedFloat(a.0 + b.0))),
+        }
+    }
+}
+
+impl Sub for Numeric {
+    type Output = Option<Self>;
+
+    fn sub(self, other: Self) -> Option<Self> {
+        match (self, other) {
+            (Numeric::Integer(a), Numeric::Integer(b)) => a.checked_sub(b).map(Numeric::Integer),
+            (Numeric::Integer(a), Numeric::Float(b)) => {
+                Some(Numeric::Float(OrderedFloat(a as f64 - b.0)))
+            }
+            (Numeric::Float(a), Numeric::Integer(b)) => {
+                Some(Numeric::Float(OrderedFloat(a.0 - b as f64)))
+            }
+            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(OrderedFloat(a.0 - b.0))),
+        }
+    }
+}
+
+impl Mul for Numeric {
+    type Output = Option<Self>;
+
+    fn mul(self, other: Self) -> Option<Self> {
+        match (self, other) {
+            (Numeric::Integer(a), Numeric::Integer(b)) => a.checked_mul(b).map(Numeric::Integer),
+            (Numeric::Integer(a), Numeric::Float(b)) => {
+                Some(Numeric::Float(OrderedFloat(a as f64 * b.0)))
+            }
+            (Numeric::Float(a), Numeric::Integer(b)) => {
+                Some(Numeric::Float(OrderedFloat(a.0 * b as f64)))
+            }
+            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(OrderedFloat(a.0 * b.0))),
+        }
+    }
+}
+
+impl Div for Numeric {
+    type Output = Option<Self>;
+
+    fn div(self, other: Self) -> Option<Self> {
+        match (self, other) {
+            (Numeric::Integer(a), Numeric::Integer(b)) => {
+                if b == 0 {
+                    None
+                } else {
+                    Some(Numeric::Float(OrderedFloat(a as f64 / b as f64)))
+                }
+            }
+            (Numeric::Integer(a), Numeric::Float(b)) => {
+                if b.0 == 0.0 {
+                    None
+                } else {
+                    Some(Numeric::Float(OrderedFloat(a as f64 / b.0)))
+                }
+            }
+            (Numeric::Float(a), Numeric::Integer(b)) => {
+                if b == 0 {
+                    None
+                } else {
+                    Some(Numeric::Float(OrderedFloat(a.0 / b as f64)))
+                }
+            }
+            (Numeric::Float(a), Numeric::Float(b)) => {
+                if b.0 == 0.0 {
+                    None
+                } else {
+                    Some(Numeric::Float(OrderedFloat(a.0 / b.0)))
+                }
+            }
+        }
+    }
+}
+
+impl PartialEq for Numeric {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(self.partial_cmp(other), Some(Ordering::Equal))
+    }
+}
+
+/// There are 53 bits of mantissa in an IEEE 754 double precision float.
+const MOST_POSITIVE_EXACT_FLOAT: i64 = 1 << 53;
+
+/// Floats larger than this are not representable as signed 64-bit integers.
+const MOST_POSITIVE_INTEGER: i64 = 0x7fffffffffffffff;
+
+impl PartialOrd for Numeric {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // Compare the integer `i` with the float `f`.
+        // Adapted from MongoDB's `compareLongToDouble`.
+        let partial_cmp = |i: i64, f: Float| {
+            if f.is_nan() {
+                None
+            } else if -MOST_POSITIVE_EXACT_FLOAT < i && i < MOST_POSITIVE_EXACT_FLOAT {
+                // The integer is exactly representable as a float.
+                (i as f64).partial_cmp(&f)
+            } else if f > OrderedFloat(MOST_POSITIVE_INTEGER as f64) {
+                // The float is greater than any representable integer.
+                Some(Ordering::Less)
+            } else if f < OrderedFloat(-MOST_POSITIVE_INTEGER as f64) {
+                // The float is less than any representable integer.
+                Some(Ordering::Greater)
+            } else {
+                // The integral part of the float is representable as an integer.
+                i.partial_cmp(&(f.0 as i64))
+            }
+        };
+        match (*self, *other) {
+            (Self::Integer(left), Self::Integer(right)) => left.partial_cmp(&right),
+            (Self::Integer(i), Self::Float(f)) => partial_cmp(i, f),
+            (Self::Float(f), Self::Integer(i)) => partial_cmp(i, f).map(Ordering::reverse),
+            (Self::Float(left), Self::Float(right)) => left.partial_cmp(&right),
+        }
+    }
+}
+
+impl From<i64> for Numeric {
+    fn from(other: i64) -> Self {
+        Self::Integer(other)
+    }
+}
+impl From<f64> for Numeric {
+    fn from(other: f64) -> Self {
+        Self::Float(other.into())
+    }
+}

--- a/polar/src/numerics.rs
+++ b/polar/src/numerics.rs
@@ -2,7 +2,6 @@ use std::cmp::Ordering;
 use std::ops::{Add, Div, Mul, Sub};
 
 use super::types::*;
-use ordered_float::OrderedFloat;
 
 impl Add for Numeric {
     type Output = Option<Self>;
@@ -10,13 +9,9 @@ impl Add for Numeric {
     fn add(self, other: Self) -> Option<Self> {
         match (self, other) {
             (Numeric::Integer(a), Numeric::Integer(b)) => a.checked_add(b).map(Numeric::Integer),
-            (Numeric::Integer(a), Numeric::Float(b)) => {
-                Some(Numeric::Float(OrderedFloat(a as f64 + b.0)))
-            }
-            (Numeric::Float(a), Numeric::Integer(b)) => {
-                Some(Numeric::Float(OrderedFloat(a.0 + b as f64)))
-            }
-            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(OrderedFloat(a.0 + b.0))),
+            (Numeric::Integer(a), Numeric::Float(b)) => Some(Numeric::Float(a as f64 + b)),
+            (Numeric::Float(a), Numeric::Integer(b)) => Some(Numeric::Float(a + b as f64)),
+            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(a + b)),
         }
     }
 }
@@ -27,13 +22,9 @@ impl Sub for Numeric {
     fn sub(self, other: Self) -> Option<Self> {
         match (self, other) {
             (Numeric::Integer(a), Numeric::Integer(b)) => a.checked_sub(b).map(Numeric::Integer),
-            (Numeric::Integer(a), Numeric::Float(b)) => {
-                Some(Numeric::Float(OrderedFloat(a as f64 - b.0)))
-            }
-            (Numeric::Float(a), Numeric::Integer(b)) => {
-                Some(Numeric::Float(OrderedFloat(a.0 - b as f64)))
-            }
-            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(OrderedFloat(a.0 - b.0))),
+            (Numeric::Integer(a), Numeric::Float(b)) => Some(Numeric::Float(a as f64 - b)),
+            (Numeric::Float(a), Numeric::Integer(b)) => Some(Numeric::Float(a - b as f64)),
+            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(a - b)),
         }
     }
 }
@@ -44,13 +35,9 @@ impl Mul for Numeric {
     fn mul(self, other: Self) -> Option<Self> {
         match (self, other) {
             (Numeric::Integer(a), Numeric::Integer(b)) => a.checked_mul(b).map(Numeric::Integer),
-            (Numeric::Integer(a), Numeric::Float(b)) => {
-                Some(Numeric::Float(OrderedFloat(a as f64 * b.0)))
-            }
-            (Numeric::Float(a), Numeric::Integer(b)) => {
-                Some(Numeric::Float(OrderedFloat(a.0 * b as f64)))
-            }
-            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(OrderedFloat(a.0 * b.0))),
+            (Numeric::Integer(a), Numeric::Float(b)) => Some(Numeric::Float(a as f64 * b)),
+            (Numeric::Float(a), Numeric::Integer(b)) => Some(Numeric::Float(a * b as f64)),
+            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(a * b)),
         }
     }
 }
@@ -64,28 +51,28 @@ impl Div for Numeric {
                 if b == 0 {
                     None
                 } else {
-                    Some(Numeric::Float(OrderedFloat(a as f64 / b as f64)))
+                    Some(Numeric::Float(a as f64 / b as f64))
                 }
             }
             (Numeric::Integer(a), Numeric::Float(b)) => {
-                if b.0 == 0.0 {
+                if b == 0.0 {
                     None
                 } else {
-                    Some(Numeric::Float(OrderedFloat(a as f64 / b.0)))
+                    Some(Numeric::Float(a as f64 / b))
                 }
             }
             (Numeric::Float(a), Numeric::Integer(b)) => {
                 if b == 0 {
                     None
                 } else {
-                    Some(Numeric::Float(OrderedFloat(a.0 / b as f64)))
+                    Some(Numeric::Float(a / b as f64))
                 }
             }
             (Numeric::Float(a), Numeric::Float(b)) => {
-                if b.0 == 0.0 {
+                if b == 0.0 {
                     None
                 } else {
-                    Some(Numeric::Float(OrderedFloat(a.0 / b.0)))
+                    Some(Numeric::Float(a / b))
                 }
             }
         }
@@ -98,6 +85,8 @@ impl PartialEq for Numeric {
     }
 }
 
+impl Eq for Numeric {}
+
 /// There are 53 bits of mantissa in an IEEE 754 double precision float.
 const MOST_POSITIVE_EXACT_FLOAT: i64 = 1 << 53;
 
@@ -108,21 +97,21 @@ impl PartialOrd for Numeric {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         // Compare the integer `i` with the float `f`.
         // Adapted from MongoDB's `compareLongToDouble`.
-        let partial_cmp = |i: i64, f: Float| {
+        let partial_cmp = |i: i64, f: f64| {
             if f.is_nan() {
                 None
             } else if -MOST_POSITIVE_EXACT_FLOAT < i && i < MOST_POSITIVE_EXACT_FLOAT {
                 // The integer is exactly representable as a float.
                 (i as f64).partial_cmp(&f)
-            } else if f > OrderedFloat(MOST_POSITIVE_INTEGER as f64) {
+            } else if f > MOST_POSITIVE_INTEGER as f64 {
                 // The float is greater than any representable integer.
                 Some(Ordering::Less)
-            } else if f < OrderedFloat(-MOST_POSITIVE_INTEGER as f64) {
+            } else if f < -MOST_POSITIVE_INTEGER as f64 {
                 // The float is less than any representable integer.
                 Some(Ordering::Greater)
             } else {
                 // The integral part of the float is representable as an integer.
-                i.partial_cmp(&(f.0 as i64))
+                i.partial_cmp(&(f as i64))
             }
         };
         match (*self, *other) {
@@ -141,6 +130,6 @@ impl From<i64> for Numeric {
 }
 impl From<f64> for Numeric {
     fn from(other: f64) -> Self {
-        Self::Float(other.into())
+        Self::Float(other)
     }
 }

--- a/polar/src/parser.rs
+++ b/polar/src/parser.rs
@@ -258,6 +258,7 @@ mod tests {
         assert_eq!(parse_query("+1.234"), term!(1.234));
         assert_eq!(parse_query("-1.234"), term!(-1.234));
         assert_eq!(parse_query("-1.234e-56"), term!(-1.234e-56));
+        assert_eq!(parse_query("-1.234e56"), term!(-1.234e56));
     }
 
     #[test]

--- a/polar/src/types.rs
+++ b/polar/src/types.rs
@@ -214,7 +214,7 @@ pub enum Numeric {
     Float(f64),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Value {
     Number(Numeric),
     String(String),

--- a/polar/src/types.rs
+++ b/polar/src/types.rs
@@ -5,8 +5,6 @@
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
-use std::convert::TryFrom;
-use std::ops::{Add, Div, Mul, Sub};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -212,142 +210,11 @@ impl Pattern {
 
 pub type Float = OrderedFloat<f64>;
 
+/// A number. See the [`numerics`] module for implementations.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq)]
 pub enum Numeric {
     Integer(i64),
     Float(Float),
-}
-
-impl Add for Numeric {
-    type Output = Option<Self>;
-
-    fn add(self, other: Self) -> Option<Self> {
-        match (self, other) {
-            (Numeric::Integer(a), Numeric::Integer(b)) => a.checked_add(b).map(Numeric::Integer),
-            (Numeric::Integer(a), Numeric::Float(b)) => {
-                Some(Numeric::Float(OrderedFloat(a as f64 + b.0)))
-            }
-            (Numeric::Float(a), Numeric::Integer(b)) => {
-                Some(Numeric::Float(OrderedFloat(a.0 + b as f64)))
-            }
-            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(OrderedFloat(a.0 + b.0))),
-        }
-    }
-}
-
-impl Sub for Numeric {
-    type Output = Option<Self>;
-
-    fn sub(self, other: Self) -> Option<Self> {
-        match (self, other) {
-            (Numeric::Integer(a), Numeric::Integer(b)) => a.checked_sub(b).map(Numeric::Integer),
-            (Numeric::Integer(a), Numeric::Float(b)) => {
-                Some(Numeric::Float(OrderedFloat(a as f64 - b.0)))
-            }
-            (Numeric::Float(a), Numeric::Integer(b)) => {
-                Some(Numeric::Float(OrderedFloat(a.0 - b as f64)))
-            }
-            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(OrderedFloat(a.0 - b.0))),
-        }
-    }
-}
-
-impl Mul for Numeric {
-    type Output = Option<Self>;
-
-    fn mul(self, other: Self) -> Option<Self> {
-        match (self, other) {
-            (Numeric::Integer(a), Numeric::Integer(b)) => a.checked_mul(b).map(Numeric::Integer),
-            (Numeric::Integer(a), Numeric::Float(b)) => {
-                Some(Numeric::Float(OrderedFloat(a as f64 * b.0)))
-            }
-            (Numeric::Float(a), Numeric::Integer(b)) => {
-                Some(Numeric::Float(OrderedFloat(a.0 * b as f64)))
-            }
-            (Numeric::Float(a), Numeric::Float(b)) => Some(Numeric::Float(OrderedFloat(a.0 * b.0))),
-        }
-    }
-}
-
-impl Div for Numeric {
-    type Output = Option<Self>;
-
-    fn div(self, other: Self) -> Option<Self> {
-        match (self, other) {
-            (Numeric::Integer(a), Numeric::Integer(b)) => {
-                if b == 0 {
-                    None
-                } else {
-                    Some(Numeric::Float(OrderedFloat(a as f64 / b as f64)))
-                }
-            }
-            (Numeric::Integer(a), Numeric::Float(b)) => {
-                if b.0 == 0.0 {
-                    None
-                } else {
-                    Some(Numeric::Float(OrderedFloat(a as f64 / b.0)))
-                }
-            }
-            (Numeric::Float(a), Numeric::Integer(b)) => {
-                if b == 0 {
-                    None
-                } else {
-                    Some(Numeric::Float(OrderedFloat(a.0 / b as f64)))
-                }
-            }
-            (Numeric::Float(a), Numeric::Float(b)) => {
-                if b.0 == 0.0 {
-                    None
-                } else {
-                    Some(Numeric::Float(OrderedFloat(a.0 / b.0)))
-                }
-            }
-        }
-    }
-}
-
-impl PartialEq for Numeric {
-    fn eq(&self, other: &Self) -> bool {
-        matches!(self.partial_cmp(other), Some(std::cmp::Ordering::Equal))
-    }
-}
-
-impl PartialOrd for Numeric {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        // compare the integer `i` and the float `f`
-        // if `swap` then do `f.partial_cmp(i)` otherwise do `i.partial_cmp(f)`
-        let cmp_and_swap = |i: i64, f: Float, swap: bool| {
-            if let Ok(i) = i32::try_from(i) {
-                // integer and float are equal if they are within Ɛ of each other
-                if (f.into_inner() - f64::from(i)).abs() <= f64::EPSILON {
-                    Some(std::cmp::Ordering::Equal)
-                } else if swap {
-                    f.into_inner().partial_cmp(&f64::from(i))
-                } else {
-                    f64::from(i).partial_cmp(&f)
-                }
-            } else {
-                None
-            }
-        };
-        match (*self, *other) {
-            (Self::Integer(left), Self::Integer(right)) => left.partial_cmp(&right),
-            (Self::Integer(i), Self::Float(f)) => cmp_and_swap(i, f, false),
-            (Self::Float(f), Self::Integer(i)) => cmp_and_swap(i, f, true),
-            (Self::Float(left), Self::Float(right)) => left.partial_cmp(&right),
-        }
-    }
-}
-
-impl From<i64> for Numeric {
-    fn from(other: i64) -> Self {
-        Self::Integer(other)
-    }
-}
-impl From<f64> for Numeric {
-    fn from(other: f64) -> Self {
-        Self::Float(other.into())
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]

--- a/polar/src/types.rs
+++ b/polar/src/types.rs
@@ -2,7 +2,6 @@
 //!
 //! Polar types
 
-use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
@@ -208,13 +207,11 @@ impl Pattern {
     }
 }
 
-pub type Float = OrderedFloat<f64>;
-
 /// A number. See the [`numerics`] module for implementations.
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum Numeric {
     Integer(i64),
-    Float(Float),
+    Float(f64),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]

--- a/polar/tests/integration_tests.rs
+++ b/polar/tests/integration_tests.rs
@@ -880,7 +880,13 @@ fn test_arithmetic() {
     };
     check_arithmetic_error("9223372036854775807 + 1 > 0");
     check_arithmetic_error("-9223372036854775807 - 2 < 0");
-    check_arithmetic_error("1 / 0 == 0");
+
+    // x / 0 = ∞
+    assert_eq!(qvar(&mut polar, "x=1/0", "x"), vec![value!(f64::INFINITY)]);
+    assert!(qeval(&mut polar, "1/0 = 2/0"));
+    assert!(qnull(&mut polar, "1/0 < 0"));
+    assert!(qeval(&mut polar, "1/0 > 0"));
+    assert!(qeval(&mut polar, "1/0 > 1e100"));
 }
 
 #[test]

--- a/polar/tests/integration_tests.rs
+++ b/polar/tests/integration_tests.rs
@@ -750,8 +750,8 @@ fn test_comparisons() {
     assert!(qeval(&mut polar, "lt(-1,+1)"));
     assert!(qnull(&mut polar, "lt(-1,-1)"));
     assert!(qeval(&mut polar, "lt(-2,-1)"));
-    assert!(qeval(&mut polar, "lt(1019,1.0e19)"));
-    assert!(qnull(&mut polar, "lt(1.0e19,1019)"));
+    assert!(qeval(&mut polar, "lt(1019,1e19)"));
+    assert!(qnull(&mut polar, "lt(1e19,1019)"));
     assert!(qnull(&mut polar, "lt(9007199254740992,9007199254740992)")); // identical
     assert!(qnull(&mut polar, "lt(9007199254740992,9007199254740992.0)")); // equal
     assert!(qnull(&mut polar, "lt(9007199254740992,9007199254740993.0)")); // indistinguishable
@@ -805,8 +805,8 @@ fn test_comparisons() {
     assert!(qnull(&mut polar, "eq(-1,+1)"));
     assert!(qeval(&mut polar, "eq(-1,-1)"));
     assert!(qeval(&mut polar, "eq(-1,-1.0)"));
-    assert!(qnull(&mut polar, "eq(1019,1.0e19)"));
-    assert!(qnull(&mut polar, "eq(1.0e19,1019)"));
+    assert!(qnull(&mut polar, "eq(1019,1e19)"));
+    assert!(qnull(&mut polar, "eq(1e19,1019)"));
     assert!(qeval(&mut polar, "eq(9007199254740992,9007199254740992)")); // identical
     assert!(qeval(&mut polar, "eq(9007199254740992,9007199254740992.0)")); // equal
     assert!(qeval(&mut polar, "eq(9007199254740992,9007199254740993.0)")); // indistinguishable
@@ -1320,20 +1320,14 @@ fn test_boolean_expression() {
 #[test]
 fn test_float_parsing() {
     let mut polar = Polar::new(None);
-    polar.load("f(x) if x = 1+1;").unwrap();
-    polar.load("f(x) if x = 1+1.5;").unwrap();
-    polar.load("f(x) if x = 1.0e+15;").unwrap();
-    polar.load("f(x) if x = 1.0E+15;").unwrap();
-    polar.load("f(x) if x = 1.0e-15;").unwrap();
-
-    assert_eq!(
-        qvar(&mut polar, "f(x)", "x"),
-        vec![
-            value!(2),
-            value!(2.5),
-            value!(1.0e+15),
-            value!(1.0E+15),
-            value!(1.0e-15)
-        ]
-    )
+    assert_eq!(qvar(&mut polar, "x=1+1", "x"), vec![value!(2)]);
+    assert_eq!(qvar(&mut polar, "x=1+1.5", "x"), vec![value!(2.5)]);
+    assert_eq!(qvar(&mut polar, "x=1.e+5", "x"), vec![value!(1e5)]);
+    assert_eq!(qvar(&mut polar, "x=1e+5", "x"), vec![value!(1e5)]);
+    assert_eq!(qvar(&mut polar, "x=1e5", "x"), vec![value!(1e5)]);
+    assert_eq!(qvar(&mut polar, "x=1e-5", "x"), vec![value!(1e-5)]);
+    assert_eq!(qvar(&mut polar, "x=1.e-5", "x"), vec![value!(1e-5)]);
+    assert_eq!(qvar(&mut polar, "x=1.0e+15", "x"), vec![value!(1e15)]);
+    assert_eq!(qvar(&mut polar, "x=1.0E+15", "x"), vec![value!(1e15)]);
+    assert_eq!(qvar(&mut polar, "x=1.0e-15", "x"), vec![value!(1e-15)]);
 }

--- a/polar/tests/integration_tests.rs
+++ b/polar/tests/integration_tests.rs
@@ -750,6 +750,12 @@ fn test_comparisons() {
     assert!(qeval(&mut polar, "lt(-1,+1)"));
     assert!(qnull(&mut polar, "lt(-1,-1)"));
     assert!(qeval(&mut polar, "lt(-2,-1)"));
+    assert!(qeval(&mut polar, "lt(1019,1.0e19)"));
+    assert!(qnull(&mut polar, "lt(1.0e19,1019)"));
+    assert!(qnull(&mut polar, "lt(9007199254740992,9007199254740992)")); // identical
+    assert!(qnull(&mut polar, "lt(9007199254740992,9007199254740992.0)")); // equal
+    assert!(qnull(&mut polar, "lt(9007199254740992,9007199254740993.0)")); // indistinguishable
+    assert!(qeval(&mut polar, "lt(9007199254740992,9007199254740994.0)")); // distinguishable
     assert!(qeval(&mut polar, "lt(\"aa\",\"ab\")"));
     assert!(qnull(&mut polar, "lt(\"aa\",\"aa\")"));
 
@@ -799,6 +805,12 @@ fn test_comparisons() {
     assert!(qnull(&mut polar, "eq(-1,+1)"));
     assert!(qeval(&mut polar, "eq(-1,-1)"));
     assert!(qeval(&mut polar, "eq(-1,-1.0)"));
+    assert!(qnull(&mut polar, "eq(1019,1.0e19)"));
+    assert!(qnull(&mut polar, "eq(1.0e19,1019)"));
+    assert!(qeval(&mut polar, "eq(9007199254740992,9007199254740992)")); // identical
+    assert!(qeval(&mut polar, "eq(9007199254740992,9007199254740992.0)")); // equal
+    assert!(qeval(&mut polar, "eq(9007199254740992,9007199254740993.0)")); // indistinguishable
+    assert!(qnull(&mut polar, "eq(9007199254740992,9007199254740994.0)")); // distinguishable
     assert!(qeval(&mut polar, "eq(\"aa\", \"aa\")"));
     assert!(qnull(&mut polar, "eq(\"ab\", \"aa\")"));
 
@@ -823,7 +835,6 @@ fn test_comparisons() {
     assert!(qeval(&mut polar, "1.0 <= 1"));
     assert!(qeval(&mut polar, "1 == 1"));
     assert!(qeval(&mut polar, "0.0 == 0"));
-    assert!(qeval(&mut polar, "0.000000000000000001 == 0"));
 }
 
 #[test]


### PR DESCRIPTION
Should be able to compare any two integer & floating-point numbers with full machine precision.

Dropped implicit support for Ɛ comparisons. We can add a separate `~` operator later if we want that, but I think `==` should be as strict an equality relation as we can make it.

Also move numeric implementations to separate `numerics` module.

And follow up to #290 to support, e.g., `1e2`.