### PR TITLE
Opt in tracing

### DIFF
--- a/languages/java/oso/src/main/java/com/osohq/oso/Ffi.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Ffi.java
@@ -35,17 +35,17 @@ public class Ffi {
         }
 
         protected Query newQueryFromStr(String queryStr) throws Exceptions.OsoException {
-            return new Query(checkResult(polarLib.polar_new_query(ptr, queryStr)));
+            return new Query(checkResult(polarLib.polar_new_query(ptr, queryStr, 0)));
         }
 
         protected Query newQueryFromTerm(String queryTerm) throws Exceptions.OsoException {
-            return new Query(checkResult(polarLib.polar_new_query_from_term(ptr, queryTerm)));
+            return new Query(checkResult(polarLib.polar_new_query_from_term(ptr, queryTerm, 0)));
         }
 
         protected Query nextInlineQuery() throws Exceptions.OsoException {
             // Don't check result here because the returned Pointer is null to indicate
             // termination
-            Pointer p = polarLib.polar_next_inline_query(ptr);
+            Pointer p = polarLib.polar_next_inline_query(ptr, 0);
             if (p == null) {
                 return null;
             } else {
@@ -154,11 +154,11 @@ public class Ffi {
 
         Pointer polar_new();
 
-        Pointer polar_new_query(Pointer polar_ptr, String query_str);
+        Pointer polar_new_query(Pointer polar_ptr, String query_str, int trace);
 
-        Pointer polar_new_query_from_term(Pointer polar_ptr, String query_term);
+        Pointer polar_new_query_from_term(Pointer polar_ptr, String query_term, int trace);
 
-        Pointer polar_next_inline_query(Pointer polar_ptr);
+        Pointer polar_next_inline_query(Pointer polar_ptr, int trace);
 
         Pointer polar_next_query_event(Pointer query_ptr);
 

--- a/languages/python/polar/polar.py
+++ b/languages/python/polar/polar.py
@@ -60,7 +60,7 @@ class Polar:
 
         # check inline queries
         while True:
-            query = lib.polar_next_inline_query(self.ffi_polar)
+            query = lib.polar_next_inline_query(self.ffi_polar, 0)
             if is_null(query):  # Load is done
                 break
             else:
@@ -81,11 +81,13 @@ class Polar:
 
         host = self.host.copy()
         if isinstance(query, str):
-            query = check_result(lib.polar_new_query(self.ffi_polar, to_c_str(query)))
+            query = check_result(
+                lib.polar_new_query(self.ffi_polar, to_c_str(query), 0)
+            )
         elif isinstance(query, Predicate):
             query = check_result(
                 lib.polar_new_query_from_term(
-                    self.ffi_polar, ffi_serialize(host.to_polar_term(query))
+                    self.ffi_polar, ffi_serialize(host.to_polar_term(query)), 0
                 )
             )
         else:
@@ -118,7 +120,7 @@ class Polar:
                 query = input("query> ").strip(";")
             except EOFError:
                 return
-            ffi_query = lib.polar_new_query(self.ffi_polar, to_c_str(query))
+            ffi_query = lib.polar_new_query(self.ffi_polar, to_c_str(query), 0)
             if is_null(ffi_query):
                 print("Parse error: ", get_error())
                 continue

--- a/languages/ruby/lib/oso/polar/ffi/polar.rb
+++ b/languages/ruby/lib/oso/polar/ffi/polar.rb
@@ -11,10 +11,10 @@ module Oso
 
           attach_function :new, :polar_new, [], FFI::Polar
           attach_function :load_str, :polar_load, [FFI::Polar, :string, :string], :int32
-          attach_function :next_inline_query, :polar_next_inline_query, [FFI::Polar], FFI::Query
+          attach_function :next_inline_query, :polar_next_inline_query, [FFI::Polar, :uint32], FFI::Query
           attach_function :new_id, :polar_get_external_id, [FFI::Polar], :uint64
-          attach_function :new_query_from_str, :polar_new_query, [FFI::Polar, :string], FFI::Query
-          attach_function :new_query_from_term, :polar_new_query_from_term, [FFI::Polar, :string], FFI::Query
+          attach_function :new_query_from_str, :polar_new_query, [FFI::Polar, :string, :uint32], FFI::Query
+          attach_function :new_query_from_term, :polar_new_query_from_term, [FFI::Polar, :string, :uint32], FFI::Query
           attach_function :register_constant, :polar_register_constant, [FFI::Polar, :string, :string], :int32
           attach_function :free, :polar_free, [FFI::Polar], :int32
         end
@@ -40,7 +40,7 @@ module Oso
         # @return [nil] if there are no remaining inline queries.
         # @raise [FFI::Error] if the FFI call returns an error.
         def next_inline_query
-          query = Rust.next_inline_query(self)
+          query = Rust.next_inline_query(self, 0)
           query.null? ? nil : query
         end
 
@@ -59,7 +59,7 @@ module Oso
         # @return [FFI::Query]
         # @raise [FFI::Error] if the FFI call returns an error.
         def new_query_from_str(str)
-          query = Rust.new_query_from_str(self, str)
+          query = Rust.new_query_from_str(self, str, 0)
           raise FFI::Error.get if query.null?
 
           query
@@ -69,7 +69,7 @@ module Oso
         # @return [FFI::Query]
         # @raise [FFI::Error] if the FFI call returns an error.
         def new_query_from_term(term)
-          query = Rust.new_query_from_term(self, JSON.dump(term))
+          query = Rust.new_query_from_term(self, JSON.dump(term), 0)
           raise FFI::Error.get if query.null?
 
           query

--- a/polar/benches/bench.rs
+++ b/polar/benches/bench.rs
@@ -10,7 +10,7 @@ use polar::{types::*, Polar, Query};
 fn runner_from_query(q: &str) -> Runner {
     let polar = Polar::new(None);
     let query_term = polar::parser::parse_query(0, q).unwrap();
-    let query = polar.new_query_from_term(query_term);
+    let query = polar.new_query_from_term(query_term, false);
     Runner::new(polar, query)
 }
 

--- a/polar/src/lib.rs
+++ b/polar/src/lib.rs
@@ -144,8 +144,11 @@ pub extern "C" fn polar_register_constant(
     })
 }
 
+// @Note(steve): trace is treated as a bool. 0 for false, anything else for true.
+// If we get more than one flag on these ffi methods, consider renaming it flags and making it a bitflags field.
+// Then we wont have to update the ffi to add new optional things like logging or tracing or whatever.
 #[no_mangle]
-pub extern "C" fn polar_next_inline_query(polar_ptr: *mut Polar) -> *mut Query {
+pub extern "C" fn polar_next_inline_query(polar_ptr: *mut Polar, trace: u32) -> *mut Query {
     ffi_try!({
         let polar = unsafe { ffi_ref!(polar_ptr) };
         match polar.next_inline_query() {
@@ -159,6 +162,7 @@ pub extern "C" fn polar_next_inline_query(polar_ptr: *mut Polar) -> *mut Query {
 pub extern "C" fn polar_new_query_from_term(
     polar_ptr: *mut Polar,
     query_term: *const c_char,
+    trace: u32,
 ) -> *mut Query {
     ffi_try!({
         let polar = unsafe { ffi_ref!(polar_ptr) };
@@ -175,7 +179,11 @@ pub extern "C" fn polar_new_query_from_term(
 }
 
 #[no_mangle]
-pub extern "C" fn polar_new_query(polar_ptr: *mut Polar, query_str: *const c_char) -> *mut Query {
+pub extern "C" fn polar_new_query(
+    polar_ptr: *mut Polar,
+    query_str: *const c_char,
+    trace: u32,
+) -> *mut Query {
     ffi_try!({
         let polar = unsafe { ffi_ref!(polar_ptr) };
         let s = unsafe { ffi_string!(query_str) };

--- a/polar/src/lib.rs
+++ b/polar/src/lib.rs
@@ -151,7 +151,8 @@ pub extern "C" fn polar_register_constant(
 pub extern "C" fn polar_next_inline_query(polar_ptr: *mut Polar, trace: u32) -> *mut Query {
     ffi_try!({
         let polar = unsafe { ffi_ref!(polar_ptr) };
-        match polar.next_inline_query() {
+        let trace = trace != 0;
+        match polar.next_inline_query(trace) {
             Some(query) => box_ptr!(query),
             None => null_mut(),
         }
@@ -168,8 +169,9 @@ pub extern "C" fn polar_new_query_from_term(
         let polar = unsafe { ffi_ref!(polar_ptr) };
         let s = unsafe { ffi_string!(query_term) };
         let term = serde_json::from_str(&s);
+        let trace = trace != 0;
         match term {
-            Ok(term) => box_ptr!(polar.new_query_from_term(term)),
+            Ok(term) => box_ptr!(polar.new_query_from_term(term, trace)),
             Err(e) => {
                 set_error(error::RuntimeError::Serialization { msg: e.to_string() }.into());
                 null_mut()
@@ -187,7 +189,8 @@ pub extern "C" fn polar_new_query(
     ffi_try!({
         let polar = unsafe { ffi_ref!(polar_ptr) };
         let s = unsafe { ffi_string!(query_str) };
-        let q = polar.new_query(&s);
+        let trace = trace != 0;
+        let q = polar.new_query(&s, trace);
         match q {
             Ok(q) => box_ptr!(q),
             Err(e) => {

--- a/polar/src/polar.rs
+++ b/polar/src/polar.rs
@@ -291,7 +291,7 @@ impl Polar {
         let query = Goal::Query { term };
         let vm = PolarVirtualMachine::new(
             self.kb.clone(),
-            false,
+            trace,
             vec![query],
             Some(self.output.clone()),
         );
@@ -308,7 +308,7 @@ impl Polar {
         let query = Goal::Query { term };
         let vm = PolarVirtualMachine::new(
             self.kb.clone(),
-            false,
+            trace,
             vec![query],
             Some(self.output.clone()),
         );

--- a/polar/src/vm.rs
+++ b/polar/src/vm.rs
@@ -149,6 +149,7 @@ pub struct PolarVirtualMachine {
     choices: Choices,
     pub queries: Queries,
 
+    pub tracing: bool,
     pub trace_stack: Vec<Vec<Rc<Trace>>>, // Stack of traces higher up the tree.
     pub trace: Vec<Rc<Trace>>,            // Traces for the current level of the trace tree.
 
@@ -215,6 +216,7 @@ impl PolarVirtualMachine {
             csp: 0,
             choices: vec![],
             queries: vec![],
+            tracing: trace,
             trace_stack: vec![],
             trace: vec![],
             external_error: None,
@@ -367,14 +369,22 @@ impl PolarVirtualMachine {
 
         if self.log {
             self.print("⇒ result");
-            for t in &self.trace {
-                self.print(&format!("trace\n{}", draw(t, 0)));
+            if self.tracing {
+                for t in &self.trace {
+                    self.print(&format!("trace\n{}", draw(t, 0)));
+                }
             }
         }
 
+        let trace = if self.tracing {
+            self.trace.first().cloned()
+        } else {
+            None
+        };
+
         Ok(QueryEvent::Result {
             bindings: self.bindings(false),
-            trace: self.trace.first().cloned(),
+            trace,
         })
     }
 

--- a/polar/src/vm.rs
+++ b/polar/src/vm.rs
@@ -184,6 +184,7 @@ impl Default for PolarVirtualMachine {
     fn default() -> Self {
         PolarVirtualMachine::new(
             Arc::new(RwLock::new(KnowledgeBase::default())),
+            false,
             vec![],
             None,
         )
@@ -196,6 +197,7 @@ impl PolarVirtualMachine {
     /// Reverse the goal list for the sanity of callers.
     pub fn new(
         kb: Arc<RwLock<KnowledgeBase>>,
+        trace: bool,
         goals: Goals,
         output: Option<Arc<RwLock<Box<dyn std::io::Write>>>>,
     ) -> Self {
@@ -2100,7 +2102,7 @@ mod tests {
 
         let goal = query!(op!(And));
 
-        let mut vm = PolarVirtualMachine::new(Arc::new(RwLock::new(kb)), vec![goal], None);
+        let mut vm = PolarVirtualMachine::new(Arc::new(RwLock::new(kb)), false, vec![goal], None);
         assert_query_events!(vm, [
             QueryEvent::Result{hashmap!()},
             QueryEvent::Done
@@ -2472,6 +2474,7 @@ mod tests {
     fn debug() {
         let mut vm = PolarVirtualMachine::new(
             Arc::new(RwLock::new(KnowledgeBase::new())),
+            false,
             vec![Goal::Debug {
                 message: "Hello".to_string(),
             }],
@@ -2487,6 +2490,7 @@ mod tests {
     fn halt() {
         let mut vm = PolarVirtualMachine::new(
             Arc::new(RwLock::new(KnowledgeBase::new())),
+            false,
             vec![Goal::Halt],
             None,
         );
@@ -2505,6 +2509,7 @@ mod tests {
         let vals = term!([zero.clone(), one.clone()]);
         let mut vm = PolarVirtualMachine::new(
             Arc::new(RwLock::new(KnowledgeBase::new())),
+            false,
             vec![Goal::Unify {
                 left: vars,
                 right: vals,
@@ -2621,6 +2626,7 @@ mod tests {
 
         let mut vm = PolarVirtualMachine::new(
             Arc::new(RwLock::new(kb)),
+            false,
             vec![query!(pred!(
                 "bar",
                 [external_instance.clone(), external_instance, sym!("z")]

--- a/polar/tests/integration_tests.rs
+++ b/polar/tests/integration_tests.rs
@@ -243,7 +243,7 @@ fn test_trace() {
     polar
         .load("f(x) if x = 1 and x = 1; f(y) if y = 1;")
         .unwrap();
-    let query = polar.new_query("f(1)", false).unwrap();
+    let query = polar.new_query("f(1)", true).unwrap();
     let results = query_results!(query);
     let trace = draw(results.first().unwrap().1.as_ref().unwrap(), 0);
     let expected = r#"f(1) [

--- a/polar/tests/integration_tests.rs
+++ b/polar/tests/integration_tests.rs
@@ -153,12 +153,12 @@ fn query_results_with_externals(query: Query) -> (QueryResults, MockExternal) {
 }
 
 fn qeval(polar: &mut Polar, query_str: &str) -> bool {
-    let query = polar.new_query(query_str).unwrap();
+    let query = polar.new_query(query_str, false).unwrap();
     !query_results!(query).is_empty()
 }
 
 fn qnull(polar: &mut Polar, query_str: &str) -> bool {
-    let query = polar.new_query(query_str).unwrap();
+    let query = polar.new_query(query_str, false).unwrap();
     query_results!(query).is_empty()
 }
 
@@ -168,12 +168,12 @@ fn qext(polar: &mut Polar, query_str: &str, external_results: Vec<Value>) -> Que
         .map(Term::new_from_test)
         .rev()
         .collect();
-    let query = polar.new_query(query_str).unwrap();
+    let query = polar.new_query(query_str, false).unwrap();
     query_results!(query, |_, _, _, _| external_results.pop())
 }
 
 fn qvar(polar: &mut Polar, query_str: &str, var: &str) -> Vec<Value> {
-    let query = polar.new_query(query_str).unwrap();
+    let query = polar.new_query(query_str, false).unwrap();
     query_results!(query)
         .iter()
         .map(|bindings| bindings.0.get(&Symbol(var.to_string())).unwrap().clone())
@@ -181,7 +181,7 @@ fn qvar(polar: &mut Polar, query_str: &str, var: &str) -> Vec<Value> {
 }
 
 fn qvars(polar: &mut Polar, query_str: &str, vars: &[&str]) -> Vec<Vec<Value>> {
-    let query = polar.new_query(query_str).unwrap();
+    let query = polar.new_query(query_str, false).unwrap();
 
     query_results!(query)
         .iter()
@@ -219,7 +219,7 @@ fn test_jealous() {
         )
         .unwrap();
 
-    let query = polar.new_query("jealous(who, of)").unwrap();
+    let query = polar.new_query("jealous(who, of)", false).unwrap();
     let results = query_results!(query);
     let jealous = |who: &str, of: &str| {
         assert!(
@@ -243,7 +243,7 @@ fn test_trace() {
     polar
         .load("f(x) if x = 1 and x = 1; f(y) if y = 1;")
         .unwrap();
-    let query = polar.new_query("f(1)").unwrap();
+    let query = polar.new_query("f(1)", false).unwrap();
     let results = query_results!(query);
     let trace = draw(results.first().unwrap().1.as_ref().unwrap(), 0);
     let expected = r#"f(1) [
@@ -640,7 +640,7 @@ fn test_lookup_derefs() {
     polar
         .load("f(x) if x = y and g(y); g(y) if new Foo{}.get(y) = y;")
         .unwrap();
-    let query = polar.new_query("f(1)").unwrap();
+    let query = polar.new_query("f(1)", false).unwrap();
     let mut foo_lookups = vec![term!(1)];
     let mock_foo = |_, _, _, args: Vec<Term>| {
         // check the argument is bound to an integer
@@ -656,7 +656,7 @@ fn test_lookup_derefs() {
         assert!(matches!(args[0].value(), Value::Number(_)));
         foo_lookups.pop()
     };
-    let query = polar.new_query("f(2)").unwrap();
+    let query = polar.new_query("f(2)", false).unwrap();
     let results = query_results!(query, mock_foo);
     assert!(results.is_empty());
 }
@@ -693,7 +693,7 @@ fn test_load_with_query() {
     let src = "f(1); f(2); ?= f(1); ?= not f(3);";
     polar.load(src).expect("load failed");
 
-    while let Some(query) = polar.next_inline_query() {
+    while let Some(query) = polar.next_inline_query(false) {
         assert_eq!(query_results!(query).len(), 1);
     }
 }
@@ -723,7 +723,7 @@ fn test_externals_instantiated() {
         );
         foo_lookups.pop()
     };
-    let query = polar.new_query("f(1, new Foo{})").unwrap();
+    let query = polar.new_query("f(1, new Foo{})", false).unwrap();
     let results = query_results!(query, mock_foo);
     assert_eq!(results.len(), 1);
 }
@@ -813,7 +813,7 @@ fn test_comparisons() {
     assert!(qnull(&mut polar, "neq(\"aa\", \"aa\")"));
     assert!(qeval(&mut polar, "neq(\"ab\", \"aa\")"));
 
-    let mut query = polar.new_query("eq(bob, bob)").unwrap();
+    let mut query = polar.new_query("eq(bob, bob)", false).unwrap();
     query
         .next_event()
         .expect_err("can't compare unbound variables");
@@ -860,7 +860,7 @@ fn test_arithmetic() {
     assert!(qnull(&mut polar, "odd(4)"));
 
     let check_arithmetic_error = |query: &str| {
-        let mut query = polar.new_query(query).unwrap();
+        let mut query = polar.new_query(query, false).unwrap();
         let error = query.next_event().unwrap_err();
         assert!(matches!(
             error.kind,
@@ -923,7 +923,7 @@ fn test_debug() {
         rt.to_string()
     };
 
-    let query = polar.new_query("a()").unwrap();
+    let query = polar.new_query("a()", false).unwrap();
     let _results = query_results!(query, no_results, no_externals, debug_handler);
 
     let mut call_num = 0;
@@ -951,7 +951,7 @@ fn test_debug() {
         call_num += 1;
         rt.to_string()
     };
-    let query = polar.new_query("a()").unwrap();
+    let query = polar.new_query("a()", false).unwrap();
     let _results = query_results!(query, no_results, no_externals, debug_handler);
 }
 
@@ -1068,7 +1068,7 @@ fn test_in() {
 
     // strange test case but it's important to note that this returns
     // 3 results, with 1 binding each
-    let query = polar.new_query("f(1, [x,y,z])").unwrap();
+    let query = polar.new_query("f(1, [x,y,z])", false).unwrap();
     let results = query_results!(query);
     assert_eq!(results.len(), 3);
     assert_eq!(
@@ -1086,7 +1086,7 @@ fn test_in() {
 
     assert!(qeval(&mut polar, "f({a:1}, [{a:1}, b, c])"));
 
-    let mut query = polar.new_query("a in {a:1}").unwrap();
+    let mut query = polar.new_query("a in {a:1}", false).unwrap();
     let e = query.next_event().unwrap_err();
     assert!(matches!(
         e.kind,
@@ -1175,11 +1175,13 @@ fn test_unify_rule_head() {
     polar.load("f(_: Foo{a: 1}, x) if x = 1;").unwrap();
     polar.load("g(_: Foo{a: Foo{a: 1}}, x) if x = 1;").unwrap();
 
-    let query = polar.new_query("f(new Foo{a: 1}, x)").unwrap();
+    let query = polar.new_query("f(new Foo{a: 1}, x)", false).unwrap();
     let (results, _externals) = query_results_with_externals(query);
     assert_eq!(results[0].0.get(&sym!("x")).unwrap(), &value!(1));
 
-    let query = polar.new_query("g(new Foo{a: new Foo{a: 1}}, x)").unwrap();
+    let query = polar
+        .new_query("g(new Foo{a: new Foo{a: 1}}, x)", false)
+        .unwrap();
     let (results, _externals) = query_results_with_externals(query);
     assert_eq!(results[0].0.get(&sym!("x")).unwrap(), &value!(1));
 }


### PR DESCRIPTION
Adds a flag to ffi query methods to enable or disable returning a trace.
Sets all the language libraries to pass false, effectively turning off tracing.

In a followup, ways to ask for a trace and get it returned back will be added to the public apis of the different libraries.

This does not actually stop the tracing goals in the vm because those are used for more than just tracing (notably stack traces on errors). I will re-evaluate how those work and if they're too expensive when I dive deeper into trace format things a bit later.

It does avoid the main place traces were blowing up which is turning very large ones into json.

Fixes #292 
```
irb(main):001:0> require 'oso'
=> true
irb(main):002:0> oso = Oso.new
irb(main):003:0> oso.load_str "fib(0,1) if cut;"
=> nil
irb(main):004:0> oso.load_str "fib(1,1) if cut;"
=> nil
irb(main):005:0> oso.load_str "fib(n,a+b) if fib(n-1, a) and fib(n-2, b);"
=> nil
irb(main):006:0> oso.query("fib(12,x)").next
=> {"x"=>233}
```