### PR TITLE
Updates to parser and traces

### DIFF
--- a/languages/python/oso/oso.py
+++ b/languages/python/oso/oso.py
@@ -36,7 +36,6 @@ class Oso(Polar):
         self.register_class(Http)
         self.register_class(PathMapper)
 
-    # TODO (dhatch): should we name this 'is_allowed'?
     def is_allowed(self, actor, action, resource) -> bool:
         """Evaluate whether ``actor`` is allowed to perform ``action`` on ``resource``.
 

--- a/languages/python/polar/polar.py
+++ b/languages/python/polar/polar.py
@@ -73,7 +73,6 @@ class Polar:
         """Query for a predicate, parsing it if necessary.
 
         :param query: The predicate to query for.
-        :param single: Whether to stop after the first result.
 
         :return: The result of the query.
         """
@@ -94,7 +93,7 @@ class Polar:
             raise PolarApiException(f"Can not query for {query}")
 
         for res in Query(query, host=host).run():
-            yield res["bindings"]
+            yield res
 
     def query_rule(self, name, *args):
         """Query for rule with name ``name`` and arguments ``args``.

--- a/languages/python/polar/test_helpers.py
+++ b/languages/python/polar/test_helpers.py
@@ -52,7 +52,7 @@ def query(polar):
     """ Query something and return the results as a list """
 
     def _query(q):
-        return list(polar.query(q))
+        return list(r["bindings"] for r in polar.query(q))
 
     return _query
 

--- a/languages/python/tests/test_polar.py
+++ b/languages/python/tests/test_polar.py
@@ -604,17 +604,23 @@ def test_register_constants_with_decorator():
     p.load_str("foo_rule(x: RegisterDecoratorTest, y) if y = 1;")
     p.load_str("foo_class_attr(y) if y = RegisterDecoratorTest.x;")
     assert (
-        next(p.query_rule("foo_rule", RegisterDecoratorTest(), Variable("y")))["y"] == 1
+        next(p.query_rule("foo_rule", RegisterDecoratorTest(), Variable("y")))[
+            "bindings"
+        ]["y"]
+        == 1
     )
-    assert next(p.query_rule("foo_class_attr", Variable("y")))["y"] == 1
+    assert next(p.query_rule("foo_class_attr", Variable("y")))["bindings"]["y"] == 1
 
     p = Polar()
     p.load_str("foo_rule(x: RegisterDecoratorTest, y) if y = 1;")
     p.load_str("foo_class_attr(y) if y = RegisterDecoratorTest.x;")
     assert (
-        next(p.query_rule("foo_rule", RegisterDecoratorTest(), Variable("y")))["y"] == 1
+        next(p.query_rule("foo_rule", RegisterDecoratorTest(), Variable("y")))[
+            "bindings"
+        ]["y"]
+        == 1
     )
-    assert next(p.query_rule("foo_class_attr", Variable("y")))["y"] == 1
+    assert next(p.query_rule("foo_class_attr", Variable("y")))["bindings"]["y"] == 1
 
 
 def test_unbound_variable(polar, query):

--- a/polar-core/src/lexer.rs
+++ b/polar-core/src/lexer.rs
@@ -1,5 +1,5 @@
-use super::error::{ErrorContext, ParseError};
-use super::types::{Source, Symbol};
+use super::error::ParseError;
+use super::types::Symbol;
 use std::iter::Peekable;
 use std::str::{CharIndices, FromStr};
 
@@ -22,15 +22,6 @@ pub fn loc_to_pos(src: &str, loc: usize) -> SrcPos {
         }
     }
     (row, col)
-}
-
-pub fn make_context(source: &Source, loc: usize) -> Option<ErrorContext> {
-    let (row, column) = loc_to_pos(&source.src, loc);
-    Some(ErrorContext {
-        source: source.clone(),
-        row,
-        column,
-    })
 }
 
 pub struct Lexer<'input> {
@@ -211,7 +202,6 @@ impl<'input> Lexer<'input> {
                     token: self.buf.clone(),
                     c: ':',
                     loc: last,
-                    context: None,
                 }));
             }
         }
@@ -263,7 +253,6 @@ impl<'input> Lexer<'input> {
                             token: self.buf.clone(),
                             c: char,
                             loc: i,
-                            context: None,
                         }))
                     }
                     '"' => {
@@ -287,7 +276,6 @@ impl<'input> Lexer<'input> {
                                 token: self.buf.clone(),
                                 c: '\0',
                                 loc: i,
-                                context: None,
                             }));
                         }
                         self.c = self.chars.next();
@@ -302,7 +290,6 @@ impl<'input> Lexer<'input> {
                     token: self.buf.clone(),
                     c: '\0',
                     loc: i,
-                    context: None,
                 }));
             }
         }
@@ -380,7 +367,6 @@ impl<'input> Lexer<'input> {
                 Some(Err(ParseError::InvalidFloat {
                     token: self.buf.clone(),
                     loc: start,
-                    context: None,
                 }))
             }
         } else if let Ok(int) = i64::from_str(&self.buf) {
@@ -389,7 +375,6 @@ impl<'input> Lexer<'input> {
             Some(Err(ParseError::IntegerOverflow {
                 token: self.buf.clone(),
                 loc: start,
-                context: None,
             }))
         }
     }
@@ -420,13 +405,11 @@ impl<'input> Lexer<'input> {
                 token: token.to_string(),
                 c: chr,
                 loc: i,
-                context: None,
             })),
             _ => Some(Err(ParseError::InvalidTokenCharacter {
                 token: token.to_string(),
                 c: '\0',
                 loc: start + 1,
-                context: None,
             })),
         }
     }
@@ -489,7 +472,6 @@ impl<'input> Iterator for Lexer<'input> {
                     token: "".to_owned(),
                     c: char,
                     loc: i,
-                    context: None,
                 })),
             },
         }
@@ -582,7 +564,6 @@ mod tests {
                 token: t,
                 c: '\u{0}',
                 loc: 5,
-                context: None
             })) if &t == "?="
         ));
     }
@@ -615,7 +596,6 @@ mod tests {
                 token: x,
                 c: ':',
                 loc: 4,
-                context: None
             })) if &x == "foo::"
         ));
     }
@@ -633,7 +613,6 @@ mod tests {
                 token: x,
                 c: '\u{0}',
                 loc: 5,
-                context: None
             })) if &x == "?="
         ));
     }

--- a/polar-core/src/macros.rs
+++ b/polar-core/src/macros.rs
@@ -41,7 +41,7 @@ macro_rules! term {
 impl From<(Symbol, Term)> for TestHelper<Parameter> {
     fn from(arg: (Symbol, Term)) -> Self {
         Self(Parameter {
-            parameter: Some(arg.1.clone_with_value(Value::Variable(arg.0))),
+            parameter: arg.1.clone_with_value(Value::Variable(arg.0)),
             specializer: Some(Pattern::term_as_pattern(&arg.1)),
         })
     }
@@ -53,7 +53,7 @@ impl From<Value> for TestHelper<Parameter> {
     /// a specializer.
     fn from(name: Value) -> Self {
         Self(Parameter {
-            parameter: Some(Term::new_from_test(name)),
+            parameter: Term::new_from_test(name),
             specializer: None,
         })
     }

--- a/polar-core/src/parser.rs
+++ b/polar-core/src/parser.rs
@@ -263,4 +263,19 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn test_primitive_methods() {
+        let q = r#""abc".startswith("a")"#;
+        assert_eq!(
+            parse_query(q),
+            term!(op!(Dot, term!("abc"), term!(pred!("startswith", ["a"])))),
+        );
+
+        let q = r#"x.("invalid-key")"#;
+        assert_eq!(
+            parse_query(q),
+            term!(op!(Dot, term!(sym!("x")), term!("invalid-key"))),
+        );
+    }
 }

--- a/polar-core/src/parser.rs
+++ b/polar-core/src/parser.rs
@@ -25,11 +25,9 @@ lazy_static::lazy_static! {
 
 fn to_parse_error(e: ParseError<usize, lexer::Token, error::ParseError>) -> error::ParseError {
     match e {
-        ParseError::InvalidToken { location: loc } => {
-            error::ParseError::InvalidToken { loc, context: None }
-        }
+        ParseError::InvalidToken { location: loc } => error::ParseError::InvalidToken { loc },
         ParseError::UnrecognizedEOF { location: loc, .. } => {
-            error::ParseError::UnrecognizedEOF { loc, context: None }
+            error::ParseError::UnrecognizedEOF { loc }
         }
         ParseError::UnrecognizedToken {
             token: (loc, t, _), ..
@@ -37,18 +35,15 @@ fn to_parse_error(e: ParseError<usize, lexer::Token, error::ParseError>) -> erro
             Token::Debug | Token::Cut | Token::In | Token::New => error::ParseError::ReservedWord {
                 token: t.to_string(),
                 loc,
-                context: None,
             },
             _ => error::ParseError::UnrecognizedToken {
                 token: t.to_string(),
                 loc,
-                context: None,
             },
         },
         ParseError::ExtraToken { token: (loc, t, _) } => error::ParseError::ExtraToken {
             token: t.to_string(),
             loc,
-            context: None,
         },
         ParseError::User { error } => error,
     }

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -491,7 +491,7 @@ RestVar<T>: Value = {
 
 
 
-Spanned<T>: Term = <start:@L> <value:T> <end:@R> =>  Term::new_from_parser(src_id, start, value);
+Spanned<T>: Term = <start:@L> <value:T> <end:@R> =>  Term::new_from_parser(src_id, start, end, value);
 
 pub Term = TermExp;
 
@@ -547,10 +547,10 @@ RuleHead: (Symbol, Vec<Parameter>) = {
 Define = {":=", "if"};
 
 pub Rule: Rule = {
-    <head:RuleHead> <start:@L> ";" => {
+    <head:RuleHead> <start:@L> <end:@R> ";" => {
         let (name, params) = head;
         let op = Operation{operator: Operator::And, args: vec![]};
-        let body = Term::new_from_parser(src_id, start, Value::Expression(op));
+        let body = Term::new_from_parser(src_id, start, end, Value::Expression(op));
         Rule{name, params, body}
     },
     <head:RuleHead> Define <body:TermExp> ";" => {
@@ -560,9 +560,8 @@ pub Rule: Rule = {
                 body
             },
             _ => {
-                let offset = body.offset();
-                let op = Operation{operator: Operator::And, args: vec![body]};
-                Term::new_from_parser(src_id, offset, Value::Expression(op))
+                let op = Operation{operator: Operator::And, args: vec![body.clone()]};
+                body.clone_with_value(Value::Expression(op))
             }
         };
         Rule{name, params, body}

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -63,40 +63,50 @@ extern {
     }
 }
 
-pub Number: Term = {
-    <start:@L> <i:"Integer"> => {
-        Term::new_from_parser(src_id, start, Value::Number(i.into()))
-    },
-    <start:@L> <f:"Float"> => {
-        Term::new_from_parser(src_id, start, Value::Number(f.into()))
-    },
-    <start:@L> "+" <i:"Integer"> => {
-        Term::new_from_parser(src_id, start, Value::Number(i.into()))
-    },
-    <start:@L> "+" <f:"Float"> => {
-        Term::new_from_parser(src_id, start, Value::Number(f.into()))
-    },
-    <start:@L> "-" <i:"Integer"> => {
-        Term::new_from_parser(src_id, start, Value::Number((-i).into()))
-    },
-    <start:@L> "-" <f:"Float"> => {
-        Term::new_from_parser(src_id, start, Value::Number((-f).into()))
-    }
+
+// ****** Values ******* //
+
+Integer: i64 = {
+    <"Integer">,
+"+" <"Integer">,
+"-" <i:"Integer"> => -i
+}
+
+Float: f64 = {
+    <"Float">,
+"+" <"Float">,
+"-" <f:"Float"> => -f
+}
+
+
+Number: Value = {
+    <Integer> => Value::Number(<>.into()),
+    <Float> => Value::Number(<>.into()),
 };
 
 
-pub PolarString: Term = <start:@L> <s:"String"> => {
-    Term::new_from_parser(src_id, start, Value::String(s))
+PolarString: Value = <s:"String"> => {
+    Value::String(s)
 };
 
-pub Boolean: Term = <start:@L> <b:"Boolean"> => {
-    Term::new_from_parser(src_id, start, Value::Boolean(b))
+Boolean: Value = <b:"Boolean"> => {
+    Value::Boolean(b)
 };
 
 Name: Symbol = <s:"Symbol"> => s;
 
-pub Symbol: Term  = <start:@L> <n:Name> => {
-    Term::new_from_parser(src_id, start, Value::Variable(n))
+Variable: Value  = <n:Name> => {
+    Value::Variable(n)
+};
+
+Predicate: Value = {
+    <name:Name> "(" <mut args:(<TermExp> ",")*> <arg:TermExp?> ")" => {
+        match arg {
+            Some(arg) => args.push(arg),
+            None => ()
+        };
+        Value::Call(Predicate{name, args})
+    }
 };
 
 Fields<T>: BTreeMap<Symbol, Term> = {
@@ -120,79 +130,42 @@ Object<T>: BTreeMap<Symbol, Term> = {
     }
 };
 
-Dictionary<T>: Term = <start:@L> <fields:Object<T>> => {
+// ****** Strange Values ******* //
+
+DictionaryTerm: Value = <fields:Object<Exp5<"Term">>> => {
     let dict = Dictionary{fields};
-    Term::new_from_parser(src_id, start, Value::Dictionary(dict))
+    Value::Dictionary(dict)
 };
-
-DictionaryTerm: Term = <Dictionary<Exp5<"Term">>> => <>;
 // Pattern dictionaries cannot contain any operators.
-DictionaryPattern: Term = <Dictionary<Exp9<"Pattern">>> => <>;
+DictionaryPattern: Value = <fields:Object<Exp9<"Pattern">>> => {
+    let dict = Dictionary{fields};
+    Value::Pattern(Pattern::Dictionary(dict))
+};
 
-InstanceLiteral<T>: Term = <start:@L> <tag:Name> <fields:Object<T>> => {
+InstanceLiteralTerm: Value = <tag:Name> <fields:Object<Exp5<"Term">>> => {
     let instance = InstanceLiteral{tag, fields: Dictionary{fields}};
-    Term::new_from_parser(src_id, start, Value::InstanceLiteral(instance))
+    Value::InstanceLiteral(instance)
 };
 
-pub InstanceLiteralTerm: Term = <InstanceLiteral<Exp5<"Term">>> => <>;
-pub InstanceLiteralPattern: Term = <InstanceLiteral<Exp9<"Pattern">>> => <>;
-
-// Either a *rest variable, or an ordinary term.
-RestVar<T>: Term = {
-    <start:@L> "*" <rest:Name> => {
-        Term::new_from_parser(src_id, start, Value::RestVariable(rest))
-    },
-    <Term> if T == "Term" => <>,
-    <Pattern> if T == "Pattern" => <>
+InstanceLiteralPattern: Value = <tag:Name> <fields:Object<Exp9<"Pattern">>> => {
+    let instance = InstanceLiteral{tag, fields: Dictionary{fields}};
+    Value::Pattern(Pattern::Instance(instance))
 };
 
-pub Pattern: Term = {
-    <term:InstanceLiteralPattern> => Pattern::term_as_pattern(&term),
-    <term:DictionaryPattern> => Pattern::term_as_pattern(&term),
-    <term:Number> => term,
-    <term:PolarString> => term,
-    <term:Boolean> => term,
-    <term:Symbol> => term,
-    <start:@L> "[" <terms:(<Pattern> ",")*> <term:RestVar<"Pattern">?> "]" => {
-        match term {
-            Some(term) => Term::new_from_parser(src_id, start, Value::List(vec![term])),
-            None => Term::new_from_parser(src_id, start, Value::List(terms))
-        }
-    }
-};
-
-pub Term: Term = {
-    <term:Number> => term,
-    <term:PolarString> => term,
-    <term:Boolean> => term,
-    <term:Symbol> => term,
-    <term:DictionaryTerm> => term,
-    <start:@L> <op:BuiltinOperation> => Term::new_from_parser(src_id, start, Value::Expression(op)),
-    <start:@L> <op:RewrittenOperation> => Term::new_from_parser(src_id, start, Value::Expression(op)),
-    <start:@L> <pred:Predicate> => Term::new_from_parser(src_id, start, Value::Call(pred)),
-    <start:@L> "[" <mut terms:(<Term> ",")*> <term:RestVar<"Term">?> "]" => {
-        match term {
-            Some(term) => {
-                terms.push(term);
-                Term::new_from_parser(src_id, start, Value::List(terms))
-            },
-            None => Term::new_from_parser(src_id, start, Value::List(terms))
-        }
-    }
-};
+// ****** Operations ******* //
 
 BuiltinOperator: Operator = {
     "debug" => Operator::Debug,
     "print" => Operator::Print,
 };
 
-pub BuiltinOperation: Operation = {
-    <op:BuiltinOperator> "(" <mut args:(<Exp2<"Term">> ",")*> <arg:Exp2<"Term">?> ")" => {
+BuiltinOperation: Value = {
+    <op:BuiltinOperator> "(" <mut args:(<TermExp> ",")*> <arg:TermExp?> ")" => {
         match arg {
             Some(arg) => args.push(arg),
             None => ()
         };
-        Operation{operator: op, args: args}
+        Value::Expression(Operation{operator: op, args: args})
     },
 };
 
@@ -202,207 +175,228 @@ RewritableOperator: Operator = {
     "in" => Operator::In,
 };
 
-pub RewrittenOperation: Operation = {
+RewrittenOperation: Value = {
     <op:RewritableOperator> "(" <mut args:(<TermExp> ",")*> <arg:TermExp?> ")" => {
         match arg {
             Some(arg) => args.push(arg),
             None => ()
         };
-        Operation{operator: op, args: args}
+        Value::Expression(Operation{operator: op, args: args})
     },
 };
 
-pub Predicate: Predicate = {
-    <name:Name> "(" <mut args:(<TermExp> ",")*> <arg:TermExp?> ")" => {
-        match arg {
-            Some(arg) => args.push(arg),
-            None => ()
-        };
-        Predicate{name, args}
-    }
+
+New: Value = "new" <literal:Spanned<InstanceLiteralTerm>> => {
+    let args = vec![literal];
+    let op = Operation{operator: Operator::New, args};
+    Value::Expression(op)
 };
 
+SpecialExp<T>: Value = {
+    // A pattern cannot contain a new operator
+    <New> if T == "Term",
+    "cut" => {
+        let args = vec![];
+        let op = Operation{operator: Operator::Cut, args};
+        Value::Expression(op)
+    },
+    "forall" "(" <arg1:TermExp> "," <arg2:TermExp> ")" => {
+        let args = vec![arg1, arg2];
+        let op = Operation{operator: Operator::ForAll, args};
+        Value::Expression(op)
+    },
+}
+
+
+
+// ****** Expressions ******* //
+
+// All ExpN & Exp productions are macros with one parameter. The parameter is the
+// *string* "Term" or "Pattern" which controls whether the expression is over terms
+// or patterns.  (It is a string since we need to conditionally
+// change the expression precedence allowed in patterns versus terms depending
+// on the parameter type, and LALRPOP does not allow conditional macros on anything
+// other than a string.
+
+Exp<T>: Term = {
+    <exp1:Exp1<T>> => exp1
+}
+
+pub TermExp: Term = {
+    <Exp<"Term">> => <>
+};
+
+pub PatternExp: Term = {
+    <Exp9<"Pattern">> => <>
+};
+
+
 Exp11<T>: Term = {
-    <term:Term> if T == "Term" => term,
-    <term:Pattern> if T == "Pattern" => term,
-    "(" <exp:Exp<T>> ")" => exp // seems sorta impossible to support parrens for expressions and list literals.
+    <Spanned<Pattern>> if T == "Pattern",
+    <Spanned<Value>> if T == "Term",
+    "(" <Exp<T>> ")", // "resets" the parsing
 }
 
 Exp10<T>: Term = {
-    // A pattern cannot contain a new operator
-    <new:New> if T == "Term" => new,
-    <start:@L> "cut" => {
-        let args = vec![];
-        let op = Operation{operator: Operator::Cut, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <start:@L> "forall" "(" <arg1:Exp2<"Term">> "," <arg2:Exp2<"Term">> ")" => {
-        let args = vec![arg1, arg2];
-        let op = Operation{operator: Operator::ForAll, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <exp11:Exp11<T>> => exp11,
+    <Spanned<SpecialExp<T>>>,
+    <Exp11<T>>,
 }
 
-New: Term = <start:@L> "new" <literal:InstanceLiteralTerm> => {
-    let args = vec![literal];
-    let op = Operation{operator: Operator::New, args};
-    Term::new_from_parser(src_id, start, Value::Expression(op))
-};
-
-Callable<T>: Term = {
+Callable<T>: Value = {
     <DictionaryTerm> if T == "Term" => <>,
     <DictionaryPattern> if T == "Pattern" => <>,
-    <Symbol> => <>,
+    <Variable> => <>,
     <DotOp<T>> => <>,
     // A pattern cannot contain a new operator.
-    <New> if T == "Term" => <>,
+    <New> if T == "Term" => <>, // TODO(Sam): should we actually allow this?
 };
 
-DotOp<T>: Term = {
-    <start:@L> <head:Callable<T>> "." <call_loc:@L> <mut call:Predicate> => {
-        let call_term = Term::new_from_parser(src_id, call_loc, Value::Call(call));
+CallTerm: Value = {
+    <Predicate>,
+    <name:Name> => Value::Call(Predicate{name, args: vec![]}),
+    "(" <Variable> ")",
+}
+
+DotOp<T>: Value = {
+    <head:Spanned<Callable<T>>> "." <call_term:Spanned<CallTerm>> => {
         let args = vec![head, call_term];
         let op = Operation{operator: Operator::Dot, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
+        Value::Expression(op)
     },
-    <start:@L> <head:Callable<T>> "." <call_loc:@L> <name:Name> => {
-        let call = Predicate{name, args: vec![]};
-        let call_term = Term::new_from_parser(src_id, call_loc, Value::Call(call));
-        let args = vec![head, call_term];
-        let op = Operation{operator: Operator::Dot, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <start:@L> <head:Callable<T>> "." <call_loc:@L> "(" <name:Name> ")" => {
-        let call_term = Term::new_from_parser(src_id, call_loc, Value::Variable(name));
-        let args = vec![head, call_term];
-        let op = Operation{operator: Operator::Dot, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    }
 }
 
 // .
 Exp9<T>: Term = {
-    <dot_op:DotOp<T>> => dot_op,
-    <exp10:Exp10<T>> => exp10
+    <Spanned<DotOp<T>>>,
+    <Exp10<T>>,
 };
 
-Matches = {"matches"};
-
-// in matches
-Exp8<T>: Term = {
-    <start:@L> <left:Exp8<T>> "in" <right:Exp9<T>> => {
+// in
+InExp<T>: Value = {
+    <left:Exp8<T>> "in" <right:Exp9<T>> => {
         let args = vec![left, right];
         let op = Operation{operator: Operator::In, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
+        Value::Expression(op)
     },
+}
+
+Matches = {"matches"};
+// matches
+MatchExp<T>: Value = {
     // Symbols on the RHS are treated as class names, just like in a specializers
-    <start:@L> <left:Exp8<T>> Matches <right:Pattern> => {
+    <left:Exp8<T>> Matches <right:Spanned<Pattern>> => {
         let right = if let Value::Variable(ref sym) = right.value() {
             right.clone_with_value(Value::Pattern(Pattern::Instance(InstanceLiteral {
                 tag: sym.clone(),
                 fields: Dictionary::new()
             })))
         } else {
-            Pattern::term_as_pattern(&right)
+            right
         };
         let args = vec![left, right];
         let op = Operation{operator: Operator::Isa, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
+        Value::Expression(op)
     },
-    <exp9:Exp9<T>> => exp9
+}
+
+Exp8<T>: Term = {
+    <Spanned<InExp<T>>>,
+    <Spanned<MatchExp<T>>>,
+    <Exp9<T>>,
 }
 
 // * /
+Op7: Operator = {
+    "*" => Operator::Mul,
+    "/" => Operator::Div,
+}
+MulExp<T>: Value = {
+    <exp7:Exp7<T>> <operator:Op7> <exp8:Exp8<T>> => {
+        let args = vec![exp7, exp8];
+        let op = Operation{operator, args};
+        Value::Expression(op)
+    },
+}
 Exp7<T>: Term = {
-    <start:@L> <exp7:Exp7<T>> "*" <exp8:Exp8<T>> => {
-        let args = vec![exp7, exp8];
-        let op = Operation{operator: Operator::Mul, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <start:@L> <exp7:Exp7<T>> "/" <exp8:Exp8<T>> => {
-        let args = vec![exp7, exp8];
-        let op = Operation{operator: Operator::Div, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <exp8:Exp8<T>> => exp8
+    <Spanned<MulExp<T>>>,
+    <Exp8<T>>,
 }
 
 // + -
+Op6: Operator = {
+    "+" => Operator::Add,
+    "-" => Operator::Sub,
+}
+AddExp<T>: Value = {
+    <exp6:Exp6<T>> <operator:Op6> <exp7:Exp7<T>> => {
+        let args = vec![exp6, exp7];
+        let op = Operation{operator, args};
+        Value::Expression(op)
+    },
+}
+
 Exp6<T>: Term = {
-    <start:@L> <exp6:Exp6<T>> "+" <exp7:Exp7<T>> => {
-        let args = vec![exp6, exp7];
-        let op = Operation{operator: Operator::Add, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <start:@L> <exp6:Exp6<T>> "-" <exp7:Exp7<T>> => {
-        let args = vec![exp6, exp7];
-        let op = Operation{operator: Operator::Sub, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <exp7:Exp7<T>> => exp7
+    <Spanned<AddExp<T>>>,
+    <Exp7<T>>,
 }
 
 // == != <= < >= >
+Op5: Operator = {
+    "==" => Operator::Eq,
+    "!=" => Operator::Neq,
+    "<=" => Operator::Leq,
+    ">=" => Operator::Geq,
+    "<" => Operator::Lt,
+    ">" => Operator::Gt,
+}
+
+CmpExp<T>: Value = {
+    <exp5:Exp5<T>> <operator:Op5> <exp6:Exp6<T>> => {
+        let args = vec![exp5, exp6];
+        let op = Operation{operator, args};
+        Value::Expression(op)
+    },
+}
+
 Exp5<T>: Term = {
-    <start:@L> <exp5:Exp5<T>> "==" <exp6:Exp6<T>> => {
-        let args = vec![exp5, exp6];
-        let op = Operation{operator: Operator::Eq, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <start:@L> <exp5:Exp5<T>> "!=" <exp6:Exp6<T>> => {
-        let args = vec![exp5, exp6];
-        let op = Operation{operator: Operator::Neq, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <start:@L> <exp5:Exp5<T>> "<=" <exp6:Exp6<T>> => {
-        let args = vec![exp5, exp6];
-        let op = Operation{operator: Operator::Leq, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <start:@L> <exp5:Exp5<T>> ">=" <exp6:Exp6<T>> => {
-        let args = vec![exp5, exp6];
-        let op = Operation{operator: Operator::Geq, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <start:@L> <exp5:Exp5<T>> "<" <exp6:Exp6<T>> => {
-        let args = vec![exp5, exp6];
-        let op = Operation{operator: Operator::Lt, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <start:@L> <exp5:Exp5<T>> ">" <exp6:Exp6<T>> => {
-        let args = vec![exp5, exp6];
-        let op = Operation{operator: Operator::Gt, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
-    },
-    <exp6:Exp6<T>> => exp6
+    <Spanned<CmpExp<T>>>,
+    <Exp6<T>>,
 }
 
 // =
-Exp4<T>: Term = {
-    <start:@L> <exp4:Exp4<T>> "=" <exp5:Exp5<T>> => {
+UnifyExp<T>: Value = {
+    <exp4:Exp4<T>> "=" <exp5:Exp5<T>> => {
         let args = vec![exp4, exp5];
         let op = Operation{operator: Operator::Unify, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
+        Value::Expression(op)
     },
-     <exp5:Exp5<T>> => exp5
- }
+}
+
+Exp4<T>: Term = {
+    <Spanned<UnifyExp<T>>>,
+    <Exp5<T>>,
+}
+
 
  // !
 Not = {"not"};
-Exp3<T>: Term = {
-    <start:@L> Not <exp4:Exp4<T>> => {
+NotExp<T>: Value = {
+    Not <exp4:Exp4<T>> => {
         let args = vec![exp4];
         let op = Operation{operator: Operator::Not, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
+        Value::Expression(op)
     },
-    // TODO (dhatch): Maybe a different type here
-    <exp4:Exp4<T>> => exp4
 }
 
+Exp3<T>: Term = {
+    <Spanned<NotExp<T>>>,
+    <Exp4<T>>,
+}
+
+
 Or = {"or"};
-Exp2<T>: Term = {
-    <start:@L> <head:Exp3<T>> Or <mut tail:Exp2<T>> => {
+OrExp<T>: Value = {
+    <head:Exp3<T>> Or <mut tail:Exp2<T>> => {
         let args = match &mut tail.value() {
             Value::Expression(Operation{operator: Operator::Or, args: tail_args}) => {
                 let mut args = vec![head];
@@ -414,14 +408,19 @@ Exp2<T>: Term = {
             }
         };
         let op = Operation{operator: Operator::Or, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
+        Value::Expression(op)
     },
-    <exp3:Exp3<T>> => exp3
 }
 
+Exp2<T>: Term = {
+    <Spanned<OrExp<T>>>,
+    <Exp3<T>>,
+}
+
+
 And = {"and"};
-Exp1<T>: Term = {
-    <start:@L> <head:Exp2<T>> And <mut tail:Exp1<T>> => {
+AndExp<T>: Value = {
+    <head:Exp2<T>> And <mut tail:Exp1<T>> => {
         let args = match &mut tail.value() {
             Value::Expression(Operation{operator: Operator::And, args: tail_args}) => {
                 let mut args = vec![head];
@@ -433,56 +432,72 @@ Exp1<T>: Term = {
             }
         };
         let op = Operation{operator: Operator::And, args};
-        Term::new_from_parser(src_id, start, Value::Expression(op))
+        Value::Expression(op)
     },
-    <exp2:Exp2<T>> => exp2
 }
 
-// All ExpN & Exp productions are macros with one parameter. The parameter is the
-// *string* "Term" or "Pattern" which controls whether the expression is over terms
-// or patterns.  (It is a string since we need to conditionally
-// change the expression precedence allowed in patterns versus terms depending
-// on the parameter type, and LALRPOP does not allow conditional macros on anything
-// other than a string.
-Exp<T>: Term = {
-    <exp1:Exp1<T>> => exp1
+Exp1<T>: Term = {
+    <Spanned<AndExp<T>>>,
+    <Exp2<T>>,
 }
 
-Parameter: Parameter = {
-    <param:Exp6<"Term">> => {
-        Parameter{parameter: Some(param), specializer: None}
-    },
-    // parenthesized specializers do not have symbol translation to class names applied
-    <start:@L> <name:Name> ":" "(" <specializer:Pattern> ")" => {
-        let mut name = Term::new_from_parser(src_id, start, Value::Variable(name));
-        Parameter {
-            parameter: Some(name),
-            specializer: Some(specializer),
-        }
-    },
-    <start:@L> <name:Name> ":" <specializer:Pattern> => {
-        let mut name = Term::new_from_parser(src_id, start, Value::Variable(name));
-        let offset = specializer.offset();
-        if let Value::Variable(class_name) = specializer.value() {
-            let fields = BTreeMap::new();
-            let instance_literal = InstanceLiteral{tag: class_name.clone(), fields: Dictionary{fields}};
-            Parameter {
-                parameter: Some(name),
-                specializer: Some(Term::new_from_parser(src_id, offset, Value::Pattern(Pattern::Instance(instance_literal)))),
-            }
-        } else {
-            Parameter{parameter: Some(name), specializer: Some(specializer)}
+
+pub Pattern: Value = {
+    <Number>,
+    <PolarString>,
+    <Boolean>,
+    <Variable>,
+    <DictionaryPattern>,
+    <InstanceLiteralPattern>,
+    "[" <terms:(<Spanned<Pattern>> ",")*> <term:Spanned<RestVar<"Pattern">>?> "]" => {
+        match term {
+            Some(term) => Value::List(vec![term]),
+            None => Value::List(terms)
         }
     },
 };
 
-pub TermExp: Term = {
-    <Exp<"Term">> => <>
+pub Value: Value = {
+    <Number>,
+    <PolarString>,
+    <Boolean>,
+    <Variable>,
+    <DictionaryTerm>,
+    <BuiltinOperation>,
+    <RewrittenOperation>,
+    <Predicate>,
+    "[" <mut terms:(<Term> ",")*> <term:Spanned<RestVar<"Term">>?> "]" => {
+        match term {
+            Some(term) => {
+                terms.push(term);
+                Value::List(terms)
+            },
+            None => Value::List(terms)
+        }
+    },
+}
+
+
+
+// ****** Terms + Patterns ******* //
+
+// Either a *rest variable, or an ordinary term.
+// TODO(Sam): come back to this one
+RestVar<T>: Value = {
+    "*" <Name> => Value::RestVariable(<>),
+    <Value> if T == "Term",
+    <Pattern> if T == "Pattern",
 };
 
-pub PatternExp: Term = {
-    <Exp9<"Pattern">> => <>
-};
+
+
+Spanned<T>: Term = <start:@L> <value:T> <end:@R> =>  Term::new_from_parser(src_id, start, value);
+
+pub Term = TermExp;
+
+
+
+// ****** Rules + Lines ******* //
 
 ParameterList: Vec<Parameter> = {
     <param:Parameter> => vec![param],
@@ -491,6 +506,34 @@ ParameterList: Vec<Parameter> = {
         list
     },
 };
+
+
+Parameter: Parameter = {
+    <param:Exp6<"Term">> => {
+        Parameter{parameter: Some(param), specializer: None}
+    },
+    // parenthesized specializers do not have symbol translation to class names applied
+    <arg:Spanned<Variable>> ":" "(" <specializer:Spanned<Pattern>> ")" => {
+        Parameter {
+            parameter: Some(arg),
+            specializer: Some(specializer),
+        }
+    },
+    <arg:Spanned<Variable>> ":" <specializer:Spanned<Pattern>> => {
+        let offset = specializer.offset();
+        if let Value::Variable(class_name) = specializer.value() {
+            let fields = BTreeMap::new();
+            let instance_literal = InstanceLiteral{tag: class_name.clone(), fields: Dictionary{fields}};
+            Parameter {
+                parameter: Some(arg),
+                specializer: Some(specializer.clone_with_value(Value::Pattern(Pattern::Instance(instance_literal)))),
+            }
+        } else {
+            Parameter{parameter: Some(arg), specializer: Some(specializer)}
+        }
+    },
+};
+
 
 RuleHead: (Symbol, Vec<Parameter>) = {
     <name:Name> "(" ")" => {
@@ -525,6 +568,7 @@ pub Rule: Rule = {
         Rule{name, params, body}
     }
 }
+
 
 pub Rules: Vec<Rule> = <Rule*>;
 

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -132,7 +132,7 @@ Object<T>: Dictionary = {
     }
 };
 
-// ****** Strange Values ******* //
+// ****** Dicts and literals ******* //
 
 DictionaryTerm: Value = <fields:Object<Exp5<"Term">>> => {
     Value::Dictionary(fields)
@@ -159,6 +159,12 @@ BuiltinOperator: Operator = {
     "print" => Operator::Print,
 };
 
+New: Value = "new" <literal:Spanned<InstanceLiteralTerm>> => {
+    let args = vec![literal];
+    let op = Operation{operator: Operator::New, args};
+    Value::Expression(op)
+};
+
 BuiltinOperation: Value = {
     <op:BuiltinOperator> "(" <mut args:(<TermExp> ",")*> <arg:TermExp?> ")" => {
         match arg {
@@ -166,6 +172,18 @@ BuiltinOperation: Value = {
             None => ()
         };
         Value::Expression(Operation{operator: op, args: args})
+    },
+    // A pattern cannot contain a new operator
+    <New>,
+    "cut" => {
+        let args = vec![];
+        let op = Operation{operator: Operator::Cut, args};
+        Value::Expression(op)
+    },
+    "forall" "(" <arg1:TermExp> "," <arg2:TermExp> ")" => {
+        let args = vec![arg1, arg2];
+        let op = Operation{operator: Operator::ForAll, args};
+        Value::Expression(op)
     },
 };
 
@@ -186,29 +204,6 @@ RewrittenOperation: Value = {
 };
 
 
-New: Value = "new" <literal:Spanned<InstanceLiteralTerm>> => {
-    let args = vec![literal];
-    let op = Operation{operator: Operator::New, args};
-    Value::Expression(op)
-};
-
-SpecialExp<T>: Value = {
-    // A pattern cannot contain a new operator
-    <New> if T == "Term",
-    "cut" => {
-        let args = vec![];
-        let op = Operation{operator: Operator::Cut, args};
-        Value::Expression(op)
-    },
-    "forall" "(" <arg1:TermExp> "," <arg2:TermExp> ")" => {
-        let args = vec![arg1, arg2];
-        let op = Operation{operator: Operator::ForAll, args};
-        Value::Expression(op)
-    },
-}
-
-
-
 // ****** Expressions ******* //
 
 // All ExpN & Exp productions are macros with one parameter. The parameter is the
@@ -219,46 +214,32 @@ SpecialExp<T>: Value = {
 // other than a string.
 
 Exp<T>: Term = {
-    <exp1:Exp1<T>> => exp1
+    <Exp1<T>>
 }
 
 pub TermExp: Term = {
-    <Exp<"Term">> => <>
+    <Exp<"Term">>
 };
 
 pub PatternExp: Term = {
-    <Exp9<"Pattern">> => <>
+    <Exp9<"Pattern">>
 };
 
 
-Exp11<T>: Term = {
+Exp10<T>: Term = {
     <Spanned<Pattern>> if T == "Pattern",
     <Spanned<Value>> if T == "Term",
     "(" <Exp<T>> ")", // "resets" the parsing
 }
 
-Exp10<T>: Term = {
-    <Spanned<SpecialExp<T>>>,
-    <Exp11<T>>,
-}
-
-Callable<T>: Value = {
-    <DictionaryTerm> if T == "Term" => <>,
-    <DictionaryPattern> if T == "Pattern" => <>,
-    <Variable> => <>,
-    <DotOp<T>> => <>,
-    // A pattern cannot contain a new operator.
-    <New> if T == "Term" => <>, // TODO(Sam): should we actually allow this?
-};
-
 CallTerm: Value = {
     <Predicate>,
     <name:Name> => Value::Call(Predicate{name, args: vec![]}),
-    "(" <Variable> ")",
+    "(" <Value> ")",
 }
 
 DotOp<T>: Value = {
-    <head:Spanned<Callable<T>>> "." <call_term:Spanned<CallTerm>> => {
+    <head:Exp9<T>> "." <call_term:Spanned<CallTerm>> => {
         let args = vec![head, call_term];
         let op = Operation{operator: Operator::Dot, args};
         Value::Expression(op)

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -121,34 +121,34 @@ Fields<T>: BTreeMap<Symbol, Term> = {
     }
 };
 
-Object<T>: BTreeMap<Symbol, Term> = {
+Object<T>: Dictionary = {
     "{" <fields:Fields<T>> "}" => {
-        fields
+        Dictionary { fields }
     },
     "{" "}" => {
-        BTreeMap::new()
+        Dictionary {
+            fields: BTreeMap::new()
+        }
     }
 };
 
 // ****** Strange Values ******* //
 
 DictionaryTerm: Value = <fields:Object<Exp5<"Term">>> => {
-    let dict = Dictionary{fields};
-    Value::Dictionary(dict)
+    Value::Dictionary(fields)
 };
 // Pattern dictionaries cannot contain any operators.
 DictionaryPattern: Value = <fields:Object<Exp9<"Pattern">>> => {
-    let dict = Dictionary{fields};
-    Value::Pattern(Pattern::Dictionary(dict))
+    Value::Pattern(Pattern::Dictionary(fields))
 };
 
 InstanceLiteralTerm: Value = <tag:Name> <fields:Object<Exp5<"Term">>> => {
-    let instance = InstanceLiteral{tag, fields: Dictionary{fields}};
+    let instance = InstanceLiteral{tag, fields };
     Value::InstanceLiteral(instance)
 };
 
 InstanceLiteralPattern: Value = <tag:Name> <fields:Object<Exp9<"Pattern">>> => {
-    let instance = InstanceLiteral{tag, fields: Dictionary{fields}};
+    let instance = InstanceLiteral{tag, fields};
     Value::Pattern(Pattern::Instance(instance))
 };
 

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -509,27 +509,27 @@ ParameterList: Vec<Parameter> = {
 
 
 Parameter: Parameter = {
-    <param:Exp6<"Term">> => {
-        Parameter{parameter: Some(param), specializer: None}
+    <parameter:Exp6<"Term">> => {
+        Parameter{parameter, specializer: None}
     },
     // parenthesized specializers do not have symbol translation to class names applied
-    <arg:Spanned<Variable>> ":" "(" <specializer:Spanned<Pattern>> ")" => {
+    <parameter:Spanned<Variable>> ":" "(" <specializer:Spanned<Pattern>> ")" => {
         Parameter {
-            parameter: Some(arg),
+            parameter,
             specializer: Some(specializer),
         }
     },
-    <arg:Spanned<Variable>> ":" <specializer:Spanned<Pattern>> => {
+    <parameter:Spanned<Variable>> ":" <specializer:Spanned<Pattern>> => {
         let offset = specializer.offset();
         if let Value::Variable(class_name) = specializer.value() {
             let fields = BTreeMap::new();
             let instance_literal = InstanceLiteral{tag: class_name.clone(), fields: Dictionary{fields}};
             Parameter {
-                parameter: Some(arg),
+                parameter,
                 specializer: Some(specializer.clone_with_value(Value::Pattern(Pattern::Instance(instance_literal)))),
             }
         } else {
-            Parameter{parameter: Some(arg), specializer: Some(specializer)}
+            Parameter{parameter, specializer: Some(specializer)}
         }
     },
 };

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -122,9 +122,7 @@ impl Polar {
         };
 
         for param in &rule.params {
-            if let Some(mut param) = param.parameter.clone() {
-                param.map_replace(&mut check_term);
-            }
+            param.parameter.clone().map_replace(&mut check_term);
             if let Some(mut spec) = param.specializer.clone() {
                 spec.map_replace(&mut check_term);
             }

--- a/polar-core/src/rewrites.rs
+++ b/polar-core/src/rewrites.rs
@@ -185,7 +185,7 @@ mod tests {
     }
 
     fn parse_rules(src: &str) -> Rules {
-        crate::parser::parse_rules(src).unwrap()
+        crate::parser::parse_rules(0, src).unwrap()
     }
 
     #[test]

--- a/polar-core/src/rewrites.rs
+++ b/polar-core/src/rewrites.rs
@@ -152,10 +152,8 @@ pub fn rewrite_rule(rule: &mut Rule, kb: &mut KnowledgeBase) {
     let mut new_terms = vec![];
 
     for param in &mut rule.params {
-        if let Some(parameter) = &mut param.parameter {
-            let mut rewrites = rewrite_parameter(parameter, kb);
-            new_terms.append(&mut rewrites);
-        }
+        let mut rewrites = rewrite_parameter(&mut param.parameter, kb);
+        new_terms.append(&mut rewrites);
     }
 
     if let Value::Expression(Operation {

--- a/polar-core/src/types.rs
+++ b/polar-core/src/types.rs
@@ -424,6 +424,14 @@ impl Term {
         }
     }
 
+    pub fn span(&self) -> Option<(usize, usize)> {
+        if let SourceInfo::Parser { left, right, .. } = self.source_info {
+            Some((left, right))
+        } else {
+            None
+        }
+    }
+
     /// Get a reference to the underlying data of this term
     pub fn value(&self) -> &Value {
         &self.value
@@ -442,7 +450,7 @@ pub fn unwrap_and(term: Term) -> TermList {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Parameter {
-    pub parameter: Option<Term>,
+    pub parameter: Term,
     pub specializer: Option<Term>,
 }
 
@@ -451,7 +459,7 @@ impl Parameter {
     where
         F: FnMut(&Term) -> Term,
     {
-        self.parameter.iter_mut().for_each(|p| p.map_replace(f));
+        self.parameter.map_replace(f);
         self.specializer.iter_mut().for_each(|p| p.map_replace(f));
     }
 }
@@ -542,6 +550,12 @@ pub enum Node {
 pub struct Trace {
     pub node: Node,
     pub children: Vec<Rc<Trace>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TraceResult {
+    pub trace: Rc<Trace>,
+    pub formatted: String,
 }
 
 #[derive(Default)]
@@ -656,7 +670,7 @@ pub enum QueryEvent {
 
     Result {
         bindings: Bindings,
-        trace: Option<Rc<Trace>>,
+        trace: Option<TraceResult>,
     },
 
     ExternalOp {

--- a/polar-core/src/types.rs
+++ b/polar-core/src/types.rs
@@ -239,8 +239,6 @@ impl Value {
             Value::RestVariable(name) => Ok(name),
             _ => Err(error::RuntimeError::TypeError {
                 msg: format!("Expected symbol, got: {}", self.to_polar()),
-                loc: 0,
-                context: None,     // @TODO
                 stack_trace: None, // @TODO
             }),
         }
@@ -251,8 +249,6 @@ impl Value {
             Value::InstanceLiteral(literal) => Ok(literal),
             _ => Err(error::RuntimeError::TypeError {
                 msg: format!("Expected instance literal, got: {}", self.to_polar()),
-                loc: 0,
-                context: None,     // @TODO
                 stack_trace: None, // @TODO
             }),
         }
@@ -263,8 +259,6 @@ impl Value {
             Value::Expression(op) => Ok(op),
             _ => Err(error::RuntimeError::TypeError {
                 msg: format!("Expected instance literal, got: {}", self.to_polar()),
-                loc: 0,
-                context: None,     // @TODO
                 stack_trace: None, // @TODO
             }),
         }
@@ -275,8 +269,6 @@ impl Value {
             Value::Call(pred) => Ok(pred),
             _ => Err(error::RuntimeError::TypeError {
                 msg: format!("Expected instance literal, got: {}", self.to_polar()),
-                loc: 0,
-                context: None,     // @TODO
                 stack_trace: None, // @TODO
             }),
         }
@@ -291,7 +283,8 @@ enum SourceInfo {
         src_id: u64,
 
         /// Location of the term within the source map
-        offset: usize,
+        left: usize,
+        right: usize,
     },
 
     /// Created as a temporary variable
@@ -339,9 +332,13 @@ impl Term {
     }
 
     /// Creates a new term from the parser
-    pub fn new_from_parser(src_id: u64, offset: usize, value: Value) -> Self {
+    pub fn new_from_parser(src_id: u64, left: usize, right: usize, value: Value) -> Self {
         Self {
-            source_info: SourceInfo::Parser { src_id, offset },
+            source_info: SourceInfo::Parser {
+                src_id,
+                left,
+                right,
+            },
             value: Rc::new(value),
         }
     }
@@ -420,8 +417,8 @@ impl Term {
     }
 
     pub fn offset(&self) -> usize {
-        if let SourceInfo::Parser { offset, .. } = self.source_info {
-            offset
+        if let SourceInfo::Parser { left, .. } = self.source_info {
+            left
         } else {
             0
         }
@@ -724,7 +721,6 @@ mod tests {
             token: "Integer".to_owned(),
             c: 'x',
             loc: 99,
-            context: None,
         };
         let err: crate::error::PolarError = e.into();
         eprintln!("{}", serde_json::to_string(&err).unwrap());

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -12,9 +12,7 @@ use std::iter::FromIterator;
 use std::rc::Rc;
 use std::thread::spawn;
 
-use polar_core::{
-    error::*, formatting::draw, polar::Polar, polar::Query, sym, term, types::*, value,
-};
+use polar_core::{error::*, polar::Polar, polar::Query, sym, term, types::*, value};
 
 type QueryResults = Vec<(HashMap<Symbol, Value>, Option<Rc<Trace>>)>;
 use mock_externals::MockExternal;
@@ -247,15 +245,23 @@ fn test_trace() {
         .unwrap();
     let query = polar.new_query("f(1)", true).unwrap();
     let results = query_results!(query);
-    let trace = draw(results.first().unwrap().1.as_ref().unwrap(), 0);
+    let trace = results[0].1.as_ref().unwrap().draw();
+    println!("{}", trace);
     let expected = r#"f(1) [
-  f(x) if x = 1 and x = 1; [
-    _x_3 = 1 and _x_3 = 1 [
-      _x_3 = 1 [
-      ]
-      _x_3 = 1 [
-      ]
-    ]
+  f(x) if
+    x = 1 and x = 1 [
+      x = 1 []
+      x = 1 []
+  ]
+]
+"#;
+    assert_eq!(trace, expected);
+    let trace = results[1].1.as_ref().unwrap().draw();
+    println!("{}", trace);
+    let expected = r#"f(1) [
+  f(y) if
+    y = 1 [
+      y = 1 []
   ]
 ]
 "#;

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -9,12 +9,11 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::Read;
 use std::iter::FromIterator;
-use std::rc::Rc;
 use std::thread::spawn;
 
 use polar_core::{error::*, polar::Polar, polar::Query, sym, term, types::*, value};
 
-type QueryResults = Vec<(HashMap<Symbol, Value>, Option<Rc<Trace>>)>;
+type QueryResults = Vec<(HashMap<Symbol, Value>, Option<TraceResult>)>;
 use mock_externals::MockExternal;
 
 fn no_results(_: u64, _: Option<Term>, _: Symbol, _: Vec<Term>) -> Option<Term> {
@@ -245,8 +244,7 @@ fn test_trace() {
         .unwrap();
     let query = polar.new_query("f(1)", true).unwrap();
     let results = query_results!(query);
-    let trace = results[0].1.as_ref().unwrap().draw();
-    println!("{}", trace);
+    let trace = results[0].1.as_ref().unwrap();
     let expected = r#"f(1) [
   f(x) if
     x = 1 and x = 1 [
@@ -255,9 +253,8 @@ fn test_trace() {
   ]
 ]
 "#;
-    assert_eq!(trace, expected);
-    let trace = results[1].1.as_ref().unwrap().draw();
-    println!("{}", trace);
+    assert_eq!(trace.formatted, expected);
+    let trace = results[1].1.as_ref().unwrap();
     let expected = r#"f(1) [
   f(y) if
     y = 1 [
@@ -265,7 +262,7 @@ fn test_trace() {
   ]
 ]
 "#;
-    assert_eq!(trace, expected);
+    assert_eq!(trace.formatted, expected);
 }
 
 #[test]


### PR DESCRIPTION
- Main parser refactor work: https://github.com/osohq/oso/commit/2ac5d7002c7302c3aab74f86d23a71482c9e72cf
  adds a macro for constructing `Terms` from `Value`s as a spanned value. Changes many of the parser terms to be just Values.
 The exception is expressions which are mostly built up out of terms.

- Rework how errors are constructed, so errors reliably have some error context on them, and this is used to produce nicer error messages. Cleans up a bunch of the error code. (https://github.com/osohq/oso/commit/6847b365c7999420b255ca815b8a3d7670f1271e)

- Used this work to try out some nicer trace output format. (https://github.com/osohq/oso/commit/29d3e0ca08fcedfede6e6fcf90033fe447e53c70)

Before:

```
  f(x) if x = 1 and x = 1; [
    _x_3 = 1 and _x_3 = 1 [
      _x_3 = 1 [
      ]
      _x_3 = 1 [
      ]
    ]
```

After:

```
f(1) [
  f(x) if
    x = 1 and x = 1 [
      x = 1 []
      x = 1 []
  ]
]
```

Pros/cons:
- Former shows the intermediate values more clearly, instead of many many `x`s
- Latter is a bit easier to read
