### PR TITLE
[poc] Partial Eval

### DIFF
--- a/languages/python/polar/host.py
+++ b/languages/python/polar/host.py
@@ -74,11 +74,11 @@ class Host:
         self.cache_instance(instance, id)
         return instance
 
-    def unify(self, left_instance_id, right_instance_id) -> bool:
+    def unify(self, left, right) -> bool:
         """Return true if the left instance is equal to the right."""
         try:
-            left = self.get_instance(left_instance_id)
-            right = self.get_instance(right_instance_id)
+            left = self.to_python(left)
+            right = self.to_python(right)
             return left == right
         except PolarRuntimeException:
             return False

--- a/languages/python/polar/query.py
+++ b/languages/python/polar/query.py
@@ -136,9 +136,9 @@ class Query:
         external_answer(self.ffi_query, data["call_id"], isa)
 
     def handle_external_unify(self, data):
-        left_instance_id = data["left_instance_id"]
-        right_instance_id = data["right_instance_id"]
-        unify = self.host.unify(left_instance_id, right_instance_id)
+        left = data["left"]
+        right = data["right"]
+        unify = self.host.unify(left, right)
         external_answer(self.ffi_query, data["call_id"], unify)
 
     def handle_external_is_subspecializer(self, data):

--- a/languages/python/tests/parital/test_partial.py
+++ b/languages/python/tests/parital/test_partial.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+import copy
+from typing import Any, List
+from abc import ABCMeta
+
+from polar.test_helpers import *
+from polar.polar import Polar
+
+
+# This metaclass stuff is sad.
+
+@dataclass
+class Expense(metaclass=ABCMeta):
+    name: str
+    amount: int
+
+
+class ExpressionField:
+    def __init__(self, name, expression):
+        self.names = [name]
+        self.expression = expression
+
+    def copy(self):
+        e = ExpressionField(None, None)
+        e.names = self.names
+        e.expression = self.expression
+        return e
+
+    def push(self, name):
+        self.names.append(name)
+
+    def __getattr__(self, name):
+        copy = self.copy()
+        copy.push(name)
+        return copy
+
+    def __eq__(self, other):
+        self.expression.equality(self, other)
+        return True
+
+@dataclass
+class Equality:
+    field_path: List[str]
+    value: Any
+
+    def __str__(self):
+        return f"{field_path.join('.')} == {value}"
+
+class PartialExpression:
+    def __init__(self, cls):
+        self._cls = cls
+        self.expressions = []
+
+    def __getattr__(self, name):
+        return ExpressionField(name, self)
+
+    def equality(self, field, other):
+        self.expressions.append(Equality(field.names, other))
+
+    def __eq__(self, other):
+        self.expressions.append(Equality("self", other))
+
+# HACK in a HACK
+Expense.register(PartialExpression)
+
+def test_partial_works():
+    polar = Polar()
+
+    polar.register_class(Expense)
+    polar.load_str("""
+        allow(actor, "view", expense: Expense) if
+            actor.id = expense.user.id;
+        """)
+
+    expr = PartialExpression(Expense)
+    result = next(polar.query_rule("allow", {'id': '1'}, "view", expr))
+    assert expr.expressions[0].field_path == ['user', 'id']
+    assert expr.expressions[0].value == '1'

--- a/polar-core/src/types.rs
+++ b/polar-core/src/types.rs
@@ -653,8 +653,8 @@ pub enum QueryEvent {
     /// Unifies two external instances.
     ExternalUnify {
         call_id: u64,
-        left_instance_id: u64,
-        right_instance_id: u64,
+        left: Term,
+        right: Term
     },
 
     Result {


### PR DESCRIPTION
This doesn't really work in any sort of generic way whatsoever, but
would be enough for us to do a SQLAlchemy bulk query using a "partially
evaluated" Polar query.  It only works when one variable is unknown, and
is always compared against other known values, not other variables.  It also
most likely only works with one rule right now that doesn't have any choice
points within it.  BUT, I think this covers the expenses policy (and probably
some other simple ones).

Basically the only change on the Polar side is to allow external unify when only
one side of the comparison is an external instance.  Then we collect those
comparisons within Python & use them to partially evalute later (this part is
left as an exercise to the reader).

Not really sure if this is remotely close to how we should do this if we do it.
Something similar to this technique could work... but probably needs to be
implemented within the VM.

```
>>> from test_partial import *
>>> expr = PartialExpression(Expense)
>>> expr.a.b == 2
True
>>> expr.user_id == 3
True
>>> print(expr.expressions)
[Equality(field_path=['a', 'b'], value=2), Equality(field_path=['user_id'], value=3)]
```