### PR TITLE
Make python API the same as the other ones

### DIFF
--- a/languages/python/oso/__init__.py
+++ b/languages/python/oso/__init__.py
@@ -1,4 +1,3 @@
-from polar import polar_class
+from polar import polar_class, Variable, Predicate
 from .oso import Oso, OsoException
 from .extras import Http, PathMapper
-from polar.ffi import Variable, Predicate

--- a/languages/python/polar/__init__.py
+++ b/languages/python/polar/__init__.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
-from .ffi import Predicate, Variable
 from .polar import Polar, polar_class
 from .query import Query, QueryResult
+from .variable import Variable
+from .predicate import Predicate

--- a/languages/python/polar/errors.py
+++ b/languages/python/polar/errors.py
@@ -17,31 +17,22 @@ from .exceptions import (
 )
 
 
-def raise_error():
-    raise get_error()
-
-
-def get_error():
+def get_python_error(err_str):
     """Fetch a Polar error and map it into a Python exception."""
-    try:
-        err_s = lib.polar_get_error()
-        err_json = ffi.string(err_s).decode()
-        err = json.loads(err_json)
+    err = json.loads(err_str)
 
-        kind = [*err["kind"]][0]
-        data = err["kind"][kind]
-        message = err["formatted"]
+    kind = [*err["kind"]][0]
+    data = err["kind"][kind]
+    message = err["formatted"]
 
-        if kind == "Parse":
-            return _parse_error(message, data)
-        elif kind == "Runtime":
-            return PolarRuntimeException(message, data)
-        elif kind == "Operational":
-            return PolarOperationalException(message, data)
-        elif kind == "Parameter":
-            return PolarApiException(message, data)
-    finally:
-        lib.string_free(err_s)
+    if kind == "Parse":
+        return _parse_error(message, data)
+    elif kind == "Runtime":
+        return PolarRuntimeException(message, data)
+    elif kind == "Operational":
+        return PolarOperationalException(message, data)
+    elif kind == "Parameter":
+        return PolarApiException(message, data)
 
 
 def _parse_error(message, data):

--- a/languages/python/polar/ffi.py
+++ b/languages/python/polar/ffi.py
@@ -8,6 +8,95 @@ from .errors import raise_error
 from .exceptions import PolarRuntimeException
 
 
+class Polar:
+    def __init__(self):
+        self.ptr = lib.polar_new()
+
+    def __del__(self):
+        lib.polar_free(self.ptr)
+
+    def new_id(self):
+        """Request a unique ID from the canonical external ID tracker."""
+        return check_result(lib.polar_get_external_id(self.ptr))
+
+    def load_str(self, string, filename):
+        """Load a Polar string, checking that all inline queries succeed."""
+        string = to_c_str(string)
+        filename = to_c_str(str(filename)) if filename else ffi.NULL
+        check_result(lib.polar_load(self.ptr, string, filename))
+
+    def new_query_from_str(self, query_str):
+        return Query(
+            check_result(lib.polar_new_query(self.ptr, to_c_str(query_str), 0))
+        )
+
+    def new_query_from_term(self, query_term):
+        return Query(
+            check_result(
+                lib.polar_new_query_from_term(self.ptr, ffi_serialize(query_term), 0)
+            )
+        )
+
+    def next_inline_query(self):
+        q = lib.polar_next_inline_query(self.ptr, 0)
+        if is_null(q):
+            return None
+        else:
+            return Query(q)
+
+    def register_constant(self, name, value):
+        name = to_c_str(name)
+        value = ffi_serialize(value)
+        check_result(lib.polar_register_constant(self.ptr, name, value))
+
+
+class Query:
+    def __init__(self, ptr):
+        self.ptr = ptr
+
+    def __del__(self):
+        lib.query_free(self.ptr)
+
+    def call_result(self, call_id, value):
+        """Make an external call and propagate FFI errors."""
+        if value is None:
+            value = ffi.NULL
+        else:
+            value = ffi_serialize(value)
+        check_result(lib.polar_call_result(self.ptr, call_id, value))
+
+    def question_result(self, call_id, answer):
+        answer = 1 if answer else 0
+        check_result(lib.polar_question_result(self.ptr, call_id, answer))
+
+    def application_error(self, message):
+        """Pass an error back to polar to get stack trace and other info."""
+        message = to_c_str(message)
+        check_result(lib.polar_application_error(self.ptr, message))
+
+    def next_event(self):
+        return ffi_deserialize(lib.polar_next_query_event(self.ptr))
+
+    def debug_command(self, command):
+        check_result(lib.polar_debug_command(self.ptr, ffi_serialize(command)))
+
+
+class QueryEvent:
+    def __init__(self, ptr):
+        self.ptr = ptr
+
+    def __del__(self):
+        lib.string_free(self.ptr)
+
+
+class Error:
+    def __init__(self, ptr):
+        self.ptr = ptr
+
+    def __del__(self):
+        lib.string_free(self.ptr)
+
+
 def check_result(result):
     if result == 0 or is_null(result):
         raise_error()
@@ -35,32 +124,3 @@ def ffi_deserialize(string):
         if not is_null(string):
             lib.string_free(string)
 
-
-def load_str(polar, string, filename):
-    """Load a Polar string, checking that all inline queries succeed."""
-    string = to_c_str(string)
-    filename = to_c_str(str(filename)) if filename else ffi.NULL
-    check_result(lib.polar_load(polar, string, filename))
-
-
-def new_id(polar):
-    """Request a unique ID from the canonical external ID tracker."""
-    return check_result(lib.polar_get_external_id(polar))
-
-
-def external_call(query, call_id, value):
-    """Make an external call and propagate FFI errors."""
-    if value is None:
-        value = ffi.NULL
-    check_result(lib.polar_call_result(query, call_id, value))
-
-
-def external_answer(query, call_id, answer):
-    answer = 1 if answer else 0
-    check_result(lib.polar_question_result(query, call_id, answer))
-
-
-def application_error(query, message):
-    """Pass an error back to polar to get stack trace and other info."""
-    message = to_c_str(message)
-    check_result(lib.polar_application_error(query, message))

--- a/languages/python/polar/ffi.py
+++ b/languages/python/polar/ffi.py
@@ -3,36 +3,9 @@ from dataclasses import dataclass
 import json
 
 from _polar_lib import ffi, lib
-from typing import Any, Sequence
 
 from .errors import raise_error
 from .exceptions import PolarRuntimeException
-
-
-class Variable(str):
-    """An unbound variable type, can be used to query the KB for information"""
-
-    pass
-
-
-@dataclass(frozen=True)
-class Predicate:
-    """Represent a predicate in Polar (`name(args, ...)`)."""
-
-    name: str
-    args: Sequence[Any]
-
-    def __str__(self):
-        return f'{self.name}({", ".join(self.args)})'
-
-    def __eq__(self, other):
-        if not isinstance(other, Predicate):
-            return False
-        return (
-            self.name == other.name
-            and len(self.args) == len(other.args)
-            and all(x == y for x, y in zip(self.args, other.args))
-        )
 
 
 def check_result(result):

--- a/languages/python/polar/host.py
+++ b/languages/python/polar/host.py
@@ -1,7 +1,9 @@
 """Translate between Polar and the host language (Python)."""
 
 from .exceptions import PolarApiException, PolarRuntimeException
-from .ffi import new_id, Predicate, Variable
+from .ffi import new_id
+from .variable import Variable
+from .predicate import Predicate
 
 
 class Host:

--- a/languages/python/polar/host.py
+++ b/languages/python/polar/host.py
@@ -1,7 +1,6 @@
 """Translate between Polar and the host language (Python)."""
 
 from .exceptions import PolarApiException, PolarRuntimeException
-from .ffi import new_id
 from .variable import Variable
 from .predicate import Predicate
 
@@ -60,7 +59,7 @@ class Host:
     def cache_instance(self, instance, id=None):
         """Cache Python instance under Polar-generated id."""
         if id is None:
-            id = new_id(self.ffi_polar)
+            id = self.ffi_polar.new_id()
         self.instances[id] = instance
         return id
 

--- a/languages/python/polar/polar.py
+++ b/languages/python/polar/polar.py
@@ -8,9 +8,11 @@ from _polar_lib import lib
 
 from .errors import get_error
 from .exceptions import PolarApiException, PolarRuntimeException
-from .ffi import ffi_serialize, load_str, check_result, is_null, to_c_str, Predicate
+from .ffi import ffi_serialize, load_str, check_result, is_null, to_c_str
 from .host import Host
 from .query import Query, QueryResult
+from .predicate import Predicate
+from .variable import Variable
 
 
 CLASSES = {}

--- a/languages/python/polar/polar.py
+++ b/languages/python/polar/polar.py
@@ -6,7 +6,6 @@ from pprint import pprint
 
 from _polar_lib import lib
 
-from .errors import get_error
 from .exceptions import PolarApiException, PolarRuntimeException, ParserException
 from .ffi import Polar as FfiPolar, Query as FfiQuery
 from .host import Host

--- a/languages/python/polar/polar.py
+++ b/languages/python/polar/polar.py
@@ -7,8 +7,8 @@ from pprint import pprint
 from _polar_lib import lib
 
 from .errors import get_error
-from .exceptions import PolarApiException, PolarRuntimeException
-from .ffi import ffi_serialize, load_str, check_result, is_null, to_c_str
+from .exceptions import PolarApiException, PolarRuntimeException, ParserException
+from .ffi import Polar as FfiPolar, Query as FfiQuery
 from .host import Host
 from .query import Query, QueryResult
 from .predicate import Predicate
@@ -23,7 +23,7 @@ class Polar:
     """Polar API"""
 
     def __init__(self, classes=CLASSES, constructors=CONSTRUCTORS):
-        self.ffi_polar = lib.polar_new()
+        self.ffi_polar = FfiPolar()
         self.host = Host(self.ffi_polar)
         self.load_queue = []
 
@@ -43,12 +43,12 @@ class Polar:
 
     def __del__(self):
         del self.host
-        lib.polar_free(self.ffi_polar)
+        del self.ffi_polar
 
     def clear(self):
         self.load_queue = []
-        lib.polar_free(self.ffi_polar)
-        self.ffi_polar = lib.polar_new()
+        del self.ffi_polar
+        self.ffi_polar = FfiPolar()
 
     def load_file(self, policy_file):
         """Load in polar policies. By default, defers loading of knowledge base
@@ -64,12 +64,12 @@ class Polar:
 
     def load_str(self, string):
         """Load a Polar string, checking that all inline queries succeed."""
-        load_str(self.ffi_polar, string, None)
+        self.ffi_polar.load_str(string, None)
 
         # check inline queries
         while True:
-            query = lib.polar_next_inline_query(self.ffi_polar, 0)
-            if is_null(query):  # Load is done
+            query = self.ffi_polar.next_inline_query()
+            if query is None:  # Load is done
                 break
             else:
                 try:
@@ -88,15 +88,9 @@ class Polar:
 
         host = self.host.copy()
         if isinstance(query, str):
-            query = check_result(
-                lib.polar_new_query(self.ffi_polar, to_c_str(query), 0)
-            )
+            query = self.ffi_polar.new_query_from_str(query)
         elif isinstance(query, Predicate):
-            query = check_result(
-                lib.polar_new_query_from_term(
-                    self.ffi_polar, ffi_serialize(host.to_polar_term(query)), 0
-                )
-            )
+            query = self.ffi_polar.new_query_from_term(host.to_polar_term(query))
         else:
             raise PolarApiException(f"Can not query for {query}")
 
@@ -127,9 +121,10 @@ class Polar:
                 query = input("query> ").strip(";")
             except EOFError:
                 return
-            ffi_query = lib.polar_new_query(self.ffi_polar, to_c_str(query), 0)
-            if is_null(ffi_query):
-                print("Parse error: ", get_error())
+            try:
+                ffi_query = self.ffi_polar.new_query_from_str(query)
+            except ParserException as e:
+                print("Parse error: ", str(e.value()))
                 continue
 
             result = False
@@ -154,16 +149,14 @@ class Polar:
 
     def register_constant(self, name, value):
         """Register `value` as a Polar constant variable called `name`."""
-        name = to_c_str(name)
-        value = ffi_serialize(self.host.to_polar_term(value))
-        lib.polar_register_constant(self.ffi_polar, name, value)
+        self.ffi_polar.register_constant(name, self.host.to_polar_term(value))
 
     def _load_queued_files(self):
         """Load queued policy files into the knowledge base."""
         while self.load_queue:
             filename = self.load_queue.pop(0)
             with open(filename) as file:
-                load_str(self.ffi_polar, file.read(), filename)
+                self.ffi_polar.load_str(file.read(), filename)
 
 
 def polar_class(_cls=None, *, name=None, from_polar=None):

--- a/languages/python/polar/predicate.py
+++ b/languages/python/polar/predicate.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+@dataclass(frozen=True)
+class Predicate:
+    """Represent a predicate in Polar (`name(args, ...)`)."""
+
+    name: str
+    args: Sequence[Any]
+
+    def __str__(self):
+        return f'{self.name}({", ".join(self.args)})'
+
+    def __eq__(self, other):
+        if not isinstance(other, Predicate):
+            return False
+        return (
+            self.name == other.name
+            and len(self.args) == len(other.args)
+            and all(x == y for x, y in zip(self.args, other.args))
+        )

--- a/languages/python/polar/query.py
+++ b/languages/python/polar/query.py
@@ -12,11 +12,11 @@ from .ffi import (
     check_result,
     is_null,
     new_id,
-    Predicate,
     to_c_str,
-    Variable,
 )
 from .host import Host
+from .predicate import Predicate
+from .variable import Variable
 
 NATIVE_TYPES = [int, float, bool, str, dict, type(None), list]
 

--- a/languages/python/polar/query.py
+++ b/languages/python/polar/query.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+import json
 
 from _polar_lib import lib
 from .exceptions import PolarApiException
@@ -35,7 +36,8 @@ class Query:
         """Run the event loop and yield results."""
         assert self.ffi_query, "no query to run"
         while True:
-            event = self.ffi_query.next_event()
+            event_str = self.ffi_query.next_event().get()
+            event = json.loads(event_str)
             if event == "Done":
                 break
             kind = [*event][0]

--- a/languages/python/polar/query.py
+++ b/languages/python/polar/query.py
@@ -36,9 +36,10 @@ class Query:
         """Run the event loop and yield results."""
         assert self.ffi_query, "no query to run"
         while True:
-            event_str = self.ffi_query.next_event().get()
-            event = json.loads(event_str)
+            ffi_event = self.ffi_query.next_event()
+            event = json.loads(ffi_event.get())
             if event == "Done":
+                del ffi_event
                 break
             kind = [*event][0]
             data = event[kind]

--- a/languages/python/polar/query.py
+++ b/languages/python/polar/query.py
@@ -2,18 +2,7 @@ from collections.abc import Iterable
 
 from _polar_lib import lib
 from .exceptions import PolarApiException
-from .ffi import (
-    external_answer,
-    external_call,
-    application_error,
-    ffi_deserialize,
-    ffi_serialize,
-    load_str,
-    check_result,
-    is_null,
-    new_id,
-    to_c_str,
-)
+from .ffi import Polar as FfiPolar, Query as FfiQuery
 from .host import Host
 from .predicate import Predicate
 from .variable import Variable
@@ -40,14 +29,13 @@ class Query:
 
     def __del__(self):
         del self.host
-        lib.query_free(self.ffi_query)
+        del self.ffi_query
 
     def run(self):
         """Run the event loop and yield results."""
         assert self.ffi_query, "no query to run"
         while True:
-            event_s = lib.polar_next_query_event(self.ffi_query)
-            event = ffi_deserialize(event_s)
+            event = self.ffi_query.next_event()
             if event == "Done":
                 break
             kind = [*event][0]
@@ -98,8 +86,8 @@ class Query:
             try:
                 attr = getattr(instance, attribute)
             except AttributeError as e:
-                application_error(self.ffi_query, str(e))
-                external_call(self.ffi_query, call_id, None)
+                self.ffi_query.application_error(str(e))
+                self.ffi_query.call_result(call_id, None)
                 return
 
             if callable(attr):  # If it's a function, call it with the args.
@@ -118,37 +106,34 @@ class Query:
         # Return the next result of the call.
         try:
             value = next(self.calls[call_id])
-            stringified = ffi_serialize(self.host.to_polar_term(value))
-            external_call(self.ffi_query, call_id, stringified)
+            self.ffi_query.call_result(call_id, self.host.to_polar_term(value))
         except StopIteration:
-            external_call(self.ffi_query, call_id, None)
+            self.ffi_query.call_result(call_id, None)
 
     def handle_external_op(self, data):
         op = data["operator"]
         args = [self.host.to_python(arg) for arg in data["args"]]
         answer = self.host.operator(op, args)
-        external_answer(self.ffi_query, data["call_id"], answer)
+        self.ffi_query.question_result(data["call_id"], answer)
 
     def handle_external_isa(self, data):
         instance = data["instance"]
         class_tag = data["class_tag"]
-        isa = self.host.isa(instance, class_tag)
-        external_answer(self.ffi_query, data["call_id"], isa)
+        answer = self.host.isa(instance, class_tag)
+        self.ffi_query.question_result(data["call_id"], answer)
 
     def handle_external_unify(self, data):
         left_instance_id = data["left_instance_id"]
         right_instance_id = data["right_instance_id"]
-        unify = self.host.unify(left_instance_id, right_instance_id)
-        external_answer(self.ffi_query, data["call_id"], unify)
+        answer = self.host.unify(left_instance_id, right_instance_id)
+        self.ffi_query.question_result(data["call_id"], answer)
 
     def handle_external_is_subspecializer(self, data):
         instance_id = data["instance_id"]
         left_tag = data["left_class_tag"]
         right_tag = data["right_class_tag"]
-        is_subspecializer = self.host.is_subspecializer(
-            instance_id, left_tag, right_tag
-        )
-        external_answer(self.ffi_query, data["call_id"], is_subspecializer)
+        answer = self.host.is_subspecializer(instance_id, left_tag, right_tag)
+        self.ffi_query.question_result(data["call_id"], answer)
 
     def handle_debug(self, data):
         if data["message"]:
@@ -157,5 +142,4 @@ class Query:
             command = input("debug> ").strip(";")
         except EOFError:
             command = "continue"
-        stringified = ffi_serialize(self.host.to_polar_term(command))
-        check_result(lib.polar_debug_command(self.ffi_query, stringified))
+        self.ffi_query.debug_command(self.host.to_polar_term(command))

--- a/languages/python/polar/query.py
+++ b/languages/python/polar/query.py
@@ -38,8 +38,8 @@ class Query:
         while True:
             ffi_event = self.ffi_query.next_event()
             event = json.loads(ffi_event.get())
+            del ffi_event
             if event == "Done":
-                del ffi_event
                 break
             kind = [*event][0]
             data = event[kind]

--- a/languages/python/polar/variable.py
+++ b/languages/python/polar/variable.py
@@ -1,0 +1,4 @@
+class Variable(str):
+    """An unbound variable type, can be used to query the KB for information"""
+
+    pass

--- a/languages/python/tests/parity/test_api.py
+++ b/languages/python/tests/parity/test_api.py
@@ -4,10 +4,9 @@ import pytest
 
 from pathlib import Path
 
-from polar import Polar
+from polar import Polar, Predicate
 from polar.exceptions import PolarRuntimeException, PolarApiException
 from oso import Http, PathMapper
-from polar.ffi import Predicate
 
 from test_api_externals import Widget, DooDad, Actor, Company, get_frobbed, set_frobbed
 


### PR DESCRIPTION
Updates to the FFI API. Split FFI functions among appropriate classes (`Polar`, `Query`, `QueryEvent`, `Error`). Upshot is that now the FFI `lib` functions only get called from `ffi.py`
