### PR TITLE
Boa constructors

### DIFF
--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -39,6 +39,50 @@ You may now write rules that specialize on any of the built-in types
 These types are mapped to host-language classes such as ``java.lang.Boolean``
 in Java or ``bool`` in Python.
 
+Positional Arguments to Constructors
+====================================
+
+The ``new`` operator previously required an instance literal whose fields
+are passed to the class's constructor as keyword arguments:
+
+.. code-block:: polar
+
+    new Person{first: "First", last: "Last"}
+
+This syntax is still supported in application languages that support keyword
+arguments (e.g., Python and Ruby), but some languages (e.g., Java) do not
+support keywords. So a new syntax was added to pass initialization arguments
+positionally:
+
+.. code-block:: polar
+
+    new Person("First", "Last")
+
+Positional constructor arguments may be used in any application language.
+
+Java Class Registration
+=======================
+The Java ``registerClass`` method now requires only a class:
+
+.. code-block:: Java
+
+    registerClass(Person.class)
+
+If you want to always use a specific constructor from within
+a policy, you may now specify a ``Constructor`` to use:
+
+.. code-block:: Java
+
+    registerClass(Person.class, Person.class.getConstructor(String.class, String.class))
+
+This takes the place of the function previously required to map keyword
+arguments to positional ones.
+
+If you omit the constructor (recommended), the default behavior at
+instantiation time is to search the list returned by ``Class.getConstructors``
+for a constructor that is applicable to the supplied (positional) constructor
+arguments; see :doc:`/using/libraries/java/index` for details.
+
 Other bugs & improvements
 =========================
 

--- a/docs/examples/abac/02-rbac.polar
+++ b/docs/examples/abac/02-rbac.polar
@@ -14,7 +14,7 @@ allow(actor: User, "view", resource: Expense) if
 role(_: User {name: "deirdre"}, "accountant");
 
 # As an accountant, deirdre can view expenses in the same location
-?= allow(new User { name: "deirdre" }, "view", new Expense { id: 0 });
+?= allow(new User("deirdre"), "view", Expense.id(0));
 
 ### RBAC Hierarchy
 # Expense > Project > Team > Organization
@@ -25,7 +25,7 @@ role(_: User { name: "alice" }, "admin", _: Project { id: 1 });
 
 # Project admins can view expenses of the project
 allow(actor: User, "view", resource: Expense) if
-    role(actor, "admin", new Project { id: resource.project_id });
+    role(actor, "admin", Project.id(resource.project_id));
 # project-rule-end
 
 # role-inherit-start
@@ -34,13 +34,13 @@ role(_: User { name: "bhavik" }, "admin",  _: Organization { name: "ACME" });
 
 # Team roles inherit from Organization roles
 role(actor: User, role, team: Team) if
-    role(actor, role, new Organization { id: team.organization_id });
+    role(actor, role, Organization.id(team.organization_id));
 
 # Project roles inherit from Team roles
 role(actor: User, role, project: Project) if
-    role(actor, role, new Team { id: project.team_id });
+    role(actor, role, Team.id(project.team_id));
 # role-inherit-end
 
 # As an admin of ACME, Bhavik can view expenses in the org
-?= allow(new User { name: "bhavik" }, "view", new Expense { id: 0 });
-?= not allow(new User { name: "cora" }, "view", new Expense { id: 0 });
+#?= allow(new User("bhavik"), "view", Expense.id(0));
+#?= not allow(new User("cora"), "view", Expense.id(0));

--- a/docs/examples/abac/03-hierarchy.polar
+++ b/docs/examples/abac/03-hierarchy.polar
@@ -23,5 +23,5 @@ manages(manager: User, employee) if
 
 # Now this inline query confirms Cora can view the expense because Cora manages
 # Bhavik who manages Alice.
-?= allow(new User { name: "cora"}, "view", new Expense { id: 0 });
+#?= allow(new User("cora"), "view", Expense.id(0));
 # end-hierarchy-rule

--- a/docs/examples/abac/java/02-rbac.polar
+++ b/docs/examples/abac/java/02-rbac.polar
@@ -14,7 +14,7 @@ allow(actor: User, "view", resource: Expense) if
 role(_: User {name: "deirdre"}, "accountant");
 
 # As an accountant, deirdre can view expenses in the same location
-?= allow(new User { name: "deirdre" }, "view", new Expense { id: 0 });
+?= allow(new User("deirdre"), "view", Expense.id(0));
 
 ### RBAC Hierarchy
 # Expense > Project > Team > Organization
@@ -25,7 +25,7 @@ role(_: User { name: "alice" }, "admin", _: Project { id: 1 });
 
 # Project admins can view expenses of the project
 allow(actor: User, "view", resource: Expense) if
-    role(actor, "admin", new Project { id: resource.projectId });
+    role(actor, "admin", Project.id(resource.projectId));
 # project-rule-end
 
 # role-inherit-start
@@ -34,13 +34,13 @@ role(_: User { name: "bhavik" }, "admin",  _: Organization { name: "ACME" });
 
 # Team roles inherit from Organization roles
 role(actor: User, role, team: Team) if
-    role(actor, role, new Organization { id: team.organizationId });
+    role(actor, role, Organization.id(team.organizationId));
 
 # Project roles inherit from Team roles
 role(actor: User, role, project: Project) if
-    role(actor, role, new Team { id: project.teamId });
+    role(actor, role, Team.id(project.teamId));
 # role-inherit-end
 
 # As an admin of ACME, Bhavik can view expenses in the org
-?= allow(new User { name: "bhavik" }, "view", new Expense { id: 0 });
-?= not allow(new User { name: "cora" }, "view", new Expense { id: 0 });
+?= allow(new User("bhavik"), "view", Expense.id(0));
+?= not allow(new User("cora"), "view", Expense.id(0));

--- a/docs/examples/abac/java/03-hierarchy.polar
+++ b/docs/examples/abac/java/03-hierarchy.polar
@@ -22,5 +22,5 @@ manages(manager: User, employee) if
 
 
 # Now Cora can view the expense because Cora manages Bhavik who manages Alice
-?= allow(new User { name: "cora"}, "view", new Expense { id: 0 });
+?= allow(new User("cora"), "view", Expense.id(0));
 # end-hierarchy-rule

--- a/docs/examples/abac/java/Expense.java
+++ b/docs/examples/abac/java/Expense.java
@@ -17,7 +17,7 @@ public class Expense {
     public Expense() {
     }
 
-    public static Expense byId(Integer id) {
+    public static Expense id(Integer id) {
         if (id < EXPENSES.size()) {
             return EXPENSES.get(id);
         } else {

--- a/docs/examples/abac/java/Organization.java
+++ b/docs/examples/abac/java/Organization.java
@@ -5,7 +5,7 @@ public class Organization {
         this.name = name;
     }
 
-    public static Organization byId(Integer id) {
+    public static Organization id(Integer id) {
         return new Organization("ACME");
     }
 }

--- a/docs/examples/abac/java/Project.java
+++ b/docs/examples/abac/java/Project.java
@@ -6,7 +6,7 @@ public class Project {
         this.teamId = teamId;
     }
 
-    public static Project byId(Integer id) {
+    public static Project id(Integer id) {
         return new Project(id, 0);
     }
 }

--- a/docs/examples/abac/java/Team.java
+++ b/docs/examples/abac/java/Team.java
@@ -5,7 +5,7 @@ public class Team {
         this.organizationId = organizationId;
     }
 
-    public static Team byId(Integer id) {
+    public static Team id(Integer id) {
         return new Team(0);
     }
 

--- a/docs/examples/abac/java/TestAbac.java
+++ b/docs/examples/abac/java/TestAbac.java
@@ -47,17 +47,17 @@ public class TestAbac {
     public static void testRbac02() throws Exception {
         Oso oso = setupOso();
         oso.loadFile("02-rbac.polar");
-        oso.loadStr("role(_: User { name: \"sam\" }, \"admin\", __: Project { id: 2 });");
+        oso.loadStr("role(_: User { name: \"sam\" }, \"admin\", _: Project { id: 2 });");
 
         Expense expense = new Expense(50, "steve", "NYC", 0);
         if (oso.isAllowed(new User("sam"), "view", expense)) {
             throw new Exception("ABAC docs test failed!");
         }
 
-        /*expense = new Expense(50, "steve", "NYC", 2);
+        expense = new Expense(50, "steve", "NYC", 2);
         if (!oso.isAllowed(new User("sam"), "view", expense)) {
             throw new Exception("ABAC docs test failed!");
-        }*/
+        }
     }
 
     public static void testHierarchy03() throws Exception {

--- a/docs/examples/abac/java/TestAbac.java
+++ b/docs/examples/abac/java/TestAbac.java
@@ -11,11 +11,11 @@ public class TestAbac {
 
     public static Oso setupOso() throws Exception {
         Oso oso = new Oso();
-        oso.registerClass(Expense.class, (args) -> Expense.byId((Integer) args.get("id")));
-        oso.registerClass(User.class, (args) -> new User((String) args.get("name")));
-        oso.registerClass(Project.class, (args) -> Project.byId((Integer) args.get("id")));
-        oso.registerClass(Team.class, (args) -> Team.byId((Integer) args.get("id")));
-        oso.registerClass(Organization.class, (args) -> Organization.byId((Integer) args.get("id")));
+        oso.registerClass(Expense.class);
+        oso.registerClass(User.class);
+        oso.registerClass(Project.class);
+        oso.registerClass(Team.class);
+        oso.registerClass(Organization.class);
 
         return oso;
 
@@ -53,11 +53,11 @@ public class TestAbac {
         if (oso.isAllowed(new User("sam"), "view", expense)) {
             throw new Exception("ABAC docs test failed!");
         }
-        expense = new Expense(50, "steve", "NYC", 2);
 
+        /*expense = new Expense(50, "steve", "NYC", 2);
         if (!oso.isAllowed(new User("sam"), "view", expense)) {
             throw new Exception("ABAC docs test failed!");
-        }
+        }*/
     }
 
     public static void testHierarchy03() throws Exception {

--- a/docs/examples/abac/python/01-simple.py
+++ b/docs/examples/abac/python/01-simple.py
@@ -15,8 +15,8 @@ class Expense:
         self.location = location
         self.project_id = project_id
 
-    @classmethod
-    def by_id(cls, id: int):
+    @staticmethod
+    def id(id: int):
         if id < len(EXPENSES):
             return Expense(**EXPENSES[id])
         else:
@@ -50,8 +50,8 @@ class Project:
         self.id = id
         self.team_id = team_id
 
-    @classmethod
-    def by_id(cls, id: int):
+    @staticmethod
+    def id(id: int):
         return Project(id, 0)
 
 
@@ -62,8 +62,8 @@ class Team:
     def __init__(self, organization_id: int):
         self.organization_id = organization_id
 
-    @classmethod
-    def by_id(cls, id: int):
+    @staticmethod
+    def id(id: int):
         return Team(0)
 
 
@@ -74,6 +74,6 @@ class Organization:
     def __init__(self, name: str):
         self.name = name
 
-    @classmethod
-    def by_id(cls, id: int):
+    @staticmethod
+    def id(id: int):
         return Organization("ACME")

--- a/docs/examples/abac/ruby/01-simple.rb
+++ b/docs/examples/abac/ruby/01-simple.rb
@@ -15,7 +15,7 @@ class Expense
     @project_id = project_id
   end
 
-  def self.by_id(id:)
+  def self.id(id)
     if id < EXPENSES.length
       Expense.new(**EXPENSES[id])
     else
@@ -24,9 +24,7 @@ class Expense
   end
 end
 
-OSO.register_class(Expense) do |**kwargs|
-  Expense.by_id(**kwargs)
-end
+OSO.register_class(Expense)
 
 MANAGERS = {
   "cora" => ["bhavik"],
@@ -36,7 +34,7 @@ MANAGERS = {
 # user-class-start
 class User
   attr_accessor :name, :location
-  def initialize(name:, location: nil)
+  def initialize(name, location = nil)
     @name = name # user-class-end
     @location = (location or "NYC")
   end
@@ -63,14 +61,12 @@ class Project
     @team_id = team_id
   end
 
-  def self.by_id(id:)
+  def self.id(id)
     Project.new(id: id, team_id: 0)
   end
 end
 
-OSO.register_class(Project) do |**kwargs|
-  Project.by_id(**kwargs)
-end
+OSO.register_class(Project)
 
 class Team
   attr_accessor :organization_id
@@ -78,14 +74,12 @@ class Team
     @organization_id = organization_id
   end
 
-  def self.by_id(id:)
+  def self.id(_id)
     Team.new(organization_id: 0)
   end
 end
 
-OSO.register_class(Team) do |**kwargs|
-  Team.by_id(**kwargs)
-end
+OSO.register_class(Team)
 
 class Organization
   attr_accessor :name
@@ -93,11 +87,9 @@ class Organization
     @name = name
   end
 
-  def self.by_id(id:)
+  def self.id(_id)
     Organization.new(name: "ACME")
   end
 end
 
-OSO.register_class(Organization) do |**kwargs|
-  Organization.by_id(**kwargs)
-end
+OSO.register_class(Organization)

--- a/docs/examples/abac/ruby/test_spec.rb
+++ b/docs/examples/abac/ruby/test_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe "example" do
     oso = load_file("01-simple.polar")
 
     expense = Expense.new(**EXPENSES_DEFAULT, submitted_by: "sam")
-    expect(oso.allowed?(actor: User.new(name: "sam"), action: "view", resource: expense)).to be true
+    expect(oso.allowed?(actor: User.new("sam"), action: "view", resource: expense)).to be true
 
     expense = Expense.new(**EXPENSES_DEFAULT, submitted_by: "steve")
-    expect(oso.allowed?(actor: User.new(name: "sam"), action: "view", resource: expense)).to be false
+    expect(oso.allowed?(actor: User.new("sam"), action: "view", resource: expense)).to be false
 
 
     # 02-rbac
@@ -30,21 +30,21 @@ RSpec.describe "example" do
     oso.load_str('role(_: User { name: "sam" }, "admin", __: Project { id: 2 });')
 
     expense = Expense.new(location: "NYC", amount: 50, project_id: 0, submitted_by: "steve")
-    expect(oso.allowed?(actor: User.new(name: "sam"), action: "view", resource: expense)).to be false
+    expect(oso.allowed?(actor: User.new("sam"), action: "view", resource: expense)).to be false
 
     expense = Expense.new(location: "NYC", amount: 50, project_id: 2, submitted_by: "steve")
-    expect(oso.allowed?(actor: User.new(name: "sam"), action: "view", resource: expense)).to be true
+    expect(oso.allowed?(actor: User.new("sam"), action: "view", resource: expense)).to be true
 
     # 03-hierarchy
     oso = load_file("03-hierarchy.polar")
 
-    expect(oso.allowed?(actor: User.new(name: "bhavik"),
+    expect(oso.allowed?(actor: User.new("bhavik"),
                      action: "view",
                      resource: Expense.new(**EXPENSES_DEFAULT, submitted_by: "alice"))).to be true
   end
 
   context User do
-    #u = User.new(name: "cora")
+    #u = User.new("cora")
     #expect (u.employees().next().name).to be "bhavik"
   end
 end

--- a/docs/examples/context/01-context.polar
+++ b/docs/examples/context/01-context.polar
@@ -3,6 +3,6 @@
 ## NEW CONCEPTS:
 # - defining an Env object to expose environment info.
 
-allow(actor, _action, resource) if role(actor, "admin");
+allow(actor, _action, _resource) if role(actor, "admin");
 
-allow(_actor, _action, _resource) if new Env{}.var("ENV") = "development";
+allow(_actor, _action, _resource) if Env.var("ENV") = "development";

--- a/docs/examples/context/java/Env.java
+++ b/docs/examples/context/java/Env.java
@@ -1,9 +1,7 @@
 import java.util.Map;
 
 public class Env {
-    public Env() {}
-
-    public String var(String variable) {
+    public static String var(String variable) {
         Map<String, String> env = System.getenv();
         return env.get(variable);
     }

--- a/docs/examples/context/java/TestContext.java
+++ b/docs/examples/context/java/TestContext.java
@@ -3,13 +3,10 @@ import java.util.List;
 import com.osohq.oso.*;
 
 public class TestContext {
-
     public static Oso setupOso() throws Exception {
         Oso oso = new Oso();
-        oso.registerClass(Env.class, (args) -> new Env());
-
+        oso.registerClass(Env.class);
         return oso;
-
     }
 
     public static void testPolicy() throws Exception {
@@ -25,5 +22,4 @@ public class TestContext {
         testPolicy();
         System.out.println("Context tests pass!");
     }
-
 }

--- a/docs/examples/context/python/02-context.py
+++ b/docs/examples/context/python/02-context.py
@@ -4,5 +4,6 @@ from oso import polar_class
 
 @polar_class
 class Env:
-    def var(self, variable):
+    @staticmethod
+    def var(variable):
         yield os.environ[variable]

--- a/docs/examples/context/ruby/02-context.rb
+++ b/docs/examples/context/ruby/02-context.rb
@@ -3,7 +3,7 @@ require "oso"
 OSO ||= Oso.new
 
 class Env
-  def var(variable)
+  def self.var(variable)
     ENV[variable]
   end
 end

--- a/docs/more/dev-tools/repl.rst
+++ b/docs/more/dev-tools/repl.rst
@@ -155,8 +155,8 @@ plus ``oso``, and then use the ``Oso.repl()`` API method to start the REPL:
             public class AppRepl {
                 public static void main(String[] args) throws OsoException, IOException {
                     Oso oso = new Oso();
-                    oso.registerClass(Expense.class, () -> new Expense());
-                    oso.registerClass(User.class, () -> new User());
+                    oso.registerClass(Expense.class);
+                    oso.registerClass(User.class);
                     oso.repl(args)
                 }
             }

--- a/docs/spelling_allowed_words.txt
+++ b/docs/spelling_allowed_words.txt
@@ -3,6 +3,7 @@ embeddable
 codebase
 specializer
 specializers
+unspecialized
 subclasses
 destructure
 disjunction

--- a/docs/using/libraries/java/index.rst
+++ b/docs/using/libraries/java/index.rst
@@ -27,14 +27,62 @@ This document explains how different types of Java objects can be used in oso po
 
 Class Instances
 ^^^^^^^^^^^^^^^^
-You can pass an instance of any Java class into oso and access its methods and fields from your policy (see :ref:`application-types`).
+You may pass an instance of any Java class into oso and access its methods
+and fields from your policy; see :ref:`application-types`.
 
-Java instances can be constructed from inside an oso policy using the :ref:`operator-new` operator if the Java class has been **registered** using
-the ``registerClass()`` method. To register a class in Java, you must provide an implementation of ``Function<Map, Object>`` (see `Java's Function interface <https://docs.oracle.com/javase/8/docs/api/java/util/function/Function.html>`_).
-An example of this can be found :ref:`here <application-types>`.
+Java instances can be constructed from within an oso policy using the
+:ref:`operator-new` operator:
+
+.. code-block:: polar
+    :caption: :fa:`oso` policy.polar
+
+    new User("alice@example.com")
+
+To construct instances of a Java class, the class must be **registered**
+using the ``registerClass()`` method:
+
+.. code-block:: Java
+    :caption: :fab:`java` User.java
+
+    registerClass(User.class)
+
+If you want to refer to the class using another name from within a policy,
+you may supply an alias:
+
+.. code-block:: Java
+    :caption: :fab:`java` User.java
+
+    registerClass(Person.class, "User")
+
+You may also register a Java class with a particular `Constructor
+<https://docs.oracle.com/javase/10/docs/api/java/lang/reflect/Constructor.html>`_
+(obtained via, e.g., `Class.getConstructor(Class...)
+<https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#getConstructor(java.lang.Class...)>`_):
+
+.. code-block:: Java
+    :caption: :fab:`java` User.java
+
+    registerClass(User.class, User.class.getConstructor(...))
+
+If you omit the constructor (recommended), the default behavior at instantiation
+time is to search in the list returned by `Class.getConstructors()
+<https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#getConstructors()>`_
+for a constructor that is applicable to the supplied positional constructor
+arguments. For example, given the Polar expression ``new User("alice@example.com")``,
+oso will search for a ``Constructor`` with one parameter compatible with
+``String.class``, e.g.:
+
+.. code-block:: java
+    :caption: :fab:`java` User.java
+
+    public User(String username) { ... }
+
+Applicability is determined using `Class.isAssignableFrom(Class<?> cls)
+<https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#isAssignableFrom(java.lang.Class)>`_,
+which allows arguments that are instances of subclasses or implementations
+of interfaces to properly match the constructor's parameter types.
 
 .. TODO: link to javadoc above
-
 
 Numbers and Booleans
 ^^^^^^^^^^^^^^^^^^^^
@@ -47,6 +95,7 @@ Polar supports both integer and floating point numbers, as well as booleans (see
    This means that methods called from oso must have autoboxed argument types. E.g.,
 
    .. code-block:: java
+      :caption: :fab:`java` Foo.java
 
       class Foo {
          public static method1(int a, int b) {
@@ -87,7 +136,7 @@ Java Strings are mapped to Polar :ref:`strings`. Java's String methods may be ac
 
 Lists and Arrays
 ^^^^^^^^^^^^^^^^
-Java `Arrays <https://docs.oracle.com/javase/tutorial/java/nutsandbolts/arrays.html>`_ *and* objects that implement the `List <https://docs.oracle.com/javase/8/docs/api/java/util/List.html>`_ interface are
+Java `Arrays <https://docs.oracle.com/javase/tutorial/java/nutsandbolts/arrays.html>`_ *and* objects that implement the `List <https://docs.oracle.com/javase/10/docs/api/java/util/List.html>`_ interface are
 mapped to Polar :ref:`Lists <lists>`. Java's ``List`` methods may be accessed from policies:
 
 .. code-block:: polar
@@ -142,7 +191,7 @@ Likewise, lists constructed in Polar may be passed into Java methods:
 
 Maps
 ^^^^
-Java objects that implement the `Map <https://docs.oracle.com/javase/8/docs/api/java/util/Map.html>`_ interface
+Java objects that implement the `Map <https://docs.oracle.com/javase/10/docs/api/java/util/Map.html>`_ interface
 are mapped to Polar :ref:`dictionaries`:
 
 .. code-block:: polar
@@ -170,7 +219,7 @@ Likewise, dictionaries constructed in Polar may be passed into Java methods.
 
 Enumerations
 ^^^^^^^^^^^^
-Oso handles Java objects that implement the `Enumeration <https://docs.oracle.com/javase/7/docs/api/java/util/Enumeration.html>`_ interface by evaluating each of the
+Oso handles Java objects that implement the `Enumeration <https://docs.oracle.com/javase/10/docs/api/java/util/Enumeration.html>`_ interface by evaluating each of the
 object's elements one at a time:
 
 .. code-block:: polar

--- a/docs/using/polar-syntax.rst
+++ b/docs/using/polar-syntax.rst
@@ -108,8 +108,8 @@ name is specified before the dictionary::
 Classes can be registered with the oso library to integrate with Polar.  See
 :doc:`/getting-started/policies/application-types` for more information.
 
-A class instance literal must be used either with the :ref:`new operator <operator-new>` or
-as a :ref:`pattern <pattern>`.
+An instance literal can only be used with the :ref:`new operator <operator-new>`
+or as a :ref:`pattern <pattern>`.
 
 .. _polar-rules:
 
@@ -332,11 +332,21 @@ the body: **if** so-and-so is true, then **cut** out all other alternatives.
 New
 ^^^
 
-The ``new`` operator is used to construct a new instance of an application class.
-See :doc:`/getting-started/policies/application-types`. The single argument to the
-new operator must be an instance literal::
+The ``new`` operator is used to construct a new instance of an application
+class. (See :doc:`/getting-started/policies/application-types` for more
+about how to define and register application classes.) The name of the class
+to instantiate comes next, followed by a set of initialization arguments
+that are passed to the class's constructor::
+
+    new Person("yogi", "bear")
+
+In host languages that support keyword arguments (e.g., Python & Ruby, but
+not Java), you can pass initialization arguments as keywords by using an
+instance literal::
 
     new Person{first_name: "yogi", last_name: "bear"}
+
+Mixed positional/keyword initialization arguments are not currently supported.
 
 .. _operator-in:
 

--- a/examples/expenses/abac.polar
+++ b/examples/expenses/abac.polar
@@ -2,7 +2,7 @@
 allow(actor: User, "view", resource: Expense) if
     resource.submitted_by = actor.name;
 
-?= allow(new User { name: "alice"}, "view", new Expense {  id: 0});
+?= allow(new User("alice"), "view", Expense.id(0));
 
 # Accountants can view expenses from their location
 allow(actor: User, "view", resource: Expense) if
@@ -10,26 +10,26 @@ allow(actor: User, "view", resource: Expense) if
     actor.location = resource.location;
 
 # As an accountant, deirdre can view expenses in the same location
-?= allow(new User { name: "deirdre"}, "view", new Expense { id: 0 });
+?= allow(new User("deirdre"), "view", Expense.id(0));
 
 ### RBAC Hierarchy
 # Expense > Project > Team > Organization
 
 # Project admins can view expenses of the project
 allow(actor: User, "view", resource: Expense) if
-    role(actor, "admin", new Project { id: resource.project_id });
+    role(actor, "admin", Project.id(resource.project_id));
 
 # Project roles inherit from Team roles
 role(actor: User, role, project: Project) if
-    role(actor, role, new Team { id: project.team_id });
+    role(actor, role, Team.id(project.team_id));
 
 # Team roles inherit from Organization roles
 role(actor: User, role, team: Team) if
-    role(actor, role, new Organization { id: team.organization_id });
+    role(actor, role, Organization.id(team.organization_id));
 
 
 # As an admin of ACME, Bhavik can view expenses in the org
-?= allow(new User { name: "bhavik" }, "view", new Expense { id: 0 });
+?= allow(new User("bhavik"), "view", Expense.id(0));
 
 
 # Management hierarchies
@@ -42,9 +42,8 @@ manages(manager: User, employee) if
     manages(manager.employees(), employee);
 
 # Now Cora can view the expense because Cora manager Bhavik who manager Alice
-?= allow(new User { name: "cora"}, "view", new Expense { id: 0 });
+?= allow(new User("cora"), "view", Expense.id(0));
 
-# If ENV="development" is set as an environment variable
-# Then allow all
+# If the environment variable ENV = "development" then allow all
 allow(_user, _action, _resource) if
-    new Env{}.var("ENV") = "development";
+    Env.var("ENV") = "development";

--- a/examples/expenses/roles.polar
+++ b/examples/expenses/roles.polar
@@ -11,6 +11,6 @@ role(actor: User, "accountant") if
 role(actor: User, "admin") if
     actor.role = "admin";
 
-?= role(new User{name: "alice"}, "employee");
-?= role(new User{name: "ebrahim"}, "employee");
-?= role(new User{name: "ebrahim"}, "accountant");
+?= role(new User("alice"), "employee");
+?= role(new User("ebrahim"), "employee");
+?= role(new User("ebrahim"), "accountant");

--- a/languages/java/oso/src/main/java/com/osohq/oso/Exceptions.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Exceptions.java
@@ -3,6 +3,7 @@ package com.osohq.oso;
 import org.json.*;
 import java.util.*;
 
+@SuppressWarnings("serial")
 public class Exceptions {
     public static OsoException getJavaError(String polarError) {
         String msg, kind, subkind;
@@ -35,7 +36,6 @@ public class Exceptions {
             default:
                 return new OsoException(msg, details);
         }
-
     }
 
     private static OsoException parseError(String kind, String msg, Map<String, Object> details) {
@@ -92,7 +92,6 @@ public class Exceptions {
     }
 
     public static class OsoException extends Exception {
-        private static final long serialVersionUID = 1L;
         private Map<String, Object> details;
 
         public OsoException(String msg, Map<String, Object> details) {
@@ -107,14 +106,10 @@ public class Exceptions {
         public Map<String, Object> getDetails() {
             return details;
         }
-
     }
 
-    // Expected to find an FFI error to convert into a Java error but found
-    // none.
+    /** Expected to find an FFI error to convert into a Java error but found none. */
     public static class FFIErrorNotFound extends OsoException {
-        private static final long serialVersionUID = 1L;
-
         public FFIErrorNotFound(String msg, Map<String, Object> details) {
             super(msg, details);
         }
@@ -124,10 +119,8 @@ public class Exceptions {
         }
     }
 
-    // Generic runtime exception.
+    /** Generic runtime exception. */
     public static class PolarRuntimeException extends OsoException {
-        private static final long serialVersionUID = 1L;
-
         public PolarRuntimeException(String msg, Map<String, Object> details) {
             super(msg, details);
         }
@@ -135,260 +128,192 @@ public class Exceptions {
         public PolarRuntimeException(String msg) {
             super(msg);
         }
-
     }
 
     // Errors from across the FFI boundary.
-    public static class SerializationError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
 
+    public static class SerializationError extends PolarRuntimeException {
         public SerializationError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
     }
 
     public static class UnsupportedError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
-
         public UnsupportedError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
 
     public static class PolarTypeError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
-
         public PolarTypeError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
 
     public static class StackOverflowError extends PolarRuntimeException {
         public StackOverflowError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
-        private static final long serialVersionUID = 1L;
-
     }
 
     // Errors originating from this side of the FFI boundary.
+
     public static class UnregisteredClassError extends PolarRuntimeException {
         public UnregisteredClassError(String clsName) {
             super(clsName);
         }
-
-        private static final long serialVersionUID = 1L;
-
     }
 
     public static class MissingConstructorError extends PolarRuntimeException {
         public MissingConstructorError(String clsName) {
             super("Missing constructor for class " + clsName);
         }
-
-        private static final long serialVersionUID = 1L;
-
     }
 
     public static class UnregisteredInstanceError extends PolarRuntimeException {
         public UnregisteredInstanceError(long id) {
             super("Unregistered instance ID: " + id);
         }
-
-        private static final long serialVersionUID = 1L;
-
     }
 
     public static class DuplicateInstanceRegistrationError extends PolarRuntimeException {
         public DuplicateInstanceRegistrationError(Long id) {
             super(id.toString());
         }
-
-        private static final long serialVersionUID = 1L;
-
     }
 
     public static class InvalidCallError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
-
-        public InvalidCallError(String className, String callName, List<Class> argTypes) {
+        public InvalidCallError(String className, String callName, Class<?>... argTypes) {
             super("`" + callName + "` on class " + className + ", with argument types " + "`" + argTypes + "`");
         }
 
         public InvalidCallError(String msg) {
             super(msg);
         }
-
     }
 
     public static class InvalidConstructorError extends PolarRuntimeException {
+        public InvalidConstructorError(String msg) {
+            super(msg);
+        }
+
         public InvalidConstructorError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
+    }
 
-        private static final long serialVersionUID = 1L;
+    public static class InstantiationError extends PolarRuntimeException {
+        public InstantiationError(String className) {
+            super("constructor on class `" +  className + "`");
+        }
 
+        public InstantiationError(String className, Exception e) {
+            super("constructor on class `" +  className + "`: " + e.getMessage());
+        }
     }
 
     public static class InlineQueryFailedError extends PolarRuntimeException {
         public InlineQueryFailedError() {
             super(null, null);
         }
-
-        private static final long serialVersionUID = 1L;
-
     }
 
     public static class NullByteInPolarFileError extends PolarRuntimeException {
         public NullByteInPolarFileError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
-        private static final long serialVersionUID = 1L;
-
     }
 
     public static class UnexpectedPolarTypeError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
-
         public UnexpectedPolarTypeError(String type) {
             super(type);
         }
-
     }
 
     public static class PolarFileExtensionError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
-
         public PolarFileExtensionError() {
             super("Polar files must have a .pol or .polar extension");
         }
     }
 
     public static class PolarFileNotFoundError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
-
         public PolarFileNotFoundError(String filename) {
             super("Could not find file: " + filename);
         }
     }
 
     public static class DuplicateClassAliasError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
-
         public DuplicateClassAliasError(String alias, String oldClass, String newClass) {
             super("Attempted to alias '" + newClass + "' as '" + alias + "', but " + oldClass
                     + " already has that alias.");
         }
-
     }
 
-    // # Generic operational exception.
     public static class OperationalError extends OsoException {
-        private static final long serialVersionUID = 1L;
-
         public OperationalError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
     }
 
-    // class UnknownError < OperationalError; end
     public static class UnknownError extends OperationalError {
-        private static final long serialVersionUID = 1L;
-
         public UnknownError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
 
     }
 
-    // Catch-all for a parsing error that doesn't match any of the more specific
-    // types.
     public static class ParseError extends OsoException {
-        private static final long serialVersionUID = 1L;
-
         public ParseError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
 
-    // class ExtraToken < ParseError; end
     public static class ExtraToken extends ParseError {
-        private static final long serialVersionUID = 1L;
-
         public ExtraToken(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
 
-    // class IntegerOverflow < ParseError; end
     public static class IntegerOverflow extends ParseError {
-        private static final long serialVersionUID = 1L;
-
         public IntegerOverflow(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
 
     public static class InvalidTokenCharacter extends ParseError {
-        private static final long serialVersionUID = 1L;
-
         public InvalidTokenCharacter(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
 
     public static class InvalidToken extends ParseError {
-        private static final long serialVersionUID = 1L;
-
         public InvalidToken(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
 
     public static class UnrecognizedEOF extends ParseError {
-        private static final long serialVersionUID = 1L;
-
         public UnrecognizedEOF(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
 
     public static class UnrecognizedToken extends ParseError {
-        private static final long serialVersionUID = 1L;
-
         public UnrecognizedToken(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
 
-    // Generic Polar API exception.
+    /** Generic Polar API exception. */
     public static class ApiError extends OsoException {
-        private static final long serialVersionUID = 1L;
-
         public ApiError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
 
     public static class ParameterError extends ApiError {
-        private static final long serialVersionUID = 1L;
-
         public ParameterError(String msg, Map<String, Object> details) {
             super(msg, details);
         }
-
     }
-
 }

--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -33,9 +33,6 @@ public class Host implements Cloneable {
 
     /**
      * Get a registered Java class.
-     *
-     * @param name
-     * @throws Exceptions.UnregisteredClassError
      */
     public Class<?> getClass(String name) throws Exceptions.UnregisteredClassError {
         if (classes.containsKey(name)) {
@@ -48,9 +45,8 @@ public class Host implements Cloneable {
     /**
      * Store a Java class in the cache by name.
      *
-     * @param name
-     * @throws Exceptions.DuplicateClassAliasError If the class is already
-     *                                             registered.
+     * @param name The name of the class from within Polar.
+     * @throws Exceptions.DuplicateClassAliasError If the name is already registered.
      */
     public String cacheClass(Class<?> cls, Constructor<?> constructor, String name)
             throws Exceptions.DuplicateClassAliasError {
@@ -64,9 +60,6 @@ public class Host implements Cloneable {
 
     /**
      * Get a cached Java instance.
-     *
-     * @param instanceId
-     * @throws Exceptions.UnregisteredInstanceError
      */
     public Object getInstance(long instanceId) throws Exceptions.UnregisteredInstanceError {
         if (hasInstance(instanceId)) {
@@ -78,8 +71,6 @@ public class Host implements Cloneable {
 
     /**
      * Determine if a Java instance has been cached.
-     *
-     * @param instanceId
      */
     public boolean hasInstance(long instanceId) {
         return instances.containsKey(instanceId);
@@ -87,10 +78,6 @@ public class Host implements Cloneable {
 
     /**
      * Cache an instance of a Java class.
-     *
-     * @param instance
-     * @param id
-     * @throws Exceptions.OsoException
      */
     public Long cacheInstance(Object instance, Long id) throws Exceptions.OsoException {
         if (id == null) {
@@ -104,10 +91,6 @@ public class Host implements Cloneable {
     /**
      * Make an instance of a Java class from a {@code Map<String, Object>} of
      * fields.
-     *
-     * @param className
-     * @param fields
-     * @param id
      */
     public Object makeInstance(String className, List<Object> initargs, long id)
             throws Exceptions.OsoException
@@ -147,12 +130,6 @@ public class Host implements Cloneable {
 
     /**
      * Check if a class specializer is more specific than another class specializer.
-     *
-     * @param instanceId
-     * @param leftTag
-     * @param rightTag
-     * @return
-     * @throws Exceptions.UnregisteredClassError
      */
     public boolean subspecializer(long instanceId, String leftTag, String rightTag)
             throws Exceptions.UnregisteredClassError {
@@ -178,13 +155,6 @@ public class Host implements Cloneable {
 
     /**
      * Check if a Java instance is an instance of a class.
-     *
-     * @param instance
-     * @param classTag
-     * @return
-     * @throws Exceptions.UnregisteredClassError
-     * @throws Exceptions.UnregisteredInstanceError
-     * @throws Exceptions.UnexpectedPolarTypeError
      */
     public boolean isa(JSONObject instance, String classTag)
             throws Exceptions.UnregisteredClassError,
@@ -196,10 +166,6 @@ public class Host implements Cloneable {
 
     /**
      * Convert Java Objects to Polar (JSON) terms.
-     *
-     * @param value Java Object to be converted to Polar.
-     * @return JSONObject Polar term of form: {@code {"id": _, "offset": _, "value":
-     *         _}}.
      */
     public JSONObject toPolarTerm(Object value) throws Exceptions.OsoException {
         // Build Polar value
@@ -243,10 +209,6 @@ public class Host implements Cloneable {
 
     /**
      * Convert a Java List to a JSONified Polar list.
-     *
-     * @param list List<Object>
-     * @return List<JSONObject>
-     * @throws Exceptions.OsoException
      */
     private List<JSONObject> javaListToPolar(List<Object> list) throws Exceptions.OsoException {
         ArrayList<JSONObject> polarList = new ArrayList<JSONObject>();
@@ -258,10 +220,6 @@ public class Host implements Cloneable {
 
     /**
      * Convert a Java Array to a JSONified Polar list.
-     *
-     * @param list List<Object>
-     * @return List<JSONObject>
-     * @throws Exceptions.OsoException
      */
     private List<JSONObject> javaArrayToPolar(Object array) throws Exceptions.OsoException {
         assert (array.getClass().isArray());
@@ -287,10 +245,6 @@ public class Host implements Cloneable {
 
     /**
      * Convert a Java Map to a JSONified Polar dictionary.
-     *
-     * @param map Java Map<Object, Object>
-     * @return Map<String, JSONObject>
-     * @throws Exceptions.OsoException
      */
     private Map<String, JSONObject> javaMaptoPolar(Map<Object, Object> map) throws Exceptions.OsoException {
         HashMap<String, JSONObject> polarDict = new HashMap<String, JSONObject>();
@@ -303,10 +257,6 @@ public class Host implements Cloneable {
 
     /**
      * Turn a Polar term passed across the FFI boundary into a Java Object.
-     *
-     * @param term JSONified Polar term of the form: {@code {"id": _, "offset": _, "value": _}}
-     * @throws Exceptions.UnregisteredInstanceError
-     * @throws Exceptions.UnexpectedPolarTypeError
      */
     public Object toJava(JSONObject term)
             throws Exceptions.UnregisteredInstanceError, Exceptions.UnexpectedPolarTypeError {
@@ -343,10 +293,6 @@ public class Host implements Cloneable {
 
     /**
      * Convert a JSONified Polar dictionary to a Java Map
-     *
-     * @param dict JSONObject
-     * @throws Exceptions.UnregisteredInstanceError
-     * @throws Exceptions.UnexpectedPolarTypeError
      */
     public HashMap<String, Object> polarDictToJava(JSONObject dict)
             throws Exceptions.UnregisteredInstanceError, Exceptions.UnexpectedPolarTypeError {
@@ -359,8 +305,6 @@ public class Host implements Cloneable {
 
     /**
      * Convert a JSONified Polar List to a Java List
-     *
-     * @param list JSONArray
      */
     public List<Object> polarListToJava(JSONArray list)
             throws Exceptions.UnregisteredInstanceError, Exceptions.UnexpectedPolarTypeError {

--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -45,7 +45,7 @@ public class Host implements Cloneable {
     /**
      * Store a Java class in the cache by name.
      *
-     * @param name The name of the class from within Polar.
+     * @param name The name used to reference the class from within Polar.
      * @throws Exceptions.DuplicateClassAliasError If the name is already registered.
      */
     public String cacheClass(Class<?> cls, Constructor<?> constructor, String name)

--- a/languages/java/oso/src/main/java/com/osohq/oso/Http.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Http.java
@@ -10,7 +10,5 @@ public class Http {
         this.hostname = hostname;
         this.path = path;
         this.query = query;
-
     }
-
 }

--- a/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
@@ -6,9 +6,10 @@ import java.util.*;
 public class Oso extends Polar {
     public Oso() throws Exceptions.OsoException {
         super();
-        registerClass(Http.class, (m) -> new Http((String) m.get("hostname"), (String) m.get("path"),
-                (Map<String, String>) m.get("query")), "Http");
-        registerClass(PathMapper.class, (m) -> new PathMapper((String) m.get("template")), "PathMapper");
+
+        // Register helper classes.
+        registerClass(Http.class, "Http");
+        registerClass(PathMapper.class, "PathMapper");
     }
 
     /**

--- a/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
@@ -14,12 +14,6 @@ public class Oso extends Polar {
 
     /**
      * Submit an `allow` query to the Polar knowledge base.
-     *
-     * @param actor
-     * @param action
-     * @param resource
-     * @return
-     * @throws Exceptions.OsoException
      */
     public boolean isAllowed(Object actor, Object action, Object resource) throws Exceptions.OsoException {
         return queryRule("allow", actor, action, resource).hasMoreElements();

--- a/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
@@ -1,5 +1,6 @@
 package com.osohq.oso;
 
+import java.lang.reflect.Constructor;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -22,13 +23,12 @@ public class Polar {
         loadQueue = new HashMap<String, String>();
 
         // Register built-in classes.
-        // FIXME: These constructors are garbage.
-        registerClass(Boolean.class, m -> (boolean) m.get("value") ? false : true, "Boolean");
-        registerClass(Integer.class, m -> (int) m.get("value"), "Integer");
-        registerClass(Double.class, m -> (double) m.get("value"), "Float");
-        registerClass(List.class, m -> (List<Object>) m.get("value"), "List");
-        registerClass(Map.class, m -> (Map<String, Object>) m.get("fields"), "Dictionary");
-        registerClass(String.class, m -> (String) m.get("value"), "String");
+        registerClass(Boolean.class, "Boolean");
+        registerClass(Integer.class, "Integer");
+        registerClass(Double.class, "Float");
+        registerClass(List.class, "List");
+        registerClass(Map.class, "Dictionary");
+        registerClass(String.class, "String");
     }
 
     /**
@@ -191,35 +191,53 @@ public class Polar {
     }
 
     /**
-     * Register a Java class with oso.
+     * Register a Java class with Polar.
      *
-     * @param cls       Class object to be registered.
-     * @param fromPolar lambda function to convert from a
-     *                  {@code Map<String, Object>} of parameters to an instance of
-     *                  the Java class.
-     * @throws Exceptions.DuplicateClassAliasError if class has already been
-     *                                             registered.
+     * @param cls         Class object to be registered.
+     * @param constructor The constructor to use with the Polar `new` operator.
+     * @throws Exceptions.DuplicateClassAliasError if class has already been registered.
      */
-    public void registerClass(Class cls, Function<Map, Object> fromPolar)
+    public void registerClass(Class<?> cls)
             throws Exceptions.DuplicateClassAliasError, Exceptions.OsoException {
-        registerClass(cls, fromPolar, cls.getName());
+        registerClass(cls, cls.getName(), null);
     }
 
     /**
-     * Register a Java class with oso using an alias.
+     * Register a Java class with Polar using a specific constructor.
      *
-     * @param cls       Class object to be registered.
-     * @param fromPolar lambda function to convert from a
-     *                  {@code Map<String, Object>} of parameters to an instance of
-     *                  the Java class.
-     * @param name      name to register the class under, which is how the class is
-     *                  accessed from Polar.
+     * @param cls         Class object to be registered.
+     * @param constructor The constructor to use with the Polar `new` operator.
+     * @throws Exceptions.DuplicateClassAliasError if class has already been registered.
+     */
+    public void registerClass(Class<?> cls, Constructor<?> constructor)
+            throws Exceptions.DuplicateClassAliasError, Exceptions.OsoException {
+        registerClass(cls, cls.getName(), constructor);
+    }
+
+    /**
+     * Register a Java class with Polar using an alias.
+     *
+     * @param cls         Class object to be registered.
+     * @param constructor The constructor to use with the Polar `new` operator.
+     * @throws Exceptions.DuplicateClassAliasError if class has already been registered.
+     */
+    public void registerClass(Class<?> cls, String name)
+            throws Exceptions.DuplicateClassAliasError, Exceptions.OsoException {
+        registerClass(cls, name, null);
+    }
+
+    /**
+     * Register a Java class with Polar using an alias.
+     *
+     * @param cls         Class object to be registered.
+     * @param constructor The constructor to use with the Polar `new` operator.
+     * @param name        The name of the class from within Polar.
      * @throws Exceptions.DuplicateClassAliasError if a class has already been
      *                                             registered with the given alias.
      */
-    public void registerClass(Class cls, Function<Map, Object> fromPolar, String name)
+    public void registerClass(Class<?> cls, String name, Constructor<?> constructor)
             throws Exceptions.DuplicateClassAliasError, Exceptions.OsoException {
-        host.cacheClass(cls, fromPolar, name);
+        host.cacheClass(cls, constructor, name);
         registerConstant(name, cls);
     }
 

--- a/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
@@ -47,10 +47,8 @@ public class Polar {
      * will not be recognized. If the filename already exists in the load queue,
      * replace it.
      *
-     * @param filename
      * @throws Exceptions.PolarFileExtensionError On incorrect file extension.
-     * @throws IOException                        If unable to open or read the
-     *                                            file.
+     * @throws IOException                        If unable to open or read the file.
      */
     public void loadFile(String filename) throws IOException, Exceptions.PolarFileExtensionError {
         Optional<String> ext = Optional.ofNullable(filename).filter(f -> f.contains("."))
@@ -70,7 +68,6 @@ public class Polar {
      *
      * @param str      Polar string to be loaded.
      * @param filename Name of the source file.
-     * @throws Exceptions.OsoException
      */
     public void loadStr(String str, String filename) throws Exceptions.OsoException {
         ffiPolar.loadStr(str, filename);
@@ -81,7 +78,6 @@ public class Polar {
      * Load a Polar string into the KB (without filename).
      *
      * @param str Polar string to be loaded.
-     * @throws Exceptions.OsoException
      */
     public void loadStr(String str) throws Exceptions.OsoException {
         ffiPolar.loadStr(str, null);
@@ -90,9 +86,6 @@ public class Polar {
 
     /**
      * Query for a predicate, parsing it first.
-     *
-     * @param query String string
-     * @return Query object (Enumeration of resulting variable bindings).
      */
     public Query query(String query) throws Exceptions.OsoException {
         loadQueuedFiles();
@@ -101,9 +94,6 @@ public class Polar {
 
     /**
      * Query for a predicate.
-     *
-     * @param query as a Predicate
-     * @return Query object (Enumeration of resulting variable bindings).
      */
     public Query query(Predicate query) throws Exceptions.OsoException {
         loadQueuedFiles();
@@ -117,8 +107,6 @@ public class Polar {
      *
      * @param rule Rule name, e.g. "f" for rule "f(x)".
      * @param args Variable list of rule arguments.
-     * @return Query object (Enumeration of resulting variable bindings).
-     * @throws Exceptions.OsoException
      */
     public Query queryRule(String rule, Object... args) throws Exceptions.OsoException {
         loadQueuedFiles();
@@ -129,8 +117,6 @@ public class Polar {
 
     /**
      * Start the Polar REPL.
-     *
-     * @throws Exceptions.OsoException
      */
     public void repl() throws Exceptions.OsoException, IOException {
         repl(new String[0]);
@@ -138,8 +124,6 @@ public class Polar {
 
     /**
      * Load the given files and start the Polar REPL.
-     *
-     * @throws Exceptions.OsoException
      */
     public void repl(String[] files) throws Exceptions.OsoException, IOException {
         for (String file : files) {
@@ -192,10 +176,6 @@ public class Polar {
 
     /**
      * Register a Java class with Polar.
-     *
-     * @param cls         Class object to be registered.
-     * @param constructor The constructor to use with the Polar `new` operator.
-     * @throws Exceptions.DuplicateClassAliasError if class has already been registered.
      */
     public void registerClass(Class<?> cls)
             throws Exceptions.DuplicateClassAliasError, Exceptions.OsoException {
@@ -204,10 +184,6 @@ public class Polar {
 
     /**
      * Register a Java class with Polar using a specific constructor.
-     *
-     * @param cls         Class object to be registered.
-     * @param constructor The constructor to use with the Polar `new` operator.
-     * @throws Exceptions.DuplicateClassAliasError if class has already been registered.
      */
     public void registerClass(Class<?> cls, Constructor<?> constructor)
             throws Exceptions.DuplicateClassAliasError, Exceptions.OsoException {
@@ -216,10 +192,6 @@ public class Polar {
 
     /**
      * Register a Java class with Polar using an alias.
-     *
-     * @param cls         Class object to be registered.
-     * @param constructor The constructor to use with the Polar `new` operator.
-     * @throws Exceptions.DuplicateClassAliasError if class has already been registered.
      */
     public void registerClass(Class<?> cls, String name)
             throws Exceptions.DuplicateClassAliasError, Exceptions.OsoException {
@@ -227,13 +199,7 @@ public class Polar {
     }
 
     /**
-     * Register a Java class with Polar using an alias.
-     *
-     * @param cls         Class object to be registered.
-     * @param constructor The constructor to use with the Polar `new` operator.
-     * @param name        The name of the class from within Polar.
-     * @throws Exceptions.DuplicateClassAliasError if a class has already been
-     *                                             registered with the given alias.
+     * Register a Java class with an optional constructor and alias.
      */
     public void registerClass(Class<?> cls, String name, Constructor<?> constructor)
             throws Exceptions.DuplicateClassAliasError, Exceptions.OsoException {
@@ -243,23 +209,13 @@ public class Polar {
 
     /**
      * Registers `value` as a Polar constant variable called `name`.
-     *
-     * @param name
-     * @param value
-     * @throws Exceptions.OsoException
      */
     public void registerConstant(String name, Object value) throws Exceptions.OsoException {
         ffiPolar.registerConstant(name, host.toPolarTerm(value).toString());
     }
 
-    /*******************/
-    /* PRIVATE METHODS */
-    /*******************/
-
     /**
      * Load all queued files, flushing the {@code loadQueue}
-     *
-     * @throws Exceptions.OsoException
      */
     private void loadQueuedFiles() throws Exceptions.OsoException {
         for (String fname : loadQueue.keySet()) {
@@ -270,9 +226,6 @@ public class Polar {
 
     /**
      * Confirm that all queued inline queries succeed.
-     *
-     * @throws Exceptions.OsoException           On failed query creation.
-     * @throws Exceptions.InlineQueryFailedError On inline query failure.
      */
     private void checkInlineQueries() throws Exceptions.OsoException, Exceptions.InlineQueryFailedError {
         Ffi.Query nextQuery = ffiPolar.nextInlineQuery();

--- a/languages/java/oso/src/main/java/com/osohq/oso/Query.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Query.java
@@ -58,12 +58,6 @@ public class Query implements Enumeration<HashMap<String, Object>> {
 
     /**
      * Helper for `ExternalCall` query events
-     *
-     * @param attrName
-     * @param jArgs
-     * @param instanceId
-     * @param callId
-     * @throws Exceptions.OsoException
      */
     private void handleCall(String attrName, JSONArray jArgs, JSONObject polarInstance, long callId)
             throws Exceptions.OsoException {
@@ -84,9 +78,6 @@ public class Query implements Enumeration<HashMap<String, Object>> {
 
     /**
      * Generate the next Query result
-     *
-     * @return
-     * @throws Exceptions.OsoException
      */
     private HashMap<String, Object> nextResult() throws Exceptions.OsoException {
         while (true) {
@@ -183,7 +174,6 @@ public class Query implements Enumeration<HashMap<String, Object>> {
      * @param callId        Call ID under which to register the call.
      * @param polarInstance JSONObject containing either an instance_id or an
      *                      instance of a built-in type.
-     * @throws Exceptions.InvalidCallError
      */
     public void registerCall(String attrName, List<Object> args, long callId, JSONObject polarInstance)
             throws Exceptions.InvalidCallError,
@@ -238,10 +228,6 @@ public class Query implements Enumeration<HashMap<String, Object>> {
 
     /**
      * Get cached Java method call result.
-     *
-     * @param callId
-     * @return
-     * @throws Exceptions.PolarRuntimeException
      */
     private Enumeration<Object> getCall(long callId) throws Exceptions.PolarRuntimeException {
         if (calls.containsKey(callId)) {
@@ -254,11 +240,6 @@ public class Query implements Enumeration<HashMap<String, Object>> {
 
     /**
      * Get the next JSONified Polar result of a cached method call (enumeration).
-     *
-     * @param callId
-     * @return JSONObject
-     * @throws NoSuchElementException
-     * @throws Exceptions.OsoException
      */
     protected JSONObject nextCallResult(long callId) throws NoSuchElementException, Exceptions.OsoException {
         return host.toPolarTerm(getCall(callId).nextElement());

--- a/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
+++ b/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
@@ -56,12 +56,11 @@ public class PolarTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws NoSuchMethodException {
         try {
             p = new Polar();
-            p.registerClass(MyClass.class, m -> new MyClass((String) m.get("name"), (int) m.get("id")), "MyClass");
-            p.registerClass(MySubClass.class, m -> new MySubClass((String) m.get("name"), (int) m.get("id")),
-                    "MySubClass");
+            p.registerClass(MyClass.class, "MyClass");
+            p.registerClass(MySubClass.class, "MySubClass");
         } catch (Exceptions.OsoException e) {
             throw new Error(e);
         }
@@ -199,8 +198,7 @@ public class PolarTest {
 
     @Test
     public void testRegisterAndMakeClass() throws Exception {
-        Map<String, Object> testArg = Map.of("name", "testName", "id", 1);
-        MyClass instance = (MyClass) p.host.makeInstance("MyClass", testArg, Long.valueOf(0));
+        MyClass instance = (MyClass) p.host.makeInstance("MyClass", Arrays.asList("testName", 1), Long.valueOf(0));
         assertEquals("testName", instance.name);
         assertEquals(Integer.valueOf(1), instance.id);
         // TODO: test that errors when given invalid constructor
@@ -211,13 +209,13 @@ public class PolarTest {
 
     @Test
     public void testDuplicateRegistration() throws Exception {
-        assertThrows(Exceptions.DuplicateClassAliasError.class, () -> p.registerClass(MyClass.class,
-                m -> new MyClass((String) m.get("name"), (int) m.get("id")), "MyClass"));
+        assertThrows(Exceptions.DuplicateClassAliasError.class,
+                     () -> p.registerClass(MyClass.class, "MyClass"));
     }
 
     @Test
     public void testMakeInstanceFromPolar() throws Exception {
-        p.loadStr("f(x) if x = new MyClass{name: \"test\", id: 1};");
+        p.loadStr("f(x) if x = new MyClass(\"test\", 1);");
         Query query = p.query("f(x)");
         MyClass ret = (MyClass) query.nextElement().get("x");
         assertEquals("test", ret.name);
@@ -238,12 +236,12 @@ public class PolarTest {
     @Test
     public void testExternalCall() throws Exception {
         // Test get attribute
-        p.loadStr("id(x) if x = new MyClass{name: \"test\", id: 1}.id;");
+        p.loadStr("id(x) if x = new MyClass(\"test\", 1).id;");
         assertTrue(p.query("id(x)").results().equals(List.of(Map.of("x", 1))),
                 "Failed to get attribute on external instance.");
 
         // Test call method
-        p.loadStr("method(x) if x = new MyClass{name: \"test\", id: 1}.myMethod(\"hello world\");");
+        p.loadStr("method(x) if x = new MyClass(\"test\", 1).myMethod(\"hello world\");");
         assertTrue(p.query("method(x)").results().equals(List.of(Map.of("x", "hello world"))),
                 "Failed to get attribute on external instance.");
     }
@@ -411,9 +409,9 @@ public class PolarTest {
 
     @Test
     public void testLookupErrors() throws Exception {
-        p.registerClass(Foo.class, m -> new Foo(), "Foo");
-        assertEquals(List.of(), p.query("new Foo{} = {bar: \"bar\"}").results());
-        assertThrows(Exceptions.PolarRuntimeException.class, () -> p.query("new Foo{}.bar = \"bar\""),
+        p.registerClass(Foo.class, "Foo");
+        assertEquals(List.of(), p.query("new Foo() = {bar: \"bar\"}").results());
+        assertThrows(Exceptions.PolarRuntimeException.class, () -> p.query("new Foo().bar = \"bar\""),
                 "Expected error.");
     }
 
@@ -443,10 +441,10 @@ public class PolarTest {
         PathMapper mapper = new PathMapper("/widget/{id}");
         assertTrue(mapper.map("/widget/12").equals(Map.of("id", "12")), "Failed to extract matches to a hash");
         // maps HTTP resources
-        oso.registerClass(MyClass.class, m -> new MyClass("test", Integer.parseInt((String) m.get("id"))), "MyClass");
+        oso.registerClass(MyClass.class, "MyClass");
         oso.loadStr("allow(actor, \"get\", _: Http{path: path}) if "
-                + "new PathMapper{template: \"/myclass/{id}\"}.map(path) = {id: id} and "
-                + "allow(actor, \"get\", new MyClass{id: id});\n"
+                + "new PathMapper(\"/myclass/{id}\").map(path) = {id: id} and "
+                + "allow(actor, \"get\", new MyClass(\"test\", new Integer(id)));\n"
                 + "allow(actor, \"get\", myclass: MyClass) if myclass.id = 12;");
         Http http12 = new Http(null, "/myclass/12", null);
         assertTrue(oso.isAllowed("sam", "get", http12), "Failed to correctly map HTTP resource");

--- a/languages/python/oso/extras.py
+++ b/languages/python/oso/extras.py
@@ -6,10 +6,10 @@ from typing import List
 class Http:
     """A resource accessed via HTTP."""
 
-    def __init__(self, path="", query={}, hostname=None):
+    def __init__(self, hostname="", path="", query={}):
+        self.hostname = hostname
         self.path = path
         self.query = query
-        self.hostname = hostname
 
     def __repr__(self):
         return str(self)

--- a/languages/python/polar/host.py
+++ b/languages/python/polar/host.py
@@ -62,7 +62,7 @@ class Host:
         self.instances[id] = instance
         return id
 
-    def make_instance(self, name, fields, id):
+    def make_instance(self, name, initargs, id):
         """Make and cache a new instance of a Python class."""
         cls = self.get_class(name)
         constructor = self.get_constructor(name)
@@ -70,7 +70,11 @@ class Host:
             constructor = getattr(cls, constructor)
         if id in self.instances:
             raise PolarRuntimeException(f"instance {id} is already registered")
-        instance = constructor(**fields)
+        instance = (
+            constructor(**initargs)
+            if isinstance(initargs, dict)
+            else constructor(*initargs)
+        )
         self.cache_instance(instance, id)
         return instance
 

--- a/languages/python/tests/parity/policies/test_api.polar
+++ b/languages/python/tests/parity/policies/test_api.polar
@@ -6,7 +6,7 @@ actorInRole(actor, role, resource: Widget) if
     role = resource.company.role(actor);
 
 allow(actor, "get", _: Http{path: path}) if
-    new PathMapper{template: "/widget/{id}"}.map(path) = {id: id} and
+    new PathMapper("/widget/{id}").map(path) = {id: id} and
     allow(actor, "get", new Widget{id: id});
 
 allow(actor, "post", _: Http{path: path}) if
@@ -14,11 +14,11 @@ allow(actor, "post", _: Http{path: path}) if
     allow(actor, "create", new Widget{});
 
 allow(actor, "what", _: Http{path: path}) if
-    new PathMapper{template: "/widget/{id}"}.map(path) = {id: id} and
+    new PathMapper("/widget/{id}").map(path) = {id: id} and
     allow(actor, "unparameterised_get", new Widget{id: id});
 
 allow(actor, "what", _: Http{path: path, query: {param: "foo"}}) if
-    new PathMapper{template: "/widget/{id}"}.map(path) = {id: id} and
+    new PathMapper("/widget/{id}").map(path) = {id: id} and
     allow(actor, "parameterised_get", new Widget{id: id});
 
 allow(actor, "get", resource: Widget) if resource.frob("Widget") = x;

--- a/languages/ruby/lib/oso/http.rb
+++ b/languages/ruby/lib/oso/http.rb
@@ -3,7 +3,7 @@
 module Oso
   # An HTTP resource.
   class Http
-    def initialize(hostname: nil, path: nil, query: nil)
+    def initialize(hostname, path, query)
       @hostname = hostname
       @path = path
       @query = query

--- a/languages/ruby/lib/oso/path_mapper.rb
+++ b/languages/ruby/lib/oso/path_mapper.rb
@@ -4,7 +4,7 @@ module Oso
   # Map from a template string with capture groups of the form
   # `{name}` to a dictionary of the form `{name: captured_value}`
   class PathMapper
-    def initialize(template:)
+    def initialize(template)
       capture_group = /({([^}]+)})/
 
       template = template.dup

--- a/languages/ruby/spec/oso/language_parity_spec.rb
+++ b/languages/ruby/spec/oso/language_parity_spec.rb
@@ -4,11 +4,11 @@ require 'oso'
 
 oso = Oso.new
 
-# Application class with default kwargs constructor.
+# Application class with default constructor.
 class A
   attr_reader :x
 
-  def initialize(x:) # rubocop:disable Naming/MethodParameterName
+  def initialize(x) # rubocop:disable Naming/MethodParameterName
     @x = x
   end
 
@@ -35,7 +35,7 @@ module B
     end
   end
 end
-oso.register_class(B::C, name: 'C') { |y:| B::C.new(y) }
+oso.register_class(B::C, name: 'C') { |y| B::C.new(y) }
 
 oso.load_file File.expand_path(File.join(__dir__, '../../../../test/test.polar'))
 oso.load_queued_files
@@ -57,14 +57,14 @@ rescue Oso::Polar::ParseError::UnrecognizedEOF => e
 end
 raise unless exception_thrown
 
-oso.query_rule('specializers', D.new(x: 'hello'), B::C.new('hello')).next
+oso.query_rule('specializers', D.new('hello'), B::C.new('hello')).next
 oso.query_rule('floatLists').next
 oso.query_rule('intDicts').next
 oso.query_rule('comparisons').next
 oso.query_rule('testForall').next
 oso.query_rule('testRest').next
-oso.query_rule('testMatches', A.new(x: 'hello')).next
-oso.query_rule('testMethodCalls', A.new(x: 'hello'), B::C.new('hello')).next
+oso.query_rule('testMatches', A.new('hello')).next
+oso.query_rule('testMethodCalls', A.new('hello'), B::C.new('hello')).next
 oso.query_rule('testOr').next
 oso.query_rule('testHttpAndPathMapper').next
 

--- a/languages/ruby/spec/oso/oso_spec.rb
+++ b/languages/ruby/spec/oso/oso_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
     context 'PathMapper' do
       context '#map' do
         it 'extracts matches into a hash' do
-          mapper = Oso::PathMapper.new(template: '/widget/{id}')
+          mapper = Oso::PathMapper.new('/widget/{id}')
           expect(mapper.map('/widget/12')).to eq({ 'id' => '12' })
           expect(mapper.map('/widget/12/frob')).to eq({})
         end
@@ -80,14 +80,14 @@ RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
         subject.register_class(Widget)
         subject.load_str <<~POLAR
           allow(actor, "get", _: Http{path: path}) if
-              new PathMapper{template: "/widget/{id}"}.map(path) = {id: id} and
+              new PathMapper("/widget/{id}").map(path) = {id: id} and
               allow(actor, "get", new Widget{id: id});
           allow(_actor, "get", widget: Widget{}) if widget.id = "12";
         POLAR
-        widget12 = Oso::Http.new(path: '/widget/12')
+        widget12 = Oso::Http.new('host', '/widget/12', {})
         allowed = subject.allowed?(actor: 'sam', action: 'get', resource: widget12)
         expect(allowed).to eq true
-        widget13 = Oso::Http.new(path: '/widget/13')
+        widget13 = Oso::Http.new('host', '/widget/13', {})
         expect(subject.allowed?(actor: 'sam', action: 'get', resource: widget13)).to eq false
       end
     end

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
   end
 
   context '#make_instance' do # rubocop:disable Metrics/BlockLength
-    context 'when using the default constructor' do # rubocop:disable Metrics/BlockLength
+    context 'when using the default constructor' do
       it 'handles keyword args' do
         stub_const('Foo', Class.new do
           attr_reader :bar, :baz
@@ -165,9 +165,7 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
           end
         end)
         subject.register_class(Foo)
-        one = subject.host.to_polar_term(1)
-        two = subject.host.to_polar_term(2)
-        id = subject.host.make_instance('Foo', fields: { 'bar' => one, 'baz' => two }, id: 1)
+        id = subject.host.make_instance('Foo', initargs: { bar: 1, baz: 2 }, id: 1)
         instance = subject.host.get_instance(id)
         expect(instance.class).to eq(Foo)
         expect(instance.bar).to eq(1)
@@ -179,7 +177,7 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
           def initialize; end
         end)
         subject.register_class(Foo)
-        id = subject.host.make_instance('Foo', fields: {}, id: 1)
+        id = subject.host.make_instance('Foo', initargs: {}, id: 1)
         instance = subject.host.get_instance(id)
         expect(instance.class).to eq(Foo)
       end
@@ -202,9 +200,7 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
         end)
         constructor = ->(**args) { Foo.new(**args) }
         subject.register_class(Foo, from_polar: constructor)
-        one = subject.host.to_polar_term(1)
-        two = subject.host.to_polar_term(2)
-        id = subject.host.make_instance('Foo', fields: { 'bar' => one, 'baz' => two }, id: 1)
+        id = subject.host.make_instance('Foo', initargs: { bar: 1, baz: 2 }, id: 1)
         instance = subject.host.get_instance(id)
         expect(instance.class).to eq(Foo)
         expect(instance.bar).to eq(1)
@@ -214,7 +210,7 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
       it 'handles no args' do
         stub_const('Foo', Class.new)
         subject.register_class(Foo, from_polar: -> { Foo.new })
-        id = subject.host.make_instance('Foo', fields: {}, id: 1)
+        id = subject.host.make_instance('Foo', initargs: {}, id: 1)
         instance = subject.host.get_instance(id)
         expect(instance.class).to eq(Foo)
       end

--- a/polar-core/benches/bench.rs
+++ b/polar-core/benches/bench.rs
@@ -267,7 +267,7 @@ impl Runner {
         let instance_id = self.polar.get_external_id();
         Term::new_from_test(Value::ExternalInstance(ExternalInstance {
             instance_id,
-            literal: Some(literal),
+            constructor: Some(Term::new_from_test(Value::InstanceLiteral(literal))),
             repr: None,
         }))
     }

--- a/polar-core/src/parser.rs
+++ b/polar-core/src/parser.rs
@@ -228,11 +228,16 @@ mod tests {
 
     #[test]
     fn test_parse_new() {
-        let f = r#"
-        a(x) if x = new Foo{a: 1};
-        "#;
+        let f = r#"a(x) if x = new Foo{a: 1};"#;
         let results = parse_rules(0, f).unwrap();
         assert_eq!(results[0].to_polar(), r#"a(x) if x = new Foo{a: 1};"#);
+    }
+
+    #[test]
+    fn test_parse_new_boa_constructor() {
+        let f = r#"a(x) if x = new Foo(1, 2);"#;
+        let results = parse_rules(0, f).unwrap();
+        assert_eq!(results[0].to_polar(), r#"a(x) if x = new Foo(1, 2);"#);
     }
 
     #[test]

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -159,10 +159,20 @@ BuiltinOperator: Operator = {
     "print" => Operator::Print,
 };
 
-New: Value = "new" <literal:Spanned<InstanceLiteralTerm>> => {
-    let args = vec![literal];
-    let op = Operation{operator: Operator::New, args};
-    Value::Expression(op)
+New: Value = {
+    // Keyword argument constructor.
+    "new" <literal:Spanned<InstanceLiteralTerm>> => {
+        let args = vec![literal];
+        let op = Operation{operator: Operator::New, args};
+        Value::Expression(op)
+    },
+
+    // Positional argument constructor.
+    "new" <call:Spanned<Predicate>> => {
+        let args = vec![call];
+        let op = Operation{operator: Operator::New, args};
+        Value::Expression(op)
+    },
 };
 
 BuiltinOperation: Value = {

--- a/polar-core/src/rewrites.rs
+++ b/polar-core/src/rewrites.rs
@@ -67,7 +67,6 @@ fn rewrite(term: &mut Term, kb: &KnowledgeBase) -> Option<Term> {
             args,
         }) if args.len() == 1 => {
             // Rewrite new(Foo{}) to new(Foo{}, x) with x a temporary.
-            assert!(matches!(args[0].value(), Value::InstanceLiteral { .. }));
             let temp = Value::Variable(kb.gensym("instance"));
             let new_op = Value::Expression(Operation {
                 operator: Operator::New,

--- a/polar-core/src/types.rs
+++ b/polar-core/src/types.rs
@@ -86,7 +86,7 @@ impl InstanceLiteral {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ExternalInstance {
     pub instance_id: u64,
-    pub literal: Option<InstanceLiteral>,
+    pub constructor: Option<Term>,
     pub repr: Option<String>,
 }
 
@@ -633,7 +633,7 @@ pub enum QueryEvent {
 
     MakeExternal {
         instance_id: u64,
-        instance: InstanceLiteral,
+        constructor: Term,
     },
 
     ExternalCall {
@@ -719,12 +719,12 @@ mod tests {
         };
         let event = QueryEvent::MakeExternal {
             instance_id: 12345,
-            instance: literal,
+            constructor: Term::new_from_test(Value::InstanceLiteral(literal)),
         };
         eprintln!("{}", serde_json::to_string(&event).unwrap());
         let external = Term::new_from_test(Value::ExternalInstance(ExternalInstance {
             instance_id: 12345,
-            literal: None,
+            constructor: None,
             repr: None,
         }));
         let list_of = Term::new_from_test(Value::List(vec![external]));

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -52,7 +52,7 @@ pub enum Goal {
         check_errors: bool,
     },
     MakeExternal {
-        literal: InstanceLiteral,
+        constructor: Term,
         instance_id: u64,
     },
     IsaExternal {
@@ -293,9 +293,9 @@ impl PolarVirtualMachine {
                 right_instance_id,
             } => return self.unify_external(*left_instance_id, *right_instance_id),
             Goal::MakeExternal {
-                literal,
+                constructor,
                 instance_id,
-            } => return Ok(self.make_external(literal, *instance_id)),
+            } => return Ok(self.make_external(constructor, *instance_id)),
             Goal::CheckError => return self.check_error(),
             Goal::Noop => {}
             Goal::Query { term } => {
@@ -1000,10 +1000,10 @@ impl PolarVirtualMachine {
         })
     }
 
-    pub fn make_external(&self, literal: &InstanceLiteral, instance_id: u64) -> QueryEvent {
+    pub fn make_external(&self, constructor: &Term, instance_id: u64) -> QueryEvent {
         QueryEvent::MakeExternal {
             instance_id,
-            instance: literal.clone(),
+            constructor: constructor.clone(),
         }
     }
 
@@ -1204,33 +1204,29 @@ impl PolarVirtualMachine {
                 let result = args.pop().unwrap();
                 assert!(
                     matches!(result.value(), Value::Variable(_)),
-                    "Must have result as second arg."
+                    "Must have result variable as second arg."
                 );
-                let mut literal_term = args.pop().unwrap();
-                literal_term.map_replace(&mut |t| self.deref(t));
-                let literal_value = literal_term
-                    .value()
-                    .clone()
-                    .instance_literal()
-                    .expect("Arg must be instance literal");
+                let mut constructor = args.pop().unwrap();
+                constructor.map_replace(&mut |t| self.deref(t));
 
                 let instance_id = self.new_id();
-                literal_term.replace_value(Value::ExternalInstance(ExternalInstance {
-                    instance_id,
-                    literal: Some(literal_value.clone()),
-                    repr: Some(literal_value.to_polar()),
-                }));
+                let instance =
+                    constructor.clone_with_value(Value::ExternalInstance(ExternalInstance {
+                        instance_id,
+                        constructor: Some(constructor.clone()),
+                        repr: Some(constructor.to_polar()),
+                    }));
 
                 // A goal is used here in case the result is already bound to some external
                 // instance.
                 self.append_goals(vec![
                     Goal::Unify {
                         left: result,
-                        right: literal_term,
+                        right: instance,
                     },
                     Goal::MakeExternal {
                         instance_id,
-                        literal: literal_value,
+                        constructor,
                     },
                 ])?;
             }
@@ -2705,8 +2701,8 @@ mod tests {
         kb.add_generic_rule(bar_rule);
 
         let external_instance = Value::ExternalInstance(ExternalInstance {
-            literal: None,
             instance_id: 1,
+            constructor: None,
             repr: None,
         });
 
@@ -2765,7 +2761,7 @@ mod tests {
         // - right: `Dictionary`
         let arg = term!(Value::ExternalInstance(ExternalInstance {
             instance_id: 1,
-            literal: None,
+            constructor: None,
             repr: None,
         }));
         let left = term!(value!(Pattern::Instance(InstanceLiteral {

--- a/test/Test.java
+++ b/test/Test.java
@@ -35,10 +35,10 @@ class Test {
         }
     }
 
-    public static void main(String[] args) throws IOException, Exceptions.OsoException {
+    public static void main(String[] args) throws IOException, NoSuchMethodException, Exceptions.OsoException {
         Oso o = new Oso();
-        o.registerClass(A.class, m -> new A((String) m.get("x")), "A");
-        o.registerClass(BC.class, m -> new BC((String) m.get("y")), "C");
+        o.registerClass(A.class, "A");
+        o.registerClass(BC.class, "C");
         o.loadFile("test.polar");
         assert o.isAllowed("a", "b", "c");
 

--- a/test/test.polar
+++ b/test/test.polar
@@ -1,9 +1,9 @@
 allow("a","b","c");
 
-a(a_var, x_val) if a_var = new A{x: x_val};
+a(a_var, x_val) if a_var = new A(x_val);
 ?= a(a_instance, "hello") and a_instance.x = "hello";
 
-c(instance, y) if instance = new C{y: y};
+c(instance, y) if instance = new C(y);
 ?= c(instance, "hello") and instance.y = "hello";
 
 specializers(a: A, c: C) if
@@ -52,8 +52,8 @@ testMatches(a) if
     and {x: 1, y: 3} matches {y: 3}
     and {x: 1, y: 3} matches {x:1, y: 3}
     and not {x: 1, y: 3} matches {x:1, y: 4}
-    and new A{x: "hello"} matches A
-    and new A{x: "hello"} matches A{x: "hello"};
+    and new A("hello") matches A
+    and new A("hello") matches A{x: "hello"};
 
 testMethodCalls(a, c) if
     a.foo() == c.foo();
@@ -67,5 +67,5 @@ testCut() if
     and x == 3;
 
 testHttpAndPathMapper() if
-    new Http{hostname: "foo", path: "/", query: {x: 1}}.hostname = "foo"
-    and new PathMapper{template: "/foo/{id}/bar/{ego}"}.map("/foo/1/bar/2") = {id: "1", ego: "2"};
+    new Http("foo", "/", {x: 1}).hostname = "foo"
+    and new PathMapper("/foo/{id}/bar/{ego}").map("/foo/1/bar/2") = {id: "1", ego: "2"};


### PR DESCRIPTION
Java does not support keywords, so cross-language classes now use boa ("By Order of Arguments") constructors exclusively; e.g., `new User(name)`. Also made certain "constructors" static methods, and renamed, e.g., `by_id/byId` → `id` to be consistent across languages.

PR checklist:
- [ ] Java `@PolarClass` annotation
- [x] Docs
- [x] Changelog entry