### PR TITLE
Wrap IDs after 52 bits of precision

### DIFF
--- a/polar-core/src/types.rs
+++ b/polar-core/src/types.rs
@@ -574,6 +574,8 @@ pub struct KnowledgeBase {
     pub inline_queries: Vec<Term>,
 }
 
+const MAX_ID: u64 = (1 << 53) - 1;
+
 impl KnowledgeBase {
     pub fn new() -> Self {
         Self {
@@ -588,8 +590,16 @@ impl KnowledgeBase {
     }
 
     /// Return a monotonically increasing integer ID.
+    ///
+    /// Wraps around at 52 bits of precision so that it can be safely coerced to an IEEE-754
+    /// double-float (f64).
     pub fn new_id(&self) -> u64 {
-        self.id_counter.fetch_add(1, Ordering::SeqCst)
+        if self.id_counter.load(Ordering::SeqCst) == MAX_ID {
+            self.id_counter.store(1, Ordering::SeqCst);
+            MAX_ID
+        } else {
+            self.id_counter.fetch_add(1, Ordering::SeqCst)
+        }
     }
 
     /// Generate a new symbol.
@@ -750,5 +760,15 @@ mod tests {
             })),
         };
         eprintln!("{}", rule);
+    }
+
+    #[test]
+    fn test_id_wrapping() {
+        let kb = KnowledgeBase::new();
+        kb.id_counter.store(MAX_ID - 1, Ordering::SeqCst);
+        assert_eq!(MAX_ID - 1, kb.new_id());
+        assert_eq!(MAX_ID, kb.new_id());
+        assert_eq!(1, kb.new_id());
+        assert_eq!(2, kb.new_id());
     }
 }

--- a/polar-core/src/types.rs
+++ b/polar-core/src/types.rs
@@ -594,8 +594,11 @@ impl KnowledgeBase {
     /// Wraps around at 52 bits of precision so that it can be safely coerced to an IEEE-754
     /// double-float (f64).
     pub fn new_id(&self) -> u64 {
-        if self.id_counter.load(Ordering::SeqCst) == MAX_ID {
-            self.id_counter.store(1, Ordering::SeqCst);
+        if self
+            .id_counter
+            .compare_and_swap(MAX_ID, 1, Ordering::SeqCst)
+            == MAX_ID
+        {
             MAX_ID
         } else {
             self.id_counter.fetch_add(1, Ordering::SeqCst)

--- a/polar-wasm-api/src/polar.rs
+++ b/polar-wasm-api/src/polar.rs
@@ -55,7 +55,7 @@ impl Polar {
     }
 
     #[wasm_bindgen(js_class = Polar, js_name = newId)]
-    pub fn wasm_get_external_id(&self) -> u64 {
-        self.0.get_external_id()
+    pub fn wasm_get_external_id(&self) -> f64 {
+        self.0.get_external_id() as f64
     }
 }

--- a/polar-wasm-api/src/query.rs
+++ b/polar-wasm-api/src/query.rs
@@ -27,7 +27,7 @@ impl Query {
     }
 
     #[wasm_bindgen(js_class = Query, js_name = callResult)]
-    pub fn wasm_call_result(&mut self, call_id: u64, value: Option<String>) -> JsResult<()> {
+    pub fn wasm_call_result(&mut self, call_id: f64, value: Option<String>) -> JsResult<()> {
         let term: Option<Term> = if let Some(value) = value {
             match serde_json::from_str(&value) {
                 Ok(term) => Some(term),
@@ -37,14 +37,14 @@ impl Query {
             None
         };
         self.0
-            .call_result(call_id, term)
+            .call_result(call_id as u64, term)
             .map_err(Error::from)
             .map_err(Error::into)
     }
 
     #[wasm_bindgen(js_class = Query, js_name = questionResult)]
-    pub fn wasm_question_result(&mut self, call_id: u64, result: bool) {
-        self.0.question_result(call_id, result)
+    pub fn wasm_question_result(&mut self, call_id: f64, result: bool) {
+        self.0.question_result(call_id as u64, result)
     }
 
     #[wasm_bindgen(js_class = Query, js_name = debugCommand)]

--- a/polar-wasm-api/tests/polar.rs
+++ b/polar-wasm-api/tests/polar.rs
@@ -117,8 +117,9 @@ fn new_query_from_term_errors() {
 }
 
 #[wasm_bindgen_test]
+#[allow(clippy::float_cmp)]
 fn get_external_id_succeeds() {
     let polar = polar_wasm_api::Polar::wasm_new();
-    assert_eq!(polar.wasm_get_external_id(), 1);
-    assert_eq!(polar.wasm_get_external_id(), 2);
+    assert_eq!(polar.wasm_get_external_id(), 1.0);
+    assert_eq!(polar.wasm_get_external_id(), 2.0);
 }

--- a/polar-wasm-api/tests/query.rs
+++ b/polar-wasm-api/tests/query.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]
+#[allow(clippy::float_cmp)]
 fn call_result_succeeds() {
     let mut polar = polar_wasm_api::Polar::wasm_new();
     polar
@@ -19,10 +20,10 @@ fn call_result_succeeds() {
     let event_data: Object = event_data.dyn_into().unwrap();
     let event_field: JsValue = "call_id".into();
     let call_id = Reflect::get(&event_data, &event_field).unwrap();
-    assert_eq!(call_id, 3);
+    assert_eq!(call_id, 3.0);
 
     let call_result = Some(r#"{"value":{"Boolean":true}}"#.to_string());
-    query.wasm_call_result(3, call_result).unwrap();
+    query.wasm_call_result(3.0, call_result).unwrap();
 
     let event: Object = query.wasm_next_event().unwrap().dyn_into().unwrap();
     let event_kind: JsValue = "Result".into();
@@ -31,13 +32,14 @@ fn call_result_succeeds() {
     let bindings = Reflect::get(&event_data, &data_key).unwrap();
     assert_eq!(bindings.dyn_into::<Map>().unwrap().size(), 0);
 
-    query.wasm_call_result(3, None).unwrap();
+    query.wasm_call_result(3.0, None).unwrap();
 
     let event: JsString = query.wasm_next_event().unwrap().dyn_into().unwrap();
     assert_eq!(event, "Done");
 }
 
 #[wasm_bindgen_test]
+#[allow(clippy::float_cmp)]
 fn app_error_succeeds() {
     let mut polar = polar_wasm_api::Polar::wasm_new();
     polar
@@ -54,7 +56,7 @@ fn app_error_succeeds() {
     let event_data: Object = event_data.dyn_into().unwrap();
     let event_field: JsValue = "call_id".into();
     let call_id = Reflect::get(&event_data, &event_field).unwrap();
-    assert_eq!(call_id, 3);
+    assert_eq!(call_id, 3.0);
 
     let msg = "doin' the hokey-pokey";
     query.wasm_app_error(msg);


### PR DESCRIPTION
This limits us to 9,007,199,254,740,991 unique IDs for calls, instances, etc. per KB and then wraps back around to 1.