### PR TITLE
Move file checking into core.

### DIFF
--- a/languages/README.md
+++ b/languages/README.md
@@ -24,8 +24,6 @@ Top-level Polar language API: load and query Polar.
 | ----------------- | ------ | ---- | ---- | ------- |
 | `ffi_polar`       | x      | x    | x    | x       |
 | `host`            | x      | x    | x    | x       |
-| `loaded_files`    | x      | x    | x    | x       |
-| `loaded_contents` | x      | x    | x    | x       |
 
 | Method              | Python | Ruby | Java | Node.js |
 | ------------------- | ------ | ---- | ---- | ------- |

--- a/languages/java/oso/src/main/java/com/osohq/oso/Exceptions.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Exceptions.java
@@ -158,6 +158,12 @@ public class Exceptions {
         }
     }
 
+    public static class FileLoadingError extends PolarRuntimeException {
+        public FileLoadingError(String msg, Map<String, Object> details) {
+            super(msg, details);
+        }
+    }
+
     // Errors originating from this side of the FFI boundary.
 
     public static class UnregisteredClassError extends PolarRuntimeException {
@@ -186,7 +192,8 @@ public class Exceptions {
 
     public static class InvalidCallError extends PolarRuntimeException {
         public InvalidCallError(String className, String callName, Class<?>... argTypes) {
-            super("Invalid call `" + callName + "` on class " + className + ", with argument types " + "`" + argTypes + "`");
+            super("Invalid call `" + callName + "` on class " + className + ", with argument types " + "`" + argTypes
+                    + "`");
         }
 
         public InvalidCallError(String msg) {
@@ -240,31 +247,6 @@ public class Exceptions {
         public UnexpectedPolarTypeError(String type) {
             super(type);
         }
-    }
-
-    public static class PolarFileAlreadyLoadedError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
-
-        public PolarFileAlreadyLoadedError(String type) {
-            super(type);
-        }
-    }
-
-    public static class PolarFileContentsChangedError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
-
-        public PolarFileContentsChangedError(String type) {
-            super(type);
-        }
-    }
-
-    public static class PolarFileNameChangedError extends PolarRuntimeException {
-        private static final long serialVersionUID = 1L;
-
-        public PolarFileNameChangedError(String type) {
-            super(type);
-        }
-
     }
 
     public static class PolarFileExtensionError extends PolarRuntimeException {

--- a/languages/java/oso/src/main/java/com/osohq/oso/Ffi.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Ffi.java
@@ -33,7 +33,7 @@ public class Ffi {
             return checkResult(polarLib.polar_get_external_id(ptr));
         }
 
-        protected int loadStr(String src, String filename) throws Exceptions.OsoException {
+        protected int load(String src, String filename) throws Exceptions.OsoException {
             int result = polarLib.polar_load(ptr, src, filename);
             processMessages();
             return checkResult(result);

--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -2,7 +2,6 @@ package com.osohq.oso;
 
 import java.lang.reflect.Constructor;
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -46,7 +45,8 @@ public class Host implements Cloneable {
      * Store a Java class in the cache by name.
      *
      * @param name The name used to reference the class from within Polar.
-     * @throws Exceptions.DuplicateClassAliasError If the name is already registered.
+     * @throws Exceptions.DuplicateClassAliasError If the name is already
+     *                                             registered.
      */
     public String cacheClass(Class<?> cls, Constructor<?> constructor, String name)
             throws Exceptions.DuplicateClassAliasError {
@@ -92,16 +92,13 @@ public class Host implements Cloneable {
      * Make an instance of a Java class from a {@code Map<String, Object>} of
      * fields.
      */
-    public Object makeInstance(String className, List<Object> initargs, long id)
-            throws Exceptions.OsoException
-    {
+    public Object makeInstance(String className, List<Object> initargs, long id) throws Exceptions.OsoException {
         Constructor<?> constructor = constructors.get(className);
         if (constructor == null) {
             // Try to find a constructor applicable to the supplied arguments.
             Class<?> cls = classes.get(className);
-            Class<?>[] argTypes = initargs.stream().map(arg -> arg.getClass())
-                .collect(Collectors.toUnmodifiableList())
-                .toArray(new Class[0]);
+            Class<?>[] argTypes = initargs.stream().map(arg -> arg.getClass()).collect(Collectors.toUnmodifiableList())
+                    .toArray(new Class[0]);
             search: for (Constructor<?> c : cls.getConstructors()) {
                 Class<?>[] paramTypes = c.getParameterTypes();
                 if (argTypes.length == paramTypes.length) {
@@ -156,10 +153,8 @@ public class Host implements Cloneable {
     /**
      * Check if a Java instance is an instance of a class.
      */
-    public boolean isa(JSONObject instance, String classTag)
-            throws Exceptions.UnregisteredClassError,
-                   Exceptions.UnregisteredInstanceError,
-                   Exceptions.UnexpectedPolarTypeError {
+    public boolean isa(JSONObject instance, String classTag) throws Exceptions.UnregisteredClassError,
+            Exceptions.UnregisteredInstanceError, Exceptions.UnexpectedPolarTypeError {
         Class<?> cls = getClass(classTag);
         return cls.isInstance(toJava(instance));
     }

--- a/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Oso.java
@@ -1,7 +1,6 @@
 package com.osohq.oso;
 
 import java.io.IOException;
-import java.util.*;
 
 public class Oso extends Polar {
     public Oso() throws Exceptions.OsoException {

--- a/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
@@ -2,15 +2,11 @@ package com.osohq.oso;
 
 import java.lang.reflect.Constructor;
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 import com.osohq.oso.Exceptions.OsoException;
@@ -20,15 +16,10 @@ import com.osohq.oso.Exceptions.PolarRuntimeException;
 public class Polar {
     private Ffi.Polar ffiPolar;
     protected Host host; // visible for tests only
-    private Map<String, String> loadedNames; // Map from filename -> file contents
-    private Map<String, String> loadedContent; // Map from file contents -> filename
 
     public Polar() throws Exceptions.OsoException {
         ffiPolar = Ffi.get().polarNew();
         host = new Host(ffiPolar);
-        loadedNames = new HashMap<String, String>();
-        loadedContent = new HashMap<String, String>();
-
         // Register built-in classes.
         registerClass(Boolean.class, "Boolean");
         registerClass(Integer.class, "Integer");
@@ -44,8 +35,6 @@ public class Polar {
      * @throws Exceptions.OsoException
      */
     public void clear() throws Exceptions.OsoException {
-        loadedNames.clear();
-        loadedContent.clear();
         ffiPolar = Ffi.get().polarNew();
     }
 
@@ -56,7 +45,8 @@ public class Polar {
      * replace it.
      *
      * @throws Exceptions.PolarFileExtensionError On incorrect file extension.
-     * @throws IOException                        If unable to open or read the file.
+     * @throws IOException                        If unable to open or read the
+     *                                            file.
      */
     public void loadFile(String filename) throws IOException, OsoException {
         Optional<String> ext = Optional.ofNullable(filename).filter(f -> f.contains("."))
@@ -68,25 +58,7 @@ public class Polar {
         }
 
         try {
-            File file = new File(Paths.get(filename).toString());
-            String hash = getFileChecksum(file);
-            if (loadedNames.containsKey(filename)) {
-                if (loadedNames.get(filename).equals(hash)) {
-                    throw new Exceptions.PolarFileAlreadyLoadedError("File " + filename + " has already been loaded.");
-                } else {
-                    throw new Exceptions.PolarFileContentsChangedError(
-                            "A file with the name " + filename + ", but different contents, has already been loaded.");
-                }
-            } else if (loadedContent.containsKey(hash)) {
-                throw new Exceptions.PolarFileNameChangedError("A file with the same contents as " + filename
-                        + " named " + loadedContent.get(hash) + "has already been loaded.");
-            } else {
-                loadStr(new String(Files.readAllBytes(Paths.get(filename))), filename);
-                loadedNames.put(filename, hash);
-                loadedContent.put(hash, filename);
-            }
-        } catch (NoSuchAlgorithmException e) {
-            throw new PolarRuntimeException("Failed to hash file " + filename);
+            loadStr(new String(Files.readAllBytes(Paths.get(filename))), filename);
         } catch (FileNotFoundException e) {
             throw new Exceptions.PolarFileNotFoundError(filename);
         }
@@ -100,7 +72,7 @@ public class Polar {
      * @param filename Name of the source file.
      */
     public void loadStr(String str, String filename) throws Exceptions.OsoException {
-        ffiPolar.loadStr(str, filename);
+        ffiPolar.load(str, filename);
         checkInlineQueries();
     }
 
@@ -110,7 +82,7 @@ public class Polar {
      * @param str Polar string to be loaded.
      */
     public void loadStr(String str) throws Exceptions.OsoException {
-        ffiPolar.loadStr(str, null);
+        ffiPolar.load(str, null);
         checkInlineQueries();
     }
 
@@ -203,8 +175,7 @@ public class Polar {
     /**
      * Register a Java class with Polar.
      */
-    public void registerClass(Class<?> cls)
-            throws Exceptions.DuplicateClassAliasError, Exceptions.OsoException {
+    public void registerClass(Class<?> cls) throws Exceptions.DuplicateClassAliasError, Exceptions.OsoException {
         registerClass(cls, cls.getName(), null);
     }
 
@@ -252,39 +223,5 @@ public class Polar {
             }
             nextQuery = ffiPolar.nextInlineQuery();
         }
-    }
-
-    private static String getFileChecksum(File file) throws IOException, NoSuchAlgorithmException {
-        // Get file input stream for reading the file content
-        FileInputStream fis = new FileInputStream(file);
-
-        // Use MD5 algorithm
-        MessageDigest digest = MessageDigest.getInstance("MD5");
-
-        // Create byte array to read data in chunks
-        byte[] byteArray = new byte[1024];
-        int bytesCount = 0;
-
-        // Read file data and update in message digest
-        while ((bytesCount = fis.read(byteArray)) != -1) {
-            digest.update(byteArray, 0, bytesCount);
-        }
-        ;
-
-        // close the stream; We don't need it now.
-        fis.close();
-
-        // Get the hash's bytes
-        byte[] bytes = digest.digest();
-
-        // This bytes[] has bytes in decimal format;
-        // Convert it to hexadecimal format
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < bytes.length; i++) {
-            sb.append(Integer.toString((bytes[i] & 0xff) + 0x100, 16).substring(1));
-        }
-
-        // return complete hash
-        return sb.toString();
     }
 }

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -367,14 +367,18 @@ describe('#loadFile', () => {
     const file = await tempFile('f();', 'a.polar');
     await expect(p.loadFile(file)).resolves.not.toThrow();
     await truncate(file);
-    await expect(p.loadFile(file)).rejects.toThrow(/Problem loading file: A file with the name .*a.polar, but different contents has already been loaded./);
+    await expect(p.loadFile(file)).rejects.toThrow(
+      /Problem loading file: A file with the name .*a.polar, but different contents has already been loaded./
+    );
   });
 
   test('throws if the same file is loaded twice', async () => {
     const p = new Polar();
     const file = await tempFileFx();
     await expect(p.loadFile(file)).resolves.not.toThrow();
-    await expect(p.loadFile(file)).rejects.toThrow(/Problem loading file: File .*f.polar has already been loaded./);
+    await expect(p.loadFile(file)).rejects.toThrow(
+      /Problem loading file: File .*f.polar has already been loaded./
+    );
   });
 
   test('can load multiple files', async () => {

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -358,7 +358,7 @@ describe('#loadFile', () => {
       p.loadFile(await tempFile('', 'a.polar'))
     ).resolves.not.toThrow();
     expect(p.loadFile(await tempFile('', 'b.polar'))).rejects.toThrow(
-      "test"
+      /Problem loading file: A file with the same contents as .*b.polar named .*a.polar has already been loaded./
     );
   });
 
@@ -367,14 +367,14 @@ describe('#loadFile', () => {
     const file = await tempFile('f();', 'a.polar');
     await expect(p.loadFile(file)).resolves.not.toThrow();
     await truncate(file);
-    await expect(p.loadFile(file)).rejects.toThrow("test");
+    await expect(p.loadFile(file)).rejects.toThrow(/Problem loading file: A file with the name .*a.polar, but different contents has already been loaded./);
   });
 
   test('throws if the same file is loaded twice', async () => {
     const p = new Polar();
     const file = await tempFileFx();
     await expect(p.loadFile(file)).resolves.not.toThrow();
-    await expect(p.loadFile(file)).rejects.toThrow("test");
+    await expect(p.loadFile(file)).rejects.toThrow(/Problem loading file: File .*f.polar has already been loaded./);
   });
 
   test('can load multiple files', async () => {

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -30,11 +30,8 @@ import {
 import {
   DuplicateClassAliasError,
   InlineQueryFailedError,
-  PolarFileContentsChangedError,
-  PolarFileDuplicateContentError,
-  PolarFileExtensionError,
-  PolarFileAlreadyLoadedError,
   PolarFileNotFoundError,
+  PolarFileExtensionError,
 } from './errors';
 
 test('it works', async () => {
@@ -361,7 +358,7 @@ describe('#loadFile', () => {
       p.loadFile(await tempFile('', 'a.polar'))
     ).resolves.not.toThrow();
     expect(p.loadFile(await tempFile('', 'b.polar'))).rejects.toThrow(
-      PolarFileDuplicateContentError
+      "test"
     );
   });
 
@@ -370,16 +367,14 @@ describe('#loadFile', () => {
     const file = await tempFile('f();', 'a.polar');
     await expect(p.loadFile(file)).resolves.not.toThrow();
     await truncate(file);
-    await expect(p.loadFile(file)).rejects.toThrow(
-      PolarFileContentsChangedError
-    );
+    await expect(p.loadFile(file)).rejects.toThrow("test");
   });
 
   test('throws if the same file is loaded twice', async () => {
     const p = new Polar();
     const file = await tempFileFx();
     await expect(p.loadFile(file)).resolves.not.toThrow();
-    await expect(p.loadFile(file)).rejects.toThrow(PolarFileAlreadyLoadedError);
+    await expect(p.loadFile(file)).rejects.toThrow("test");
   });
 
   test('can load multiple files', async () => {

--- a/languages/js/src/errors.ts
+++ b/languages/js/src/errors.ts
@@ -64,27 +64,6 @@ export class InvalidQueryEventError extends PolarError {
   }
 }
 
-export class PolarFileAlreadyLoadedError extends PolarError {
-  constructor(file: string) {
-    super(`File '${file}' already loaded.`);
-    Object.setPrototypeOf(this, PolarFileAlreadyLoadedError.prototype);
-  }
-}
-
-export class PolarFileContentsChangedError extends PolarError {
-  constructor(file: string) {
-    super(`File '${file}' already loaded, but contents have changed.`);
-    Object.setPrototypeOf(this, PolarFileContentsChangedError.prototype);
-  }
-}
-
-export class PolarFileDuplicateContentError extends PolarError {
-  constructor(file: string, existing: string) {
-    super(`Content of '${file}' matches the already loaded '${existing}'.`);
-    Object.setPrototypeOf(this, PolarFileDuplicateContentError.prototype);
-  }
-}
-
 export class PolarFileExtensionError extends PolarError {
   constructor(file: string) {
     super(`Polar files must have .polar extension. Offending file: ${file}`);

--- a/languages/js/test/parity.ts
+++ b/languages/js/test/parity.ts
@@ -15,7 +15,7 @@ class A {
 }
 oso.registerClass(A);
 
-class D extends A {}
+class D extends A { }
 
 namespace B {
   export class C {

--- a/languages/js/test/parity.ts
+++ b/languages/js/test/parity.ts
@@ -15,7 +15,7 @@ class A {
 }
 oso.registerClass(A);
 
-class D extends A { }
+class D extends A {}
 
 namespace B {
   export class C {

--- a/languages/python/oso/polar/exceptions.py
+++ b/languages/python/oso/polar/exceptions.py
@@ -33,18 +33,6 @@ class PolarRuntimeException(PolarException):
         return super(PolarException, self).__str__()
 
 
-class PolarFileAlreadyLoadedError(PolarRuntimeException):
-    pass
-
-
-class PolarFileContentsChangedError(PolarRuntimeException):
-    pass
-
-
-class PolarFileNameChangedError(PolarRuntimeException):
-    pass
-
-
 class InlineQueryFailedError(PolarRuntimeException):
     pass
 

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -19,7 +19,7 @@ class Polar:
         """Request a unique ID from the canonical external ID tracker."""
         return check_result(lib.polar_get_external_id(self.ptr))
 
-    def load_str(self, string, filename):
+    def load(self, string, filename=None):
         """Load a Polar string, checking that all inline queries succeed."""
         string = to_c_str(string)
         filename = to_c_str(str(filename)) if filename else ffi.NULL

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -4,8 +4,6 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from pprint import pprint
 import sys
-import hashlib
-import os
 
 try:
     import readline
@@ -19,9 +17,6 @@ from .exceptions import (
     PolarRuntimeException,
     InlineQueryFailedError,
     ParserException,
-    PolarFileAlreadyLoadedError,
-    PolarFileContentsChangedError,
-    PolarFileNameChangedError,
 )
 from .ffi import Polar as FfiPolar, Query as FfiQuery
 from .host import Host
@@ -63,8 +58,6 @@ class Polar:
     def __init__(self, classes=CLASSES, constructors=CONSTRUCTORS):
         self.ffi_polar = FfiPolar()
         self.host = Host(self.ffi_polar)
-        self.loaded_names = {}
-        self.loaded_contents = {}
 
         # Register built-in classes.
         self.register_class(bool, name="Boolean")
@@ -85,8 +78,6 @@ class Polar:
         del self.ffi_polar
 
     def clear(self):
-        self.loaded_names = {}
-        self.loaded_contents = {}
         del self.ffi_polar
         self.ffi_polar = FfiPolar()
 
@@ -106,31 +97,14 @@ class Polar:
         try:
             with open(fname, "rb") as f:
                 file_data = f.read()
-            fhash = hashlib.md5(file_data).hexdigest()
         except FileNotFoundError:
             raise PolarApiException(f"Could not find file: {policy_file}")
 
-        if fname in self.loaded_names.keys():
-            if self.loaded_names.get(fname) == fhash:
-                raise PolarFileAlreadyLoadedError(
-                    f"File {fname} has already been loaded."
-                )
-            else:
-                raise PolarFileContentsChangedError(
-                    f"A file with the name {fname}, but different contents, has already been loaded."
-                )
-        elif fhash in self.loaded_contents.keys():
-            raise PolarFileNameChangedError(
-                f"A file with the same contents as {fname} named {self.loaded_contents.get(fhash)} has already been loaded."
-            )
-        else:
-            self.load_str(file_data.decode("utf-8"), policy_file)
-            self.loaded_names[fname] = fhash
-            self.loaded_contents[fhash] = fname
+        self.load_str(file_data.decode("utf-8"), policy_file)
 
     def load_str(self, string, filename=None):
         """Load a Polar string, checking that all inline queries succeed."""
-        self.ffi_polar.load_str(string, filename)
+        self.ffi_polar.load(string, filename)
 
         # check inline queries
         while True:

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -41,13 +41,13 @@ def test_load_function(polar, query, qvar):
         polar.load_file(Path(__file__).parent / "test_file.polar")
     assert (
         str(e.value)
-        == f"File {Path(__file__).parent}/test_file.polar has already been loaded."
+        == f"Problem loading file: File {Path(__file__).parent}/test_file.polar has already been loaded."
     )
     with pytest.raises(exceptions.PolarRuntimeException) as e:
         polar.load_file(Path(__file__).parent / "test_file_renamed.polar")
     assert (
         str(e.value)
-        == f"A file with the same contents as {Path(__file__).parent}/test_file_renamed.polar named {Path(__file__).parent}/test_file.polar has already been loaded."
+        == f"Problem loading file: A file with the same contents as {Path(__file__).parent}/test_file_renamed.polar named {Path(__file__).parent}/test_file.polar has already been loaded."
     )
     assert query("f(x)") == [{"x": 1}, {"x": 2}, {"x": 3}]
     assert qvar("f(x)", "x") == [1, 2, 3]

--- a/languages/ruby/lib/oso/polar/errors.rb
+++ b/languages/ruby/lib/oso/polar/errors.rb
@@ -27,6 +27,7 @@ module Oso
     class UnsupportedError < PolarRuntimeError; end
     class PolarTypeError < PolarRuntimeError; end
     class StackOverflowError < PolarRuntimeError; end
+    class FileLoadingError < PolarRuntimeError; end
 
     # Errors originating from this side of the FFI boundary.
 
@@ -43,25 +44,6 @@ module Oso
       # @param source [String]
       def initialize(source)
         super("Inline query failed: #{source}")
-      end
-    end
-    class PolarFileAlreadyLoadedError < PolarRuntimeError # rubocop:disable Style/Documentation
-      # @param file [String]
-      def initialize(file)
-        super("File #{file} has already been loaded.")
-      end
-    end
-    class PolarFileContentsChangedError < PolarRuntimeError # rubocop:disable Style/Documentation
-      # @param file [String]
-      def initialize(file)
-        super("A file with the name #{file}, but different contents, has already been loaded.")
-      end
-    end
-    class PolarFileNameChangedError < PolarRuntimeError # rubocop:disable Style/Documentation
-      # @param file [String]
-      # @param existing [String]
-      def initialize(file, existing)
-        super("A file with the same contents as #{file} named #{existing} has already been loaded.")
       end
     end
     class PolarFileExtensionError < PolarRuntimeError # rubocop:disable Style/Documentation

--- a/languages/ruby/lib/oso/polar/ffi/error.rb
+++ b/languages/ruby/lib/oso/polar/ffi/error.rb
@@ -83,6 +83,8 @@ module Oso
             ::Oso::Polar::PolarTypeError.new(msg, details: details)
           when 'StackOverflow'
             ::Oso::Polar::StackOverflowError.new(msg, details: details)
+          when 'FileLoading'
+            ::Oso::Polar::FileLoadingError.new(msg, details: details)
           else
             ::Oso::Polar::PolarRuntimeError.new(msg, details: details)
           end

--- a/languages/ruby/lib/oso/polar/ffi/polar.rb
+++ b/languages/ruby/lib/oso/polar/ffi/polar.rb
@@ -10,7 +10,7 @@ module Oso
           ffi_lib FFI::LIB_PATH
 
           attach_function :new, :polar_new, [], FFI::Polar
-          attach_function :load_str, :polar_load, [FFI::Polar, :string, :string], :int32
+          attach_function :load, :polar_load, [FFI::Polar, :string, :string], :int32
           attach_function :next_inline_query, :polar_next_inline_query, [FFI::Polar, :uint32], FFI::Query
           attach_function :new_id, :polar_get_external_id, [FFI::Polar], :uint64
           attach_function :new_query_from_str, :polar_new_query, [FFI::Polar, :string, :uint32], FFI::Query
@@ -33,8 +33,8 @@ module Oso
         # @param src [String]
         # @param filename [String]
         # @raise [FFI::Error] if the FFI call returns an error.
-        def load_str(src, filename: nil)
-          loaded = Rust.load_str(self, src, filename)
+        def load(src, filename: nil)
+          loaded = Rust.load(self, src, filename)
           process_messages
           raise FFI::Error.get if loaded.zero?
         end

--- a/languages/ruby/lib/oso/polar/polar.rb
+++ b/languages/ruby/lib/oso/polar/polar.rb
@@ -35,7 +35,7 @@ end
 module Oso
   module Polar
     # Create and manage an instance of the Polar runtime.
-    class Polar # rubocop:disable Metrics/ClassLength
+    class Polar
       # @return [Host]
       attr_reader :host
 
@@ -62,7 +62,7 @@ module Oso
       # @param name [String]
       # @raise [PolarFileExtensionError] if provided filename has invalid extension.
       # @raise [PolarFileNotFoundError] if provided filename does not exist.
-      def load_file(name) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def load_file(name)
         raise PolarFileExtensionError, name unless File.extname(name) == '.polar'
 
         file_data = File.open(name, &:read)

--- a/languages/ruby/lib/oso/polar/polar.rb
+++ b/languages/ruby/lib/oso/polar/polar.rb
@@ -35,7 +35,7 @@ end
 module Oso
   module Polar
     # Create and manage an instance of the Polar runtime.
-    class Polar
+    class Polar # rubocop:disable Metrics/ClassLength
       # @return [Host]
       attr_reader :host
 

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -125,8 +125,8 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
 
     it 'is idempotent' do
       expect { 2.times { subject.load_file(test_file) } }.to raise_error do |e|
-        expect(e).to be_an Oso::Polar::PolarFileAlreadyLoadedError
-        expect(e.message).to eq("File #{test_file} has already been loaded.")
+        expect(e).to be_an Oso::Polar::FileLoadingError
+        expect(e.message).to eq("Problem loading file: File #{test_file} has already been loaded.")
       end
     end
 

--- a/polar-c-api/src/lib.rs
+++ b/polar-c-api/src/lib.rs
@@ -92,7 +92,7 @@ pub extern "C" fn polar_load(
                 .map(|ptr| CStr::from_ptr(ptr).to_string_lossy().to_string())
         };
 
-        match polar.load_file(&src, filename) {
+        match polar.load(&src, filename) {
             Err(err) => {
                 set_error(err);
                 POLAR_FAILURE

--- a/polar-core/benches/bench.rs
+++ b/polar-core/benches/bench.rs
@@ -56,7 +56,7 @@ pub fn fib(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let mut runner = runner_from_query(&format!("fib({}, result)", n));
-                    runner.load(policy).unwrap();
+                    runner.load_str(policy).unwrap();
                     runner.expected_result(maplit::hashmap!(
                         sym!("result") => term!(fib(*n))
                     ));
@@ -94,7 +94,7 @@ pub fn prime(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let mut runner = runner_from_query(&format!("prime({})", n));
-                    runner.load(policy).unwrap();
+                    runner.load_str(policy).unwrap();
                     if prime(n) {
                         runner.expected_result(maplit::hashmap!())
                     }
@@ -118,9 +118,11 @@ pub fn many_rules(c: &mut Criterion) {
     const TARGET: usize = 10;
     fn make_runner() -> Runner {
         let mut runner = runner_from_query(&format!("f({})", TARGET));
-        runner.load("f(0);").unwrap();
+        runner.load_str("f(0);").unwrap();
         for i in 1..=TARGET {
-            runner.load(&format!("f({}) if f({});", i, i - 1)).unwrap();
+            runner
+                .load_str(&format!("f({}) if f({});", i, i - 1))
+                .unwrap();
         }
         runner.expected_result(Bindings::new());
         runner
@@ -196,7 +198,7 @@ pub fn n_plus_one_queries(c: &mut Criterion) {
                             let mut runner =
                                 runner_from_query("has_grandchild_called(new Person{}, \"bert\")");
                             runner.register_pseudo_class("Person");
-                            runner.load(policy).unwrap();
+                            runner.load_str(policy).unwrap();
                             n_results(&mut runner, *n);
                             runner.external_cost = Some(std::time::Duration::new(0, *delay));
                             runner

--- a/polar-core/src/error.rs
+++ b/polar-core/src/error.rs
@@ -221,6 +221,9 @@ pub enum RuntimeError {
         msg: String,
         stack_trace: Option<String>,
     },
+    FileLoading {
+        msg: String,
+    },
 }
 
 impl RuntimeError {
@@ -255,6 +258,7 @@ impl fmt::Display for RuntimeError {
                 }
                 write!(f, "Application error: {}", msg)
             }
+            Self::FileLoading { msg } => write!(f, "Problem loading file: {}", msg),
         }
     }
 }

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -80,8 +80,8 @@ impl Polar {
         Self {
             kb: Arc::new(RwLock::new(KnowledgeBase::new())),
             messages: MessageQueue::new(),
-            loaded_content: Arc::new(RwLock::new(HashMap::new())),    // file content -> file name
-            loaded_files: Arc::new(RwLock::new(HashSet::new())),            // set of file names
+            loaded_content: Arc::new(RwLock::new(HashMap::new())), // file content -> file name
+            loaded_files: Arc::new(RwLock::new(HashSet::new())),   // set of file names
         }
     }
 

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -80,8 +80,8 @@ impl Polar {
         Self {
             kb: Arc::new(RwLock::new(KnowledgeBase::new())),
             messages: MessageQueue::new(),
-            loaded_content: Arc::new(RwLock::new(HashMap::new())),
-            loaded_files: Arc::new(RwLock::new(HashSet::new())),
+            loaded_content: Arc::new(RwLock::new(HashMap::new())),    // file content -> file name
+            loaded_files: Arc::new(RwLock::new(HashSet::new())),            // set of file names
         }
     }
 

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -5,6 +5,7 @@ use super::types::*;
 use super::vm::*;
 use super::warnings::check_singletons;
 
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 pub struct Query {
@@ -62,6 +63,10 @@ impl Iterator for Query {
 pub struct Polar {
     pub kb: Arc<RwLock<KnowledgeBase>>,
     messages: MessageQueue,
+    /// Set of filenames already loaded
+    loaded_files: Arc<RwLock<HashSet<String>>>,
+    /// Map from source code loaded to the filename it was loaded as
+    loaded_content: Arc<RwLock<HashMap<String, String>>>,
 }
 
 impl Default for Polar {
@@ -75,10 +80,58 @@ impl Polar {
         Self {
             kb: Arc::new(RwLock::new(KnowledgeBase::new())),
             messages: MessageQueue::new(),
+            loaded_content: Arc::new(RwLock::new(HashMap::new())),
+            loaded_files: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
-    pub fn load_file(&self, src: &str, filename: Option<String>) -> PolarResult<()> {
+    fn check_file(&self, src: &str, filename: &str) -> PolarResult<()> {
+        match (
+            self.loaded_content.read().unwrap().get(src),
+            self.loaded_files.read().unwrap().contains(filename),
+        ) {
+            (Some(other_file), true) if other_file == filename => {
+                return Err(error::RuntimeError::FileLoading {
+                    msg: format!("File {} has already been loaded.", filename),
+                }
+                .into())
+            }
+            (_, true) => {
+                return Err(error::RuntimeError::FileLoading {
+                    msg: format!(
+                        "A file with the name {}, but different contents has already been loaded.",
+                        filename
+                    ),
+                }
+                .into());
+            }
+            (Some(other_file), _) => {
+                return Err(error::RuntimeError::FileLoading {
+                    msg: format!(
+                        "A file with the same contents as {} named {} has already been loaded.",
+                        filename, other_file
+                    ),
+                }
+                .into());
+            }
+            _ => {}
+        }
+        self.loaded_content
+            .write()
+            .unwrap()
+            .insert(src.to_string(), filename.to_string());
+        self.loaded_files
+            .write()
+            .unwrap()
+            .insert(filename.to_string());
+
+        Ok(())
+    }
+
+    pub fn load(&self, src: &str, filename: Option<String>) -> PolarResult<()> {
+        if let Some(ref filename) = filename {
+            self.check_file(src, filename)?;
+        }
         let source = Source {
             filename,
             src: src.to_owned(),
@@ -118,8 +171,8 @@ impl Polar {
     }
 
     // Used in integration tests
-    pub fn load(&self, src: &str) -> PolarResult<()> {
-        self.load_file(src, None)
+    pub fn load_str(&self, src: &str) -> PolarResult<()> {
+        self.load(src, None)
     }
 
     pub fn next_inline_query(&self, trace: bool) -> Option<Query> {
@@ -189,6 +242,6 @@ mod tests {
     fn can_load_and_query() {
         let polar = Polar::new();
         let _query = polar.new_query("1 = 1", false);
-        let _ = polar.load("f(_);");
+        let _ = polar.load_str("f(_);");
     }
 }

--- a/polar-core/src/types.rs
+++ b/polar-core/src/types.rs
@@ -1003,11 +1003,11 @@ mod tests {
     #[test]
     fn test_rule_index() {
         let polar = Polar::new();
-        polar.load(r#"f(1, 1, "x");"#).unwrap();
-        polar.load(r#"f(1, 1, "y");"#).unwrap();
-        polar.load(r#"f(1, x, "y") if x = 2;"#).unwrap();
-        polar.load(r#"f(1, 2, {b: "y"});"#).unwrap();
-        polar.load(r#"f(1, 3, {c: "z"});"#).unwrap();
+        polar.load_str(r#"f(1, 1, "x");"#).unwrap();
+        polar.load_str(r#"f(1, 1, "y");"#).unwrap();
+        polar.load_str(r#"f(1, x, "y") if x = 2;"#).unwrap();
+        polar.load_str(r#"f(1, 2, {b: "y"});"#).unwrap();
+        polar.load_str(r#"f(1, 3, {c: "z"});"#).unwrap();
 
         // Test the index itself.
         let kb = polar.kb.read().unwrap();

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1504,7 +1504,7 @@ fn test_list_results() {
         x != z and delete(xs, z, ys);
     delete([], _, []);
     "#;
-    polar.load(policy).unwrap();
+    polar.load_str(policy).unwrap();
     assert!(qeval(&mut polar, "delete([1,2,3,2,1],2,[1,3,1])"));
     assert_eq!(
         qvar(&mut polar, "delete([1,2,3,2,1],2,result)", "result"),

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -196,7 +196,7 @@ fn qvars(polar: &mut Polar, query_str: &str, vars: &[&str]) -> Vec<Vec<Value>> {
 fn test_functions() {
     let mut polar = Polar::new();
     polar
-        .load("f(1); f(2); g(1); g(2); h(2); k(x) if f(x) and h(x) and g(x);")
+        .load_str("f(1); f(2); g(1); g(2); h(2); k(x) if f(x) and h(x) and g(x);")
         .unwrap();
 
     assert!(qnull(&mut polar, "k(1)"));
@@ -210,7 +210,7 @@ fn test_functions() {
 fn test_jealous() {
     let polar = Polar::new();
     polar
-        .load(
+        .load_str(
             r#"loves("vincent", "mia");
                loves("marcellus", "mia");
                jealous(a, b) if loves(a, c) and loves(b, c);"#,
@@ -239,7 +239,7 @@ fn test_jealous() {
 fn test_trace() {
     let polar = Polar::new();
     polar
-        .load("f(x) if x = 1 and x = 1; f(y) if y = 1;")
+        .load_str("f(x) if x = 1 and x = 1; f(y) if y = 1;")
         .unwrap();
     let query = polar.new_query("f(1)", true).unwrap();
     let results = query_results!(query);
@@ -268,7 +268,7 @@ fn test_trace() {
 fn test_nested_rule() {
     let mut polar = Polar::new();
     polar
-        .load("f(x) if g(x); g(x) if h(x); h(2); g(x) if j(x); j(4);")
+        .load_str("f(x) if g(x); g(x) if h(x); h(2); g(x) if j(x); j(4);")
         .unwrap();
 
     assert!(qeval(&mut polar, "f(2)"));
@@ -282,7 +282,7 @@ fn test_nested_rule() {
 fn test_bad_functions() {
     let mut polar = Polar::new();
     polar
-        .load("f(2); f(1); g(1); g(2); h(2); k(x) if f(x) and h(x) and g(x);")
+        .load_str("f(2); f(1); g(1); g(2); h(2); k(x) if f(x) and h(x) and g(x);")
         .unwrap();
     assert_eq!(qvar(&mut polar, "k(a)", "a"), vec![value!(2)]);
 }
@@ -304,7 +304,7 @@ fn test_functions_reorder() {
 
         let mut joined = permutation.join(";");
         joined.push(';');
-        polar.load(&joined).unwrap();
+        polar.load_str(&joined).unwrap();
 
         assert!(
             qnull(&mut polar, "k(1)"),
@@ -331,7 +331,7 @@ fn test_functions_reorder() {
 #[test]
 fn test_results() {
     let mut polar = Polar::new();
-    polar.load("foo(1); foo(2); foo(3);").unwrap();
+    polar.load_str("foo(1); foo(2); foo(3);").unwrap();
     assert_eq!(
         qvar(&mut polar, "foo(a)", "a"),
         vec![value!(1), value!(2), value!(3)]
@@ -351,7 +351,7 @@ fn test_result_permutations() {
         eprintln!("{:?}", permutation);
         let mut polar = Polar::new();
         let (results, rules): (Vec<_>, Vec<_>) = permutation.into_iter().unzip();
-        polar.load(&format!("{};", rules.join(";"))).unwrap();
+        polar.load_str(&format!("{};", rules.join(";"))).unwrap();
         assert_eq!(
             qvar(&mut polar, "foo(a)", "a"),
             results.into_iter().map(|v| value!(v)).collect::<Vec<_>>()
@@ -363,7 +363,7 @@ fn test_result_permutations() {
 fn test_multi_arg_method_ordering() {
     let mut polar = Polar::new();
     polar
-        .load("bar(2, 1); bar(1, 1); bar(1, 2); bar(2, 2);")
+        .load_str("bar(2, 1); bar(1, 1); bar(1, 2); bar(2, 2);")
         .unwrap();
     assert_eq!(
         qvars(&mut polar, "bar(a, b)", &["a", "b"]),
@@ -381,7 +381,7 @@ fn test_no_applicable_rules() {
     let mut polar = Polar::new();
     assert!(qnull(&mut polar, "f()"));
 
-    polar.load("f(_);").unwrap();
+    polar.load_str("f(_);").unwrap();
     assert!(qnull(&mut polar, "f()"));
 }
 
@@ -390,7 +390,7 @@ fn test_no_applicable_rules() {
 fn test_ait_kaci_34() {
     let mut polar = Polar::new();
     polar
-        .load(
+        .load_str(
             r#"a() if b(x) and c(x);
                b(x) if e(x);
                c(1);
@@ -413,7 +413,7 @@ fn test_constants() {
         kb.constant(sym!("three"), term!(3));
     }
     polar
-        .load(
+        .load_str(
             r#"one(x) if one = one and one = x and x < two;
                two(x) if one < x and two = two and two = x and two < three;
                three(x) if three = three and three = x;"#,
@@ -429,7 +429,7 @@ fn test_constants() {
 #[test]
 fn test_not() {
     let mut polar = Polar::new();
-    polar.load("odd(1); even(2);").unwrap();
+    polar.load_str("odd(1); even(2);").unwrap();
     assert!(qeval(&mut polar, "odd(1)"));
     assert!(qnull(&mut polar, "not odd(1)"));
     assert!(qnull(&mut polar, "even(1)"));
@@ -442,7 +442,7 @@ fn test_not() {
     assert!(qeval(&mut polar, "not even(3)"));
 
     polar
-        .load("f(x) if not a(x); a(1); b(2); g(x) if not (a(x) or b(x));")
+        .load_str("f(x) if not a(x); a(1); b(2); g(x) if not (a(x) or b(x));")
         .unwrap();
 
     assert!(qnull(&mut polar, "f(1)"));
@@ -455,7 +455,7 @@ fn test_not() {
     assert!(qeval(&mut polar, "x=3 and g(x)"));
 
     polar
-        .load("h(x) if not (not (x = 1 or x = 3) or x = 3);")
+        .load_str("h(x) if not (not (x = 1 or x = 3) or x = 3);")
         .unwrap();
     assert!(qeval(&mut polar, "h(1)"));
     assert!(qnull(&mut polar, "h(2)"));
@@ -472,7 +472,7 @@ fn test_not() {
 #[test]
 fn test_and() {
     let mut polar = Polar::new();
-    polar.load("f(1); f(2);").unwrap();
+    polar.load_str("f(1); f(2);").unwrap();
     assert!(qeval(&mut polar, "f(1) and f(2)"));
     assert!(qnull(&mut polar, "f(1) and f(2) and f(3)"));
 }
@@ -506,7 +506,7 @@ fn test_instance_lookup() {
 fn test_retries() {
     let mut polar = Polar::new();
     polar
-        .load("f(1); f(2); g(1); g(2); h(2); k(x) if f(x) and h(x) and g(x); k(3);")
+        .load_str("f(1); f(2); g(1); g(2); h(2); k(x) if f(x) and h(x) and g(x); k(3);")
         .unwrap();
 
     assert!(qnull(&mut polar, "k(1)"));
@@ -518,14 +518,14 @@ fn test_retries() {
 #[test]
 fn test_two_rule_bodies_not_nested() {
     let mut polar = Polar::new();
-    polar.load("f(x) if a(x); f(1);").unwrap();
+    polar.load_str("f(x) if a(x); f(1);").unwrap();
     assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1)]);
 }
 
 #[test]
 fn test_two_rule_bodies_nested() {
     let mut polar = Polar::new();
-    polar.load("f(x) if a(x); f(1); a(x) if g(x);").unwrap();
+    polar.load_str("f(x) if a(x); f(1); a(x) if g(x);").unwrap();
     assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1)]);
 }
 
@@ -533,7 +533,7 @@ fn test_two_rule_bodies_nested() {
 fn test_unify_and() {
     let mut polar = Polar::new();
     polar
-        .load("f(x, y) if a(x) and y = 2; a(1); a(3);")
+        .load_str("f(x, y) if a(x) and y = 2; a(1); a(3);")
         .unwrap();
     assert_eq!(qvar(&mut polar, "f(x, y)", "x"), vec![value!(1), value!(3)]);
     assert_eq!(qvar(&mut polar, "f(x, y)", "y"), vec![value!(2), value!(2)]);
@@ -555,14 +555,16 @@ fn test_symbol_lookup() {
 #[test]
 fn test_or() {
     let mut polar = Polar::new();
-    polar.load("f(x) if a(x) or b(x); a(1); b(3);").unwrap();
+    polar.load_str("f(x) if a(x) or b(x); a(1); b(3);").unwrap();
 
     assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1), value!(3)]);
     assert!(qeval(&mut polar, "f(1)"));
     assert!(qnull(&mut polar, "f(2)"));
     assert!(qeval(&mut polar, "f(3)"));
 
-    polar.load("g(x) if a(x) or b(x) or c(x); c(5);").unwrap();
+    polar
+        .load_str("g(x) if a(x) or b(x) or c(x); c(5);")
+        .unwrap();
     assert_eq!(
         qvar(&mut polar, "g(x)", "x"),
         vec![value!(1), value!(3), value!(5)]
@@ -576,8 +578,8 @@ fn test_or() {
 #[test]
 fn test_dict_head() {
     let mut polar = Polar::new();
-    polar.load("f({x: 1});").unwrap();
-    polar.load("g(_: {x: 1});").unwrap();
+    polar.load_str("f({x: 1});").unwrap();
+    polar.load_str("g(_: {x: 1});").unwrap();
 
     // Test unifying dicts against our dict head.
     assert!(qeval(&mut polar, "f({x: 1})"));
@@ -609,15 +611,15 @@ fn test_dict_head() {
 #[test]
 fn test_non_instance_specializers() {
     let mut polar = Polar::new();
-    polar.load("f(x: 1) if x = 1;").unwrap();
+    polar.load_str("f(x: 1) if x = 1;").unwrap();
     assert!(qeval(&mut polar, "f(1)"));
     assert!(qnull(&mut polar, "f(2)"));
 
-    polar.load("g(x: 1, y: [x]) if y = [1];").unwrap();
+    polar.load_str("g(x: 1, y: [x]) if y = [1];").unwrap();
     assert!(qeval(&mut polar, "g(1, [1])"));
     assert!(qnull(&mut polar, "g(1, [2])"));
 
-    polar.load("h(x: {y: y}, x.y) if y = 1;").unwrap();
+    polar.load_str("h(x: {y: y}, x.y) if y = 1;").unwrap();
     assert!(qeval(&mut polar, "h({y: 1}, 1)"));
     assert!(qnull(&mut polar, "h({y: 1}, 2)"));
 }
@@ -633,7 +635,7 @@ fn test_bindings() {
     );
 
     polar
-        .load("f(x) if x = y and g(y); g(y) if y = 1;")
+        .load_str("f(x) if x = y and g(y); g(y) if y = 1;")
         .unwrap();
     assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1)]);
 }
@@ -642,7 +644,7 @@ fn test_bindings() {
 fn test_lookup_derefs() {
     let polar = Polar::new();
     polar
-        .load("f(x) if x = y and g(y); g(y) if new Foo{}.get(y) = y;")
+        .load_str("f(x) if x = y and g(y); g(y) if new Foo{}.get(y) = y;")
         .unwrap();
     let query = polar.new_query("f(1)", false).unwrap();
     let mut foo_lookups = vec![term!(1)];
@@ -669,7 +671,7 @@ fn test_lookup_derefs() {
 fn unify_predicates() {
     let mut polar = Polar::new();
     polar
-        .load("f(g(_x)); k(x) if h(g(x), g(x)); h(g(1), g(1));")
+        .load_str("f(g(_x)); k(x) if h(g(x), g(x)); h(g(1), g(1));")
         .unwrap();
 
     assert!(qeval(&mut polar, "f(g(1))"));
@@ -681,9 +683,9 @@ fn unify_predicates() {
 #[test]
 fn test_rule_order() {
     let mut polar = Polar::new();
-    polar.load("a(\"foo\");").unwrap();
-    polar.load("a(\"bar\");").unwrap();
-    polar.load("a(\"baz\");").unwrap();
+    polar.load_str("a(\"foo\");").unwrap();
+    polar.load_str("a(\"bar\");").unwrap();
+    polar.load_str("a(\"baz\");").unwrap();
 
     assert_eq!(
         qvar(&mut polar, "a(x)", "x"),
@@ -692,10 +694,10 @@ fn test_rule_order() {
 }
 
 #[test]
-fn test_load_with_query() {
+fn test_load_str_with_query() {
     let polar = Polar::new();
     let src = "f(1); f(2); ?= f(1); ?= not f(3);";
-    polar.load(src).expect("load failed");
+    polar.load_str(src).expect("load_str failed");
 
     while let Some(query) = polar.next_inline_query(false) {
         assert_eq!(query_results!(query).len(), 1);
@@ -707,7 +709,7 @@ fn test_externals_instantiated() {
     let mut polar = Polar::new();
     polar.register_constant(sym!("Foo"), term!(true));
     polar
-        .load("f(x, foo: Foo) if foo.bar(new Bar{x: x}) = 1;")
+        .load_str("f(x, foo: Foo) if foo.bar(new Bar{x: x}) = 1;")
         .unwrap();
 
     let mut foo_lookups = vec![term!(1)];
@@ -739,7 +741,7 @@ fn test_externals_instantiated() {
 #[should_panic(expected = "Goal count exceeded! MAX_EXECUTED_GOALS = 10000")]
 fn test_infinite_loop() {
     let mut polar = Polar::new();
-    polar.load("f(x) if f(x);").unwrap();
+    polar.load_str("f(x) if f(x);").unwrap();
     qeval(&mut polar, "f(1)");
 }
 
@@ -748,7 +750,7 @@ fn test_comparisons() {
     let mut polar = Polar::new();
 
     // <
-    polar.load("lt(x, y) if x < y;").unwrap();
+    polar.load_str("lt(x, y) if x < y;").unwrap();
     assert!(qnull(&mut polar, "lt(1,1)"));
     assert!(qeval(&mut polar, "lt(1,2)"));
     assert!(qnull(&mut polar, "lt(2,1)"));
@@ -766,7 +768,7 @@ fn test_comparisons() {
     assert!(qnull(&mut polar, "lt(\"aa\",\"aa\")"));
 
     // <=
-    polar.load("leq(x, y) if x <= y;").unwrap();
+    polar.load_str("leq(x, y) if x <= y;").unwrap();
     assert!(qeval(&mut polar, "leq(1,1)"));
     assert!(qeval(&mut polar, "leq(1,2)"));
     assert!(qnull(&mut polar, "leq(2,1)"));
@@ -779,7 +781,7 @@ fn test_comparisons() {
     assert!(qnull(&mut polar, "leq(\"ab\",\"aa\")"));
 
     // >
-    polar.load("gt(x, y) if x > y;").unwrap();
+    polar.load_str("gt(x, y) if x > y;").unwrap();
     assert!(qnull(&mut polar, "gt(1,1)"));
     assert!(qnull(&mut polar, "gt(1,2)"));
     assert!(qeval(&mut polar, "gt(2,1)"));
@@ -791,7 +793,7 @@ fn test_comparisons() {
     assert!(qnull(&mut polar, "gt(\"aa\",\"aa\")"));
 
     // >=
-    polar.load("geq(x, y) if x >= y;").unwrap();
+    polar.load_str("geq(x, y) if x >= y;").unwrap();
     assert!(qeval(&mut polar, "geq(1,1)"));
     assert!(qnull(&mut polar, "geq(1,2)"));
     assert!(qeval(&mut polar, "geq(2,1)"));
@@ -804,7 +806,7 @@ fn test_comparisons() {
     assert!(qeval(&mut polar, "geq(\"aa\",\"aa\")"));
 
     // ==
-    polar.load("eq(x, y) if x == y;").unwrap();
+    polar.load_str("eq(x, y) if x == y;").unwrap();
     assert!(qeval(&mut polar, "eq(1,1)"));
     assert!(qnull(&mut polar, "eq(1,2)"));
     assert!(qnull(&mut polar, "eq(2,1)"));
@@ -821,7 +823,7 @@ fn test_comparisons() {
     assert!(qnull(&mut polar, "eq(\"ab\", \"aa\")"));
 
     // !=
-    polar.load("neq(x, y) if x != y;").unwrap();
+    polar.load_str("neq(x, y) if x != y;").unwrap();
     assert!(qnull(&mut polar, "neq(1,1)"));
     assert!(qeval(&mut polar, "neq(1,2)"));
     assert!(qeval(&mut polar, "neq(2,1)"));
@@ -856,7 +858,7 @@ fn test_arithmetic() {
     assert!(qeval(&mut polar, "2 / 6 == 0.3333333333333333"));
 
     polar
-        .load(
+        .load_str(
             r#"even(0) if cut;
                even(x) if x > 0 and odd(x - 1);
                odd(1) if cut;
@@ -899,7 +901,9 @@ fn test_arithmetic() {
 fn test_debug() {
     let polar = Polar::new();
     polar
-        .load("a() if debug(\"a\") and b() and c() and d();\nb();\nc() if debug(\"c\");\nd();\n")
+        .load_str(
+            "a() if debug(\"a\") and b() and c() and d();\nb();\nc() if debug(\"c\");\nd();\n",
+        )
         .unwrap();
 
     let mut call_num = 0;
@@ -990,7 +994,7 @@ fn test_singleton_vars() {
     let mut polar = Polar::new();
     polar.register_constant(sym!("X"), term!(true));
     polar.register_constant(sym!("Y"), term!(true));
-    polar.load("f(x:X,y:Y,z:Z) if z = z;").unwrap();
+    polar.load_str("f(x:X,y:Y,z:Z) if z = z;").unwrap();
     let output = polar.next_message().unwrap();
     assert!(matches!(&output.kind, MessageKind::Warning));
     assert_eq!(
@@ -1014,7 +1018,7 @@ fn test_singleton_vars() {
 #[test]
 fn test_print() {
     let mut polar = Polar::new();
-    polar.load("f(x,y,z) if print(x, y, z);").unwrap();
+    polar.load_str("f(x,y,z) if print(x, y, z);").unwrap();
     assert!(qeval(&mut polar, "f(1, 2, 3)"));
     let output = polar.next_message().unwrap();
     assert!(matches!(&output.kind, MessageKind::Print));
@@ -1044,7 +1048,7 @@ fn test_rest_vars() {
     assert!(qnull(&mut polar, "[1,2,3] = [1,2,3,4, *_rest]"));
 
     polar
-        .load(
+        .load_str(
             r#"member(x, [x, *_rest]);
                member(x, [_first, *rest]) if member(x, rest);"#,
         )
@@ -1058,7 +1062,7 @@ fn test_rest_vars() {
     );
 
     polar
-        .load(
+        .load_str(
             r#"append([], x, x);
                append([first, *rest], x, [first, *tail]) if append(rest, x, tail);"#,
         )
@@ -1074,7 +1078,7 @@ fn test_rest_vars() {
 #[test]
 fn test_in_op() {
     let mut polar = Polar::new();
-    polar.load("f(x, y) if x in y;").unwrap();
+    polar.load_str("f(x, y) if x in y;").unwrap();
     assert!(qeval(&mut polar, "f(1, [1,2,3])"));
     assert_eq!(
         qvar(&mut polar, "f(x, [1,2,3])", "x"),
@@ -1144,25 +1148,25 @@ fn test_matches() {
 #[test]
 fn test_keyword_bug() {
     let polar = Polar::new();
-    let result = polar.load("g(a) if a.new(b);").unwrap_err();
+    let result = polar.load_str("g(a) if a.new(b);").unwrap_err();
     assert!(matches!(
         result.kind,
         ErrorKind::Parse(ParseError::ReservedWord { .. })
     ));
 
-    let result = polar.load("f(a) if a.in(b);").unwrap_err();
+    let result = polar.load_str("f(a) if a.in(b);").unwrap_err();
     assert!(matches!(
         result.kind,
         ErrorKind::Parse(ParseError::ReservedWord { .. })
     ));
 
-    let result = polar.load("cut(a) if a;").unwrap_err();
+    let result = polar.load_str("cut(a) if a;").unwrap_err();
     assert!(matches!(
         result.kind,
         ErrorKind::Parse(ParseError::ReservedWord { .. })
     ));
 
-    let result = polar.load("debug(a) if a;").unwrap_err();
+    let result = polar.load_str("debug(a) if a;").unwrap_err();
     assert!(matches!(
         result.kind,
         ErrorKind::Parse(ParseError::ReservedWord { .. })
@@ -1175,35 +1179,37 @@ fn test_unify_rule_head() {
     let mut polar = Polar::new();
     assert!(matches!(
         polar
-            .load("f(Foo{a: 1});")
+            .load_str("f(Foo{a: 1});")
             .expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
     assert!(matches!(
         polar
-            .load("f(new Foo{a: Foo{a: 1}});")
+            .load_str("f(new Foo{a: Foo{a: 1}});")
             .expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
     assert!(matches!(
         polar
-            .load("f(x: new Foo{a: 1});")
+            .load_str("f(x: new Foo{a: 1});")
             .expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
     assert!(matches!(
         polar
-            .load("f(x: Foo{a: new Foo{a: 1}});")
+            .load_str("f(x: Foo{a: new Foo{a: 1}});")
             .expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
     polar.register_constant(sym!("Foo"), term!(true));
-    polar.load("f(_: Foo{a: 1}, x) if x = 1;").unwrap();
-    polar.load("g(_: Foo{a: Foo{a: 1}}, x) if x = 1;").unwrap();
+    polar.load_str("f(_: Foo{a: 1}, x) if x = 1;").unwrap();
+    polar
+        .load_str("g(_: Foo{a: Foo{a: 1}}, x) if x = 1;")
+        .unwrap();
 
     let query = polar.new_query("f(new Foo{a: 1}, x)", false).unwrap();
     let (results, _externals) = query_results_with_externals(query);
@@ -1220,17 +1226,19 @@ fn test_unify_rule_head() {
 #[test]
 fn test_cut() {
     let mut polar = Polar::new();
-    polar.load("a(x) if x = 1 or x = 2;").unwrap();
-    polar.load("b(x) if x = 3 or x = 4;").unwrap();
-    polar.load("bcut(x) if x = 3 or x = 4 and cut;").unwrap();
-
-    polar.load("c(a, b) if a(a) and b(b) and cut;").unwrap();
-    polar.load("c_no_cut(a, b) if a(a) and b(b);").unwrap();
+    polar.load_str("a(x) if x = 1 or x = 2;").unwrap();
+    polar.load_str("b(x) if x = 3 or x = 4;").unwrap();
     polar
-        .load("c_partial_cut(a, b) if a(a) and bcut(b);")
+        .load_str("bcut(x) if x = 3 or x = 4 and cut;")
+        .unwrap();
+
+    polar.load_str("c(a, b) if a(a) and b(b) and cut;").unwrap();
+    polar.load_str("c_no_cut(a, b) if a(a) and b(b);").unwrap();
+    polar
+        .load_str("c_partial_cut(a, b) if a(a) and bcut(b);")
         .unwrap();
     polar
-        .load("c_another_partial_cut(a, b) if a(a) and cut and b(b);")
+        .load_str("c_another_partial_cut(a, b) if a(a) and cut and b(b);")
         .unwrap();
 
     // Ensure we return multiple results without a cut.
@@ -1255,7 +1263,7 @@ fn test_cut() {
         vec![vec![value!(1), value!(3)], vec![value!(1), value!(4)]]
     );
 
-    polar.load("f(x) if (x = 1 and cut) or x = 2;").unwrap();
+    polar.load_str("f(x) if (x = 1 and cut) or x = 2;").unwrap();
     assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1)]);
     assert!(qeval(&mut polar, "f(1)"));
     assert!(qeval(&mut polar, "f(2)"));
@@ -1265,7 +1273,7 @@ fn test_cut() {
 fn test_forall() {
     let mut polar = Polar::new();
     polar
-        .load("all_ones(l) if forall(item in l, item = 1);")
+        .load_str("all_ones(l) if forall(item in l, item = 1);")
         .unwrap();
 
     assert!(qeval(&mut polar, "all_ones([1])"));
@@ -1273,7 +1281,7 @@ fn test_forall() {
     assert!(qnull(&mut polar, "all_ones([1, 2, 1])"));
 
     polar
-        .load("not_ones(l) if forall(item in l, item != 1);")
+        .load_str("not_ones(l) if forall(item in l, item != 1);")
         .unwrap();
     assert!(qnull(&mut polar, "not_ones([1])"));
     assert!(qeval(&mut polar, "not_ones([2, 3, 4])"));
@@ -1284,15 +1292,15 @@ fn test_forall() {
     assert!(qeval(&mut polar, "forall(x = 1, x = 1)"));
     assert!(qeval(&mut polar, "forall(x in [2, 3, 4], x > 1)"));
 
-    polar.load("g(1);").unwrap();
-    polar.load("g(2);").unwrap();
-    polar.load("g(3);").unwrap();
+    polar.load_str("g(1);").unwrap();
+    polar.load_str("g(2);").unwrap();
+    polar.load_str("g(3);").unwrap();
 
     assert!(qeval(&mut polar, "forall(g(x), x in [1, 2, 3])"));
 
-    polar.load("allow(_: {x: 1}, y) if y = 1;").unwrap();
-    polar.load("allow(_: {y: 1}, y) if y = 2;").unwrap();
-    polar.load("allow(_: {z: 1}, y) if y = 3;").unwrap();
+    polar.load_str("allow(_: {x: 1}, y) if y = 1;").unwrap();
+    polar.load_str("allow(_: {y: 1}, y) if y = 2;").unwrap();
+    polar.load_str("allow(_: {z: 1}, y) if y = 3;").unwrap();
 
     assert!(qeval(
         &mut polar,
@@ -1304,7 +1312,7 @@ fn test_forall() {
 fn test_emoji_policy() {
     let mut polar = Polar::new();
     polar
-        .load(
+        .load_str(
             r#"
                     👩‍🔧("👩‍🦰");
                     allow(👩, "🛠", "🚙") if 👩‍🔧(👩);
@@ -1370,7 +1378,7 @@ fn test_assignment() {
     assert!(qeval(&mut polar, "x := y and y = 6 and x = 6"));
 
     // confirm old syntax -> parse error
-    let e = polar.load("f(x) := g(x)").unwrap_err();
+    let e = polar.load_str("f(x) := g(x)").unwrap_err();
     assert!(matches!(
         e.kind,
         ErrorKind::Parse(ParseError::UnrecognizedToken { .. })
@@ -1380,11 +1388,11 @@ fn test_assignment() {
 #[test]
 fn test_rule_index() {
     let mut polar = Polar::new();
-    polar.load(r#"f(1, 1, "x");"#).unwrap();
-    polar.load(r#"f(1, 1, "y");"#).unwrap();
-    polar.load(r#"f(1, x, "y") if x = 2;"#).unwrap();
-    polar.load(r#"f(1, 2, {b: "y"});"#).unwrap();
-    polar.load(r#"f(1, 3, {c: "z"});"#).unwrap();
+    polar.load_str(r#"f(1, 1, "x");"#).unwrap();
+    polar.load_str(r#"f(1, 1, "y");"#).unwrap();
+    polar.load_str(r#"f(1, x, "y") if x = 2;"#).unwrap();
+    polar.load_str(r#"f(1, 2, {b: "y"});"#).unwrap();
+    polar.load_str(r#"f(1, 3, {c: "z"});"#).unwrap();
 
     // Exercise the index.
     assert!(qeval(&mut polar, r#"f(1, 1, "x")"#));
@@ -1408,7 +1416,7 @@ fn test_fib() {
     "#;
 
     let mut polar = Polar::new();
-    polar.load(policy).unwrap();
+    polar.load_str(policy).unwrap();
 
     assert_eq!(qvar(&mut polar, r#"fib(0, x)"#, "x"), vec![value!(1)]);
     assert_eq!(qvar(&mut polar, r#"fib(1, x)"#, "x"), vec![value!(1)]);
@@ -1426,7 +1434,7 @@ fn test_duplicated_rule() {
     "#;
 
     let mut polar = Polar::new();
-    polar.load(policy).unwrap();
+    polar.load_str(policy).unwrap();
 
     assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1), value!(1)]);
 }
@@ -1452,7 +1460,7 @@ fn test_numeric_applicability() {
         f(9223372036854776000.0); # i64::MAX as f64
         f(nan1); # NaN
     "#;
-    polar.load(policy).unwrap();
+    polar.load_str(policy).unwrap();
 
     assert!(qeval(&mut polar, "f(0)"));
     assert!(qeval(&mut polar, "f(0.0)"));

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1484,7 +1484,7 @@ fn test_numeric_applicability() {
 #[test]
 fn test_external_unify() {
     let polar = Polar::new();
-    polar.load("selfEq(x) if eq(x, x); eq(x, x);").unwrap();
+    polar.load_str("selfEq(x) if eq(x, x); eq(x, x);").unwrap();
 
     let query = polar.new_query("selfEq(new Foo{})", false).unwrap();
     let (results, _externals) = query_results_with_externals(query);

--- a/polar-wasm-api/src/errors.rs
+++ b/polar-wasm-api/src/errors.rs
@@ -34,6 +34,7 @@ fn kind(err: &PolarError) -> String {
         Parse(InvalidFloat { .. }) => "ParseError::InvalidFloat",
         Runtime(Application { .. }) => "RuntimeError::Application",
         Runtime(ArithmeticError { .. }) => "RuntimeError::ArithmeticError",
+        Runtime(FileLoading { .. }) => "RuntimeError::FileLoading",
         Runtime(QueryTimeout { .. }) => "RuntimeError::QueryTimeout",
         Runtime(Serialization { .. }) => "RuntimeError::Serialization",
         Runtime(StackOverflow { .. }) => "RuntimeError::StackOverflow",

--- a/polar-wasm-api/src/polar.rs
+++ b/polar-wasm-api/src/polar.rs
@@ -16,10 +16,10 @@ impl Polar {
         Self(polar::Polar::new())
     }
 
-    #[wasm_bindgen(js_class = Polar, js_name = loadFile)]
-    pub fn wasm_load_file(&self, src: &str, filename: Option<String>) -> JsResult<()> {
+    #[wasm_bindgen(js_class = Polar, js_name = load)]
+    pub fn wasm_load(&self, src: &str, filename: Option<String>) -> JsResult<()> {
         self.0
-            .load_file(src, filename)
+            .load(src, filename)
             .map_err(Error::from)
             .map_err(Error::into)
     }

--- a/polar-wasm-api/tests/polar.rs
+++ b/polar-wasm-api/tests/polar.rs
@@ -5,14 +5,14 @@ use wasm_bindgen_test::*;
 #[wasm_bindgen_test]
 fn load_file_succeeds() {
     let polar = polar_wasm_api::Polar::wasm_new();
-    let res = polar.wasm_load_file("x() if 1 == 1;\n", Some("foo.polar".to_owned()));
+    let res = polar.wasm_load("x() if 1 == 1;\n", Some("foo.polar".to_owned()));
     assert!(matches!(res, Ok(())));
 }
 
 #[wasm_bindgen_test]
 fn load_file_errors() {
     let polar = polar_wasm_api::Polar::wasm_new();
-    let err = polar.wasm_load_file(";", None).unwrap_err();
+    let err = polar.wasm_load(";", None).unwrap_err();
     let err: Error = err.dyn_into().unwrap();
     assert_eq!(err.name(), "ParseError::UnrecognizedToken");
     assert_eq!(
@@ -24,7 +24,7 @@ fn load_file_errors() {
 #[wasm_bindgen_test]
 fn next_inline_query_succeeds() {
     let polar = polar_wasm_api::Polar::wasm_new();
-    let res = polar.wasm_load_file("?= 1 = 1;", None);
+    let res = polar.wasm_load("?= 1 = 1;", None);
     assert!(matches!(res, Ok(())));
 
     let mut query = polar.wasm_next_inline_query().unwrap();
@@ -44,7 +44,7 @@ fn next_inline_query_succeeds() {
 #[wasm_bindgen_test]
 fn next_inline_query_errors() {
     let polar = polar_wasm_api::Polar::wasm_new();
-    let res = polar.wasm_load_file("?= 1 = 2;", None);
+    let res = polar.wasm_load("?= 1 = 2;", None);
     assert!(matches!(res, Ok(())));
     let mut query = polar.wasm_next_inline_query().unwrap();
     let event: JsString = query.wasm_next_event().unwrap().dyn_into().unwrap();

--- a/polar-wasm-api/tests/query.rs
+++ b/polar-wasm-api/tests/query.rs
@@ -12,7 +12,7 @@ fn call_result_succeeds() {
             r#"{"value":{"ExternalInstance":{"instance_id":1,"literal":null,"repr":null}}}"#,
         )
         .unwrap();
-    polar.wasm_load_file("x() if y.z;", None).unwrap();
+    polar.wasm_load("x() if y.z;", None).unwrap();
     let mut query = polar.wasm_new_query_from_str("x()").unwrap();
     let event: Object = query.wasm_next_event().unwrap().dyn_into().unwrap();
     let event_kind: JsValue = "ExternalCall".into();
@@ -48,7 +48,7 @@ fn app_error_succeeds() {
             r#"{"value":{"ExternalInstance":{"instance_id":1,"literal":null,"repr":null}}}"#,
         )
         .unwrap();
-    polar.wasm_load_file("x() if y.z;", None).unwrap();
+    polar.wasm_load("x() if y.z;", None).unwrap();
     let mut query = polar.wasm_new_query_from_str("x()").unwrap();
     let event: Object = query.wasm_next_event().unwrap().dyn_into().unwrap();
     let event_kind: JsValue = "ExternalCall".into();


### PR DESCRIPTION
Reduces the duplication needed, and unlocks handling conflicts
in the core (e.g. remove all rules whose source matches the
new filename).

Made the usage of `load` and `load_str` a little more consistent
across core + host languages.
