### PR TITLE
Tiny tweak to phrasing in quickstart

### DIFF
--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -573,7 +573,7 @@ To accomplish that, we can **replace** our existing rule with:
       :caption: :fa:`oso` expenses.polar
       :class: copybutton
 
-Behind the scenes, oso looks up the ``submitted_by`` field on the provided
+Behind the scenes, oso looks up the associated field on the provided
 ``Expense`` instance and compares that value against the provided **actor**.
 And just like that, an actor can only see an expense if they submitted the expense.
 


### PR DESCRIPTION
The quickstart includes Python and Ruby policies which check:

    expense.submitted_by = actor;

However, the example Java policy uses a camelCase attribute name:

    expense.submittedBy = actor;

The docs then say that "oso looks up the `submitted_by` field," but this
is only true for Ruby and Python. In Java, the field is `submittedBy`.
The discrepancy could mislead Java developers into thinking that oso
somehow converts identifier formats when evaluating Polar policies.

Long term, it might be better to completely avoid referencing variable
names that differ between languages. For instance, the examples could be
reworded to use `submitter` instead of `submittedBy` / `submitted_by`.