### PR TITLE
Fix Python readline prompt on Linux

### DIFF
--- a/docs/changelogs/0.5.2.rst
+++ b/docs/changelogs/0.5.2.rst
@@ -12,22 +12,33 @@ None
 New features
 ============
 
-Support for constructors with both positional and keyword arguments
--------------------------------------------------------------------
+Support for constructors with both positional and keyword arguments (`#405 <https://github.com/osohq/oso/pull/405>`_)
+---------------------------------------------------------------------------------------------------------------------
 
-- In languages that support both positional and keyword arguments (currently Python and Ruby), oso now supports registering classes with constructors that use both.
-- The syntax for calling a constructor with mixed arguments from an oso policy is::
+- In languages that support both positional and keyword arguments (currently
+  Python and Ruby), oso now supports registering classes with constructors that
+  use both.
+- The syntax for calling a constructor with mixed arguments from an oso policy is:
 
-    instance = new MyClass(1, 2, foo: 3)
+  .. code-block:: polar
 
-- As is the convention in Python and Ruby, positional arguments must come before keyword arguments.
-- See :ref:`operator-new`
+    new MyClass(1, 2, foo: 3)
+
+- As with Python and Ruby, positional arguments must come before keyword
+  arguments.
+- For more, see documentation for the :ref:`new operator <operator-new>`.
 
 Other bugs & improvements
 =========================
 
 - The Node.js library will now throw an ``InvalidConstructorError`` when
   attempting to register a non-constructable object via ``registerClass``.
-- Rule indexing performance improvements.
-- Standardize handling of ±∞ and NaN across all language libraries.
+  (`#392 <https://github.com/osohq/oso/pull/392>`_)
+- Rule indexing performance improvements. (`#409
+  <https://github.com/osohq/oso/pull/409>`_)
+- Standardize handling of ±∞ and NaN across all language libraries. (`#410
+  <https://github.com/osohq/oso/pull/410>`_)
 - Better warnings for unknown specializers that are similar to built-in types.
+  (`#403 <https://github.com/osohq/oso/pull/403>`_)
+- Fix an issue with readline's calculation of the cursor position in the Python
+  REPL on Linux. (`#397 <https://github.com/osohq/oso/pull/397>`_)

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -39,9 +39,11 @@ FG_RED = ""
 
 
 if supports_color():
-    # \001 and \002 signal these should be
-    # ignored by readline
-    # https://stackoverflow.com/a/9468954/390293
+    # \001 and \002 signal these should be ignored by readline. Explanation of
+    # the issue: https://stackoverflow.com/a/9468954/390293. Issue has been
+    # observed in the Python REPL on Linux by @samscott89 and @plotnick, but
+    # not on macOS or Windows (with readline installed) or in the Ruby or
+    # Node.js REPLs, both of which also use readline.
     RESET = "\001\x1b[0m\002"
     FG_BLUE = "\001\x1b[34m\002"
     FG_RED = "\001\x1b[31m\002"

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -42,9 +42,9 @@ if supports_color():
     # \001 and \002 signal these should be
     # ignored by readline
     # https://stackoverflow.com/a/9468954/390293
-    RESET =   "\001\x1b[0m\002"
+    RESET = "\001\x1b[0m\002"
     FG_BLUE = "\001\x1b[34m\002"
-    FG_RED =  "\001\x1b[31m\002"
+    FG_RED = "\001\x1b[31m\002"
 
 
 def print_error(error):

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -39,9 +39,12 @@ FG_RED = ""
 
 
 if supports_color():
-    RESET = "\x1b[0m"
-    FG_BLUE = "\x1b[34m"
-    FG_RED = "\x1b[31m"
+    # \001 and \002 signal these should be
+    # ignored by readline
+    # https://stackoverflow.com/a/9468954/390293
+    RESET =   "\001\x1b[0m\002"
+    FG_BLUE = "\001\x1b[34m\002"
+    FG_RED =  "\001\x1b[31m\002"
 
 
 def print_error(error):


### PR DESCRIPTION
Previously you would get this happening:

```
query> long_variable_name = 1
long_variable_name => 1
#  here I go to the beginning of the line and type x = 2, but readline isn't sure where that is
query> long_varix = 2 and able_name = 1
x => 2
long_variable_name => 1
# I pressed up and enter to the command from history, it actually entered correctly
query> x = 2 and long_variable_name = 1
x => 2
long_variable_name => 1
query>
```