### PR TITLE
More consistent printing in REPL

### DIFF
--- a/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Polar.java
@@ -162,7 +162,11 @@ public class Polar {
             } else {
                 do {
                     HashMap<String, Object> result = query.nextElement();
-                    System.out.println(result.size() > 0 ? result.toString() : "true");
+                    if (result.size() == 0) {
+                        System.out.println("true");
+                    } else {
+                        result.forEach((variable, value) -> System.out.println(variable + " = " + value.toString()));
+                    }
                 } while (query.hasMoreElements());
             }
         }

--- a/languages/js/src/Polar.ts
+++ b/languages/js/src/Polar.ts
@@ -208,7 +208,7 @@ export class Polar {
         } else {
           for (const result of results) {
             for (const [variable, value] of result) {
-              console.log(variable + ' => ' + repr(value));
+              console.log(variable + ' = ' + repr(value));
             }
           }
           return true;

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -171,7 +171,7 @@ class Polar:
                     bindings = res["bindings"]
                     if bindings:
                         for variable, value in bindings.items():
-                            print(variable + " => " + repr(value))
+                            print(variable + " = " + repr(value))
                     else:
                         print(True)
             except PolarRuntimeException as e:

--- a/languages/ruby/lib/oso/polar/polar.rb
+++ b/languages/ruby/lib/oso/polar/polar.rb
@@ -220,7 +220,7 @@ module Oso
               puts true
             else
               result.each do |variable, value|
-                puts "#{variable} => #{value.inspect}"
+                puts "#{variable} = #{value.inspect}"
               end
             end
           end


### PR DESCRIPTION
The goal is to print syntactically valid Polar in the REPL, and that bindings should be indicated with `=` (unify).