### PR TITLE
Add benchmark for simple indexing + some simple optimisations 

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,5 +31,5 @@ jobs:
           alert-threshold: "150%"
           # Only push, save + comment on main
           auto-push: ${{ github.ref == 'refs/heads/main' }}
-          comment-always: ${{ github.ref == 'refs/heads/main' }}
+          comment-always: ${{ github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[bench]') }}
           save-data-file: ${{ github.ref == 'refs/heads/main' }}

--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -1,24 +1,8 @@
 =====
-NEXT
+0.5.2
 =====
 
 **Release date:** XXXX-XX-XX
-
-Breaking changes
-================
-
-.. TODO remove warning and replace with "None" if no breaking
-   changes.
-
-.. warning:: This release contains breaking changes. Be sure
-   to follow migration steps before upgrading.
-
-Breaking change 1
------------------
-
-- summary of breaking change
-
-Link to migration guide
 
 
 New features
@@ -37,7 +21,5 @@ Link to relevant documentation section
 Other bugs & improvements
 =========================
 
-- bulleted list
-- improvements
-- of smaller
-- potentially with doc links
+- Improve rule indexing performance
+

--- a/polar-core/benches/bench.rs
+++ b/polar-core/benches/bench.rs
@@ -16,16 +16,16 @@ fn runner_from_query(q: &str) -> Runner {
 
 pub fn simple_queries(c: &mut Criterion) {
     c.bench_function("unify_once", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || runner_from_query("1=1"),
-            |mut runner| runner.run(),
+            |runner| runner.run(),
             criterion::BatchSize::SmallInput,
         )
     });
     c.bench_function("unify_twice", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || runner_from_query("1=1 and 2=2"),
-            |mut runner| runner.run(),
+            |runner| runner.run(),
             criterion::BatchSize::SmallInput,
         )
     });
@@ -53,7 +53,7 @@ pub fn fib(c: &mut Criterion) {
     let mut group = c.benchmark_group("fib");
     for n in &n_array {
         group.bench_function(BenchmarkId::from_parameter(format!("{}", n)), |b| {
-            b.iter_batched(
+            b.iter_batched_ref(
                 || {
                     let mut runner = runner_from_query(&format!("fib({}, result)", n));
                     runner.load_str(policy).unwrap();
@@ -62,7 +62,7 @@ pub fn fib(c: &mut Criterion) {
                     ));
                     runner
                 },
-                |mut runner| {
+                |runner| {
                     runner.run();
                 },
                 criterion::BatchSize::SmallInput,
@@ -91,7 +91,7 @@ pub fn prime(c: &mut Criterion) {
     let mut group = c.benchmark_group("prime");
     for n in &[3, 23, 43, 83, 255] {
         group.bench_function(BenchmarkId::from_parameter(format!("{}", n)), |b| {
-            b.iter_batched(
+            b.iter_batched_ref(
                 || {
                     let mut runner = runner_from_query(&format!("prime({})", n));
                     runner.load_str(policy).unwrap();
@@ -100,7 +100,7 @@ pub fn prime(c: &mut Criterion) {
                     }
                     runner
                 },
-                |mut runner| {
+                |runner| {
                     runner.run();
                 },
                 criterion::BatchSize::SmallInput,
@@ -130,9 +130,9 @@ pub fn indexed_rules(c: &mut Criterion) {
     let mut group = c.benchmark_group("indexed");
     for n in &n_array {
         group.bench_function(BenchmarkId::from_parameter(format!("{}", n)), |b| {
-            b.iter_batched(
+            b.iter_batched_ref(
                 || make_runner(*n),
-                |mut runner| {
+                |runner| {
                     runner.run();
                 },
                 criterion::BatchSize::SmallInput,
@@ -161,9 +161,9 @@ pub fn many_rules(c: &mut Criterion) {
     }
 
     c.bench_function("many_rules", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             make_runner,
-            |mut runner| runner.run(),
+            |runner| runner.run(),
             criterion::BatchSize::SmallInput,
         )
     });
@@ -225,7 +225,7 @@ pub fn n_plus_one_queries(c: &mut Criterion) {
             group.bench_function(
                 BenchmarkId::from_parameter(format!("{}, cost={}ns", n, delay)),
                 |b| {
-                    b.iter_batched(
+                    b.iter_batched_ref(
                         || {
                             let mut runner =
                                 runner_from_query("has_grandchild_called(new Person{}, \"bert\")");
@@ -235,7 +235,7 @@ pub fn n_plus_one_queries(c: &mut Criterion) {
                             runner.external_cost = Some(std::time::Duration::new(0, *delay));
                             runner
                         },
-                        |mut runner| {
+                        |runner| {
                             runner.run();
                             // check: we do actually run N+1 queries
                             assert_eq!(runner.calls_count, 1 + *n);

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -352,8 +352,13 @@ impl PolarVirtualMachine {
             }
             Goal::TraceRule { trace } => {
                 if let Node::Rule(rule) = &trace.node {
-                    let source_str = self.rule_source(&rule);
-                    self.log(&format!("RULE:\n{}", source_str), &[]);
+                    self.log_with(
+                        || {
+                            let source_str = self.rule_source(&rule);
+                            format!("RULE:\n{}", source_str)
+                        },
+                        &[],
+                    );
                 }
                 self.trace.push(trace.clone());
             }
@@ -697,12 +702,21 @@ impl PolarVirtualMachine {
     }
 
     fn log(&self, message: &str, terms: &[&Term]) {
+        self.log_with(|| message, terms)
+    }
+
+    fn log_with<F, R>(&self, message_fn: F, terms: &[&Term])
+    where
+        F: FnOnce() -> R,
+        R: AsRef<str>,
+    {
         if self.polar_log && !self.polar_log_mute {
             let mut indent = String::new();
             for _ in 0..=self.queries.len() {
                 indent.push_str("  ");
             }
-            let lines = message.split('\n').collect::<Vec<&str>>();
+            let message = message_fn();
+            let lines = message.as_ref().split('\n').collect::<Vec<&str>>();
             if let Some(line) = lines.first() {
                 let mut msg = format!("[debug] {}{}", &indent, line);
                 if !terms.is_empty() {
@@ -915,8 +929,8 @@ impl PolarVirtualMachine {
             "Called isa with bare dictionary!"
         );
 
-        self.log(
-            &format!("MATCHES :{} matches {}", left.to_polar(), right.to_polar(),),
+        self.log_with(
+            || format!("MATCHES :{} matches {}", left.to_polar(), right.to_polar()),
             &[left, right],
         );
 
@@ -1144,19 +1158,24 @@ impl PolarVirtualMachine {
             self.push_goal(Goal::CheckError)?;
         }
 
-        let mut msg = format!("LOOKUP: {}.{}", instance.to_string(), field_name);
-        if let Some(arguments) = &args {
-            msg.push('(');
-            msg.push_str(
-                &arguments
-                    .iter()
-                    .map(|a| a.to_polar())
-                    .collect::<Vec<String>>()
-                    .join(", "),
-            );
-            msg.push(')');
-        }
-        self.log(&msg, &[]);
+        self.log_with(
+            || {
+                let mut msg = format!("LOOKUP: {}.{}", instance.to_string(), field_name);
+                if let Some(arguments) = &args {
+                    msg.push('(');
+                    msg.push_str(
+                        &arguments
+                            .iter()
+                            .map(|a| a.to_polar())
+                            .collect::<Vec<String>>()
+                            .join(", "),
+                    );
+                    msg.push(')');
+                }
+                msg
+            },
+            &[],
+        );
 
         Ok(QueryEvent::ExternalCall {
             call_id,
@@ -1251,7 +1270,7 @@ impl PolarVirtualMachine {
                 args,
             }) if args.len() == 1 => (),
             _ => {
-                self.log(&format!("QUERY: {}", term.to_polar(),), &[term]);
+                self.log_with(|| format!("QUERY: {}", term.to_polar()), &[term]);
             }
         };
 
@@ -1600,14 +1619,16 @@ impl PolarVirtualMachine {
         let result = &args[2];
         assert!(matches!(result.value(), Value::Variable(_)));
 
-        self.log(
-            &format!(
-                "MATH: {} {} {} = {}",
-                left_term.to_polar(),
-                op.to_polar(),
-                right_term.to_polar(),
-                result.to_polar()
-            ),
+        self.log_with(
+            || {
+                format!(
+                    "MATH: {} {} {} = {}",
+                    left_term.to_polar(),
+                    op.to_polar(),
+                    right_term.to_polar(),
+                    result.to_polar()
+                )
+            },
             &[&left_term, &right_term, result],
         );
 
@@ -1656,13 +1677,15 @@ impl PolarVirtualMachine {
         let mut left_term = self.deref(&args[0]);
         let mut right_term = self.deref(&args[1]);
 
-        self.log(
-            &format!(
-                "CMP: {} {} {}",
-                left_term.to_polar(),
-                op.to_polar(),
-                right_term.to_polar(),
-            ),
+        self.log_with(
+            || {
+                format!(
+                    "CMP: {} {} {}",
+                    left_term.to_polar(),
+                    op.to_polar(),
+                    right_term.to_polar(),
+                )
+            },
             &[&left_term, &right_term],
         );
 
@@ -1751,7 +1774,7 @@ impl PolarVirtualMachine {
         // For example what happens if the call asked for a field that doesn't exist?
 
         if let Some(value) = term {
-            self.log(&format!("=> {}", value.to_string()), &[]);
+            self.log_with(|| format!("=> {}", value.to_string()), &[]);
 
             self.bind(
                 &self
@@ -2201,13 +2224,18 @@ impl PolarVirtualMachine {
             // We're done; the rules are sorted.
             // Make alternatives for calling them.
 
-            let mut rule_strs = "APPLICABLE_RULES: [\n".to_owned();
-            for rule in rules {
-                rule_strs.push_str(&format!("  {}\n", rule.to_string()))
-            }
-            rule_strs.push_str("]");
+            self.log_with(
+                || {
+                    let mut rule_strs = "APPLICABLE_RULES: [\n".to_owned();
+                    for rule in rules {
+                        rule_strs.push_str(&format!("  {}\n", rule.to_string()))
+                    }
+                    rule_strs.push_str("]");
+                    rule_strs
+                },
+                &[],
+            );
             self.polar_log_mute = false;
-            self.log(&rule_strs, &[]);
 
             let mut alternatives = Vec::with_capacity(rules.len());
             for rule in rules.iter() {


### PR DESCRIPTION
Added a benchmark to check to that "trivial" indexing is approximately linear in complexity.
(This is a nice resource to see why we would expect that to be the case: https://github.com/Rufflewind/bench-maps) 

There were some performance optimisations to be made across the board, but also a specific one for indexing which has significantly increased that benchmark.

There was also a huge change from using [`iter_batched_ref`](http://bheisler.github.io/criterion.rs/criterion/struct.Bencher.html#method.iter_batched_ref) which, I think, basically removes the time to drop the entire KB after running the query. The before/after below is cherry-picking that change too

The change was moving the borrow of the kb rules so we can avoid cloning. Overall on the newly added benchmarks, this is the improvement:

```
indexed/1               time:   [4.9974 us 5.1745 us 5.3621 us]
                        change: [-39.293% -36.543% -33.355%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

indexed/10              time:   [5.3793 us 5.5503 us 5.7522 us]
                        change: [-36.308% -33.545% -30.729%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

indexed/100             time:   [7.0676 us 7.6192 us 8.2091 us]
                        change: [-69.387% -67.421% -65.173%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
```