### PR TITLE
Handle ±∞ and NaN across FFI

### DIFF
--- a/docs/changelogs/0.5.2.rst
+++ b/docs/changelogs/0.5.2.rst
@@ -7,25 +7,13 @@
 Breaking changes
 ================
 
-.. TODO remove warning and replace with "None" if no breaking
-   changes.
-
-.. warning:: This release contains breaking changes. Be sure
-   to follow migration steps before upgrading.
-
-Breaking change 1
------------------
-
-- summary of breaking change
-
-Link to migration guide
-
+None
 
 New features
-==============
+============
 
 Support for constructors with both positional and keyword arguments
-===================================================================
+-------------------------------------------------------------------
 
 - In languages that support both positional and keyword arguments (currently Python and Ruby), oso now supports registering classes with constructors that use both.
 - The syntax for calling a constructor with mixed arguments from an oso policy is::
@@ -38,7 +26,7 @@ Support for constructors with both positional and keyword arguments
 Other bugs & improvements
 =========================
 
-- bulleted list
-- improvements
-- of smaller
-- potentially with doc links
+- The Node.js library will now throw an ``InvalidConstructorError`` when
+  attempting to register a non-constructable object via ``registerClass``.
+- Rule indexing performance improvements.
+- Standardize handling of ±∞ and NaN across all language libraries.

--- a/docs/changelogs/0.5.2.rst
+++ b/docs/changelogs/0.5.2.rst
@@ -30,3 +30,4 @@ Other bugs & improvements
   attempting to register a non-constructable object via ``registerClass``.
 - Rule indexing performance improvements.
 - Standardize handling of ±∞ and NaN across all language libraries.
+- Better warnings for unknown specializers that are similar to built-in types.

--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -24,3 +24,4 @@ Other bugs & improvements
 - The Node.js library will now throw an ``InvalidConstructorError`` when
   attempting to register a non-constructable object via ``registerClass``.
 - Rule indexing performance improvements.
+- Standardize handling of ±∞ and NaN across all language libraries.

--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -1,15 +1,31 @@
-=====
-0.5.2
-=====
+====
+NEXT
+====
 
 **Release date:** XXXX-XX-XX
 
+Breaking changes
+================
+
+.. TODO remove warning and replace with "None" if no breaking
+   changes.
+
+.. warning:: This release contains breaking changes. Be sure
+   to follow migration steps before upgrading.
+
+Breaking change 1
+-----------------
+
+- summary of breaking change
+
+Link to migration guide
+
 
 New features
-==============
+============
 
 Feature 1
-=========
+---------
 
 - summary
 - of
@@ -21,7 +37,7 @@ Link to relevant documentation section
 Other bugs & improvements
 =========================
 
-- The Node.js library will now throw an ``InvalidConstructorError`` when
-  attempting to register a non-constructable object via ``registerClass``.
-- Rule indexing performance improvements.
-- Standardize handling of ±∞ and NaN across all language libraries.
+- bulleted list
+- improvements
+- of smaller
+- potentially with doc links

--- a/docs/changelogs/vTEMPLATE.rst
+++ b/docs/changelogs/vTEMPLATE.rst
@@ -1,6 +1,6 @@
-=====
+====
 NEXT
-=====
+====
 
 **Release date:** XXXX-XX-XX
 
@@ -22,10 +22,10 @@ Link to migration guide
 
 
 New features
-==============
+============
 
 Feature 1
-=========
+---------
 
 - summary
 - of

--- a/docs/spelling_allowed_words.txt
+++ b/docs/spelling_allowed_words.txt
@@ -57,6 +57,8 @@ musl
 glibc
 repl
 arity
+NaN
+constructable
 
 ## Product names
 sqlite

--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -287,7 +287,7 @@ public class Host implements Cloneable {
                                     return Double.NaN;
                                 default:
                                     throw new Exceptions.OsoException(
-                                        "Expected a Float; received the string \"" + f + "\"");
+                                        "Expected a floating point number, got \"" + f + "\"");
                             }
                         }
                         return (Double) f;

--- a/languages/java/oso/src/main/java/com/osohq/oso/Query.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Query.java
@@ -97,7 +97,7 @@ public class Query implements Enumeration<HashMap<String, Object>> {
                 kind = event.keys().next();
                 data = event.getJSONObject(kind);
             } catch (JSONException e) {
-                // TODO: this sucks, we should have a consistent serialization format
+                // TODO: we should have a consistent serialization format
                 kind = eventStr.replace("\"", "");
                 data = null;
             }

--- a/languages/java/oso/src/main/java/com/osohq/oso/Query.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Query.java
@@ -189,8 +189,11 @@ public class Query implements Enumeration<HashMap<String, Object>> {
      *                      instance of a built-in type.
      */
     public void registerCall(String attrName, Optional<List<Object>> args, long callId, JSONObject polarInstance)
-            throws Exceptions.InvalidAttributeError, Exceptions.InvalidCallError, Exceptions.UnregisteredInstanceError,
-            Exceptions.UnexpectedPolarTypeError {
+            throws Exceptions.InvalidAttributeError,
+                Exceptions.InvalidCallError,
+                Exceptions.OsoException,
+                Exceptions.UnregisteredInstanceError,
+                Exceptions.UnexpectedPolarTypeError {
         if (calls.containsKey(callId)) {
             return;
         }

--- a/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
+++ b/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
@@ -430,13 +430,13 @@ public class PolarTest {
         assertEquals(result.get("y"), 1);
     }
 
+    /** TODO(gj): Test this when NULL is handled. */
     public void testReturnNull() throws Exception {
-        p.loadStr("f(x) if x.myReturnNull = 1;");
+        p.loadStr("f(x) if x.myReturnNull() = 1;");
         assertTrue(p.queryRule("f", new MyClass("test", 1)).results().isEmpty());
 
-        p.loadStr("f(x) if x.myReturnNull.badCall = 1;");
+        p.loadStr("f(x) if x.myReturnNull().badCall = 1;");
         assertThrows(Exceptions.PolarRuntimeException.class, () -> p.queryRule("f", new MyClass("test", 1)).results());
-
     }
 
     /*** TEST OSO ***/

--- a/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
+++ b/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
@@ -458,4 +458,42 @@ public class PolarTest {
         assertFalse(oso.isAllowed("sam", "get", http13), "Failed to correctly map HTTP resource");
     }
 
+    @Test
+    public void testNaN() throws Exception {
+      p.registerConstant("nan", Double.NaN);
+
+      List<HashMap<String, Object>> results = p.query("x = nan").results();
+      HashMap<String, Object> result = results.get(0);
+      Object x = result.get("x");
+      assertTrue(x instanceof Double);
+      Double y = (Double) x;
+      assertTrue(Double.isNaN(y));
+
+      assertTrue(p.query("nan = nan").results().isEmpty(), "NaN != NaN");
+    }
+
+    @Test
+    public void testInfinities() throws Exception {
+      p.registerConstant("inf", Double.POSITIVE_INFINITY);
+
+      List<HashMap<String, Object>> inf_results = p.query("x = inf").results();
+      HashMap<String, Object> inf_result = inf_results.get(0);
+      Object inf = inf_result.get("x");
+      assertTrue((Double) inf == Double.POSITIVE_INFINITY);
+
+      assertFalse(p.query("inf = inf").results().isEmpty(), "Infinity == Infinity");
+
+      p.registerConstant("neg_inf", Double.NEGATIVE_INFINITY);
+
+      List<HashMap<String, Object>> neg_inf_results = p.query("x = neg_inf").results();
+      HashMap<String, Object> neg_inf_result = neg_inf_results.get(0);
+      Object neg_inf = neg_inf_result.get("x");
+      assertTrue((Double) neg_inf == Double.NEGATIVE_INFINITY);
+
+      assertFalse(p.query("neg_inf = neg_inf").results().isEmpty(), "-Infinity == -Infinity");
+
+      assertTrue(p.query("inf = neg_inf").results().isEmpty(), "Infinity != -Infinity");
+      assertTrue(p.query("inf < neg_inf").results().isEmpty(), "Infinity > -Infinity");
+      assertFalse(p.query("neg_inf < inf").results().isEmpty(), "-Infinity < Infinity");
+    }
 }

--- a/languages/js/Makefile
+++ b/languages/js/Makefile
@@ -1,5 +1,8 @@
 .PHONY: wasm install clean dev build fmtcheck typecheck lint parity test
 
+build: wasm
+	yarn build
+
 wasm: clean
 	rm -f src/polar_wasm_api.js src/polar_wasm_api.d.ts src/polar_wasm_api_bg.wasm src/polar_wasm_api_bg.d.ts
 	$(MAKE) -C ../../polar-wasm-api build
@@ -15,9 +18,6 @@ clean: install
 dev: wasm
 	yarn build --watch
 
-build: wasm
-	yarn build
-
 fmt: clean
 	yarn fmt
 
@@ -29,10 +29,10 @@ typecheck: wasm
 
 lint: fmtcheck typecheck
 
-parity: wasm
+parity: build
 	yarn ts-node test/parity.ts
 
-test: wasm
+test: build
 	yarn test
 
 repl: build

--- a/languages/js/src/Host.ts
+++ b/languages/js/src/Host.ts
@@ -203,9 +203,9 @@ export class Host {
       case Number.isInteger(v):
         return { value: { Number: { Integer: v } } };
       case typeof v === 'number':
-        if (v == Infinity) {
+        if (v === Infinity) {
           v = 'Infinity';
-        } else if (v == -Infinity) {
+        } else if (v === -Infinity) {
           v = '-Infinity';
         } else if (Number.isNaN(v)) {
           v = 'NaN';
@@ -255,7 +255,9 @@ export class Host {
             return NaN;
           default:
             if (typeof f !== 'number')
-              throw new PolarError('Expected a floating point number.');
+              throw new PolarError(
+                'Expected a floating point number, got "' + f + '"'
+              );
             return f;
         }
       } else {

--- a/languages/js/src/Host.ts
+++ b/languages/js/src/Host.ts
@@ -1,5 +1,6 @@
 import {
   DuplicateClassAliasError,
+  PolarError,
   UnregisteredClassError,
   UnregisteredInstanceError,
 } from './errors';
@@ -201,7 +202,14 @@ export class Host {
         return { value: { Boolean: v } };
       case Number.isInteger(v):
         return { value: { Number: { Integer: v } } };
-      case typeof v === 'number' && Number.isFinite(v):
+      case typeof v === 'number':
+        if (v == Infinity) {
+          v = 'Infinity';
+        } else if (v == -Infinity) {
+          v = '-Infinity';
+        } else if (Number.isNaN(v)) {
+          v = 'NaN';
+        }
         return { value: { Number: { Float: v } } };
       case typeof v === 'string':
         return { value: { String: v } };
@@ -237,7 +245,19 @@ export class Host {
       return t.String;
     } else if (isPolarNum(t)) {
       if ('Float' in t.Number) {
-        return t.Number.Float;
+        const f = t.Number.Float;
+        switch (f) {
+          case 'Infinity':
+            return Infinity;
+          case '-Infinity':
+            return -Infinity;
+          case 'NaN':
+            return NaN;
+          default:
+            if (typeof f !== 'number')
+              throw new PolarError('Expected a floating point number.');
+            return f;
+        }
       } else {
         return t.Number.Integer;
       }

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -674,3 +674,28 @@ describe('unbound variables', () => {
     expect(result.get('x')).toBeInstanceOf(Variable);
   });
 });
+
+describe('±∞ and NaN', () => {
+  test('are handled properly', async () => {
+    const p = new Polar();
+    p.registerConstant('nan', NaN);
+    p.registerConstant('inf', Infinity);
+    p.registerConstant('neg_inf', -Infinity);
+
+    const nan = (await query(p, 'x = nan'))[0];
+    expect(Number.isNaN(nan.get('x'))).toBe(true);
+    expect(await query(p, 'nan = nan')).toStrictEqual([]);
+
+    const inf = (await query(p, 'x = inf'))[0];
+    expect(inf.get('x')).toEqual(Infinity);
+    expect(await query(p, 'inf = inf')).toStrictEqual([map()]);
+
+    const negInf = (await query(p, 'x = neg_inf'))[0];
+    expect(negInf.get('x')).toEqual(-Infinity);
+    expect(await query(p, 'neg_inf = neg_inf')).toStrictEqual([map()]);
+
+    expect(await query(p, 'inf = neg_inf')).toStrictEqual([]);
+    expect(await query(p, 'inf < neg_inf')).toStrictEqual([]);
+    expect(await query(p, 'neg_inf < inf')).toStrictEqual([map()]);
+  });
+});

--- a/languages/js/src/types.ts
+++ b/languages/js/src/types.ts
@@ -38,11 +38,12 @@ export function isPolarNum(v: PolarValue): v is PolarNum {
 
 /**
  * Polar floating point type.
+ * The string variant is to support ±∞ and NaN.
  *
  * @internal
  */
 interface PolarFloat {
-  Float: number;
+  Float: number | string;
 }
 
 /**

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -135,8 +135,10 @@ class Host:
         elif type(v) == int:
             val = {"Number": {"Integer": v}}
         elif type(v) == float:
-            if isinf(v):
-                v = "Infinity" if v > 0 else "-Infinity"
+            if v == inf:
+                v = "Infinity"
+            elif v == -inf:
+                v = "-Infinity"
             elif isnan(v):
                 v = "NaN"
             val = {"Number": {"Float": v}}

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -1,6 +1,6 @@
 """Translate between Polar and the host language (Python)."""
 
-from math import inf, isinf, isnan, nan
+from math import inf, isnan, nan
 
 from .exceptions import PolarApiException, PolarRuntimeException
 from .variable import Variable

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -1,5 +1,7 @@
 """Translate between Polar and the host language (Python)."""
 
+from math import inf, isinf, isnan, nan
+
 from .exceptions import PolarApiException, PolarRuntimeException
 from .variable import Variable
 from .predicate import Predicate
@@ -133,6 +135,10 @@ class Host:
         elif type(v) == int:
             val = {"Number": {"Integer": v}}
         elif type(v) == float:
+            if isinf(v):
+                v = "Infinity" if v > 0 else "-Infinity"
+            elif isnan(v):
+                v = "NaN"
             val = {"Number": {"Float": v}}
         elif type(v) == str:
             val = {"String": v}
@@ -170,7 +176,15 @@ class Host:
         if tag in ["String", "Boolean"]:
             return value[tag]
         elif tag == "Number":
-            return [*value[tag].values()][0]
+            number = [*value[tag].values()][0]
+            if "Float" in value[tag]:
+                if number == "Infinity":
+                    return inf
+                elif number == "-Infinity":
+                    return -inf
+                elif number == "NaN":
+                    return nan
+            return number
         elif tag == "List":
             return [self.to_python(e) for e in value[tag]]
         elif tag == "Dictionary":

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -189,7 +189,8 @@ class Host:
                 else:
                     if not isinstance(number, float):
                         raise PolarRuntimeException(
-                            f'Expected a floating point number, got "{number}"')
+                            f'Expected a floating point number, got "{number}"'
+                        )
             return number
         elif tag == "List":
             return [self.to_python(e) for e in value[tag]]

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -186,6 +186,10 @@ class Host:
                     return -inf
                 elif number == "NaN":
                     return nan
+                else:
+                    if not isinstance(number, float):
+                        raise PolarRuntimeException(
+                            f'Expected a floating point number, got "{number}"')
             return number
         elif tag == "List":
             return [self.to_python(e) for e in value[tag]]

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from math import inf, isnan, nan, pi
+from math import inf, isnan, nan
 from pathlib import Path
 
 from polar import polar_class

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -615,12 +615,10 @@ def test_inf_nan(polar, qeval, query):
     assert isnan(query("x = nan")[0]["x"])
     assert not query("nan = nan")
 
-    x = query("x = inf")[0]["x"]
-    assert x == inf
+    assert query("x = inf")[0]["x"] == inf
     assert qeval("inf = inf")
 
-    x = query("x = neg_inf")[0]["x"]
-    assert x == -inf
+    assert query("x = neg_inf")[0]["x"] == -inf
     assert qeval("neg_inf = neg_inf")
 
     assert not query("inf = neg_inf")

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from math import inf, isinf, isnan, nan, pi
+from math import inf, isnan, nan, pi
 from pathlib import Path
 
 from polar import polar_class
@@ -615,15 +615,17 @@ def test_inf_nan(polar, qeval, query):
     assert isnan(query("x = nan")[0]["x"])
     assert not query("nan = nan")
 
-    assert isinf(query("x = inf")[0]["x"])
+    x = query("x = inf")[0]["x"]
+    assert x == inf
     assert qeval("inf = inf")
 
     x = query("x = neg_inf")[0]["x"]
-    assert isinf(x) and x < 0
+    assert x == -inf
+    assert qeval("neg_inf = neg_inf")
+
     assert not query("inf = neg_inf")
     assert not query("inf < neg_inf")
     assert qeval("neg_inf < inf")
-    assert qeval("neg_inf = neg_inf")
 
 
 def test_register_constants_with_decorator():

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from math import pi
+from math import inf, isinf, isnan, nan, pi
 from pathlib import Path
 
 from polar import polar_class
@@ -599,12 +599,31 @@ def test_other_constants(polar, qvar, query):
     assert qvar("x = d.a", "x") == [1]
 
 
-def test_host_methods(polar, qeval, query):
+def test_host_methods(qeval):
     assert qeval('x = "abc" and x.startswith("a") = true and x.find("bc") = 1')
     assert qeval("i = 4095 and i.bit_length() = 12")
     assert qeval('f = 3.14159 and f.hex() = "0x1.921f9f01b866ep+1"')
     assert qeval("l = [1, 2, 3] and l.index(3) = 2 and l.copy() = [1, 2, 3]")
     assert qeval('d = {a: 1} and d.get("a") = 1 and d.get("b", 2) = 2')
+
+
+def test_inf_nan(polar, qeval, query):
+    polar.register_constant("inf", inf)
+    polar.register_constant("neg_inf", -inf)
+    polar.register_constant("nan", nan)
+
+    assert isnan(query("x = nan")[0]["x"])
+    assert not query("nan = nan")
+
+    assert isinf(query("x = inf")[0]["x"])
+    assert qeval("inf = inf")
+
+    x = query("x = neg_inf")[0]["x"]
+    assert isinf(x) and x < 0
+    assert not query("inf = neg_inf")
+    assert not query("inf < neg_inf")
+    assert qeval("neg_inf < inf")
+    assert qeval("neg_inf = neg_inf")
 
 
 def test_register_constants_with_decorator():

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -238,7 +238,9 @@ module Oso
             when 'NaN'
               return Float::NAN
             else
-              raise PolarRuntimeError, "Expected a floating point number, got \"#{value}\"" unless value.is_a? Float # rubocop:disable Metrics/BlockNesting
+              unless value['Float'].is_a? Float # rubocop:disable Metrics/BlockNesting
+                raise PolarRuntimeError, "Expected a floating point number, got \"#{value['Float']}\""
+              end
             end
           end
           num

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -222,7 +222,7 @@ module Oso
       # @option data [Hash<String, Object>] :value
       # @return [Object]
       # @raise [UnexpectedPolarTypeError] if type cannot be converted to Ruby.
-      def to_ruby(data) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+      def to_ruby(data) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         tag, value = data['value'].first
         case tag
         when 'String', 'Boolean'
@@ -237,6 +237,8 @@ module Oso
               return -Float::INFINITY
             when 'NaN'
               return Float::NAN
+            else
+              raise PolarRuntimeError, "Expected a floating point number, got \"#{value}\"" unless value.is_a? Float # rubocop:disable Metrics/BlockNesting
             end
           end
           num

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -727,4 +727,24 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
       expect(first['x']).to be_instance_of(Oso::Polar::Variable)
     end
   end
+
+  it 'handles ±∞ and NaN' do
+    subject.register_constant('inf', value: Float::INFINITY)
+    subject.register_constant('neg_inf', value: -Float::INFINITY)
+    subject.register_constant('nan', value: Float::NAN)
+
+    x = qvar(subject, 'x = nan', 'x', one: true)
+    expect(x.nan?).to be true
+    expect(query(subject, 'nan = nan')).to eq([])
+
+    expect(qvar(subject, 'x = inf', 'x', one: true)).to eq(Float::INFINITY)
+    expect(query(subject, 'inf = inf')).to eq([{}])
+
+    expect(qvar(subject, 'x = neg_inf', 'x', one: true)).to eq(-Float::INFINITY)
+    expect(query(subject, 'neg_inf = neg_inf')).to eq([{}])
+
+    expect(query(subject, 'inf = neg_inf')).to eq([])
+    expect(query(subject, 'inf < neg_inf')).to eq([])
+    expect(query(subject, 'neg_inf < inf')).to eq([{}])
+  end
 end

--- a/polar-core/src/numerics.rs
+++ b/polar-core/src/numerics.rs
@@ -27,7 +27,11 @@ where
     match f.classify() {
         FpCategory::Zero => s.serialize_f64(*f),
         FpCategory::Nan => s.serialize_str("NaN"),
-        FpCategory::Infinite => s.serialize_str(if *f > 0.0 { "Infinity" } else { "-Infinity" }),
+        FpCategory::Infinite => s.serialize_str(if *f == f64::INFINITY {
+            "Infinity"
+        } else {
+            "-Infinity"
+        }),
         FpCategory::Subnormal | FpCategory::Normal => s.serialize_f64(*f),
     }
 }

--- a/polar-core/src/numerics.rs
+++ b/polar-core/src/numerics.rs
@@ -25,14 +25,13 @@ where
     S: Serializer,
 {
     match f.classify() {
-        FpCategory::Zero => s.serialize_f64(*f),
         FpCategory::Nan => s.serialize_str("NaN"),
         FpCategory::Infinite => s.serialize_str(if *f == f64::INFINITY {
             "Infinity"
         } else {
             "-Infinity"
         }),
-        FpCategory::Subnormal | FpCategory::Normal => s.serialize_f64(*f),
+        FpCategory::Zero | FpCategory::Subnormal | FpCategory::Normal => s.serialize_f64(*f),
     }
 }
 


### PR DESCRIPTION
JSON does not directly support ±∞ or NaN, so we encode them as the strings `Infinity`, `-Infinity`, and `NaN`.