### PR TITLE
Don't translate errors that shouldn't ever occur into query failures

### DIFF
--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -120,8 +120,8 @@ public class Host implements Cloneable {
 
   /** Check if a class specializer is more specific than another class specializer. */
   public boolean subspecializer(long instanceId, String leftTag, String rightTag)
-      throws Exceptions.UnregisteredClassError {
-    Object instance = instances.get(instanceId);
+      throws Exceptions.UnregisteredClassError, Exceptions.UnregisteredInstanceError {
+    Object instance = getInstance(instanceId);
     Class<?> cls, leftClass, rightClass;
     cls = instance.getClass();
     leftClass = getClass(leftTag);

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -79,20 +79,14 @@ class Host:
 
     def unify(self, left_instance_id, right_instance_id) -> bool:
         """Return true if the left instance is equal to the right."""
-        try:
-            left = self.get_instance(left_instance_id)
-            right = self.get_instance(right_instance_id)
-            return left == right
-        except PolarRuntimeException:
-            return False
+        left = self.get_instance(left_instance_id)
+        right = self.get_instance(right_instance_id)
+        return left == right
 
     def isa(self, instance, class_tag) -> bool:
-        try:
-            instance = self.to_python(instance)
-            cls = self.get_class(class_tag)
-            return isinstance(instance, cls)
-        except PolarRuntimeException:
-            return False
+        instance = self.to_python(instance)
+        cls = self.get_class(class_tag)
+        return isinstance(instance, cls)
 
     def is_subspecializer(self, instance_id, left_tag, right_tag) -> bool:
         """Return true if the left class is more specific than the right class
@@ -102,7 +96,7 @@ class Host:
             left = self.get_class(left_tag)
             right = self.get_class(right_tag)
             return mro.index(left) < mro.index(right)
-        except (ValueError, PolarRuntimeException):
+        except ValueError:
             return False
 
     def operator(self, op, args):

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -146,9 +146,9 @@ module Oso
       # @return [Boolean]
       def subspecializer?(instance_id, left_tag:, right_tag:)
         mro = get_instance(instance_id).class.ancestors
-        mro.index(get_class(left_tag)) < mro.index(get_class(right_tag))
-      rescue StandardError
-        false
+        left_index = mro.index(get_class(left_tag))
+        right_index = mro.index(get_class(right_tag))
+        left_index && right_index && left_index < right_index
       end
 
       # Check if instance is an instance of class.
@@ -160,8 +160,6 @@ module Oso
         instance = to_ruby(instance)
         cls = get_class(class_tag)
         instance.is_a? cls
-      rescue PolarRuntimeError
-        false
       end
 
       # Check if two instances unify
@@ -173,8 +171,6 @@ module Oso
         left_instance = get_instance(left_instance_id)
         right_instance = get_instance(right_instance_id)
         left_instance == right_instance
-      rescue PolarRuntimeError
-        false
       end
 
       # Turn a Ruby value into a Polar term that's ready to be sent across the


### PR DESCRIPTION
Don't translate errors that _shouldn't_ ever occur into query failures; let them propagate.