### PR TITLE
Proof of concept: scope helpers for django.

### DIFF
--- a/languages/python/django-oso/django_oso/manager.py
+++ b/languages/python/django-oso/django_oso/manager.py
@@ -1,0 +1,41 @@
+import threading
+from django.db import models
+from django.db.models import Q
+
+from .oso import Oso
+from oso import Variable
+
+
+class OsoManager(models.Manager):
+    _requests = {}
+
+    @classmethod
+    def get_request(cls, default=None):
+        """
+        Retrieve the request object for the current thread, or the optionally
+        provided default if there is no current request.
+        """
+        return cls._requests.get(threading.current_thread(), default)
+
+    @classmethod
+    def set_request(cls, request):
+        """
+        Save the given request into storage for the current thread.
+        """
+        cls._requests[threading.current_thread()] = request
+
+    @classmethod
+    def del_request(cls):
+        """
+        Delete the request that was stored for the current thread.
+        """
+        cls._requests.pop(threading.current_thread(), None)
+
+    def get_queryset(self):
+        request = OsoManager.get_request()
+        filter = Q()
+        for result in Oso.query_rule(
+            "allow_scope", request.user, request.method, self.model, Variable("scope")
+        ):
+            filter |= result["bindings"]["scope"]
+        return super().get_queryset().filter(filter)

--- a/languages/python/django-oso/django_oso/oso.py
+++ b/languages/python/django-oso/django_oso/oso.py
@@ -1,6 +1,7 @@
 import os.path
 
 from django.apps import AppConfig, apps
+from django.db.models import Q
 from django.http import HttpRequest
 from django.utils.autoreload import autoreload_started
 
@@ -19,8 +20,8 @@ def reset_oso():
     Useful as a test helper to clean state between tests, but generally should
     not be used otherwise.
     """
-    Oso.clear()
-    init_oso()
+    # Oso.clear()
+    # init_oso()
 
 
 def init_oso():
@@ -39,6 +40,9 @@ def init_oso():
 
     # Register request
     Oso.register_class(HttpRequest)
+
+    # Register query object
+    Oso.register_class(Q)
 
     loaded_files = []
 

--- a/languages/python/django-oso/tests/conftest.py
+++ b/languages/python/django-oso/tests/conftest.py
@@ -10,6 +10,12 @@ def pytest_configure():
     sys.path.append(test_app.as_posix())
 
     settings.configure(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": "mydatabase",
+            }
+        },
         INSTALLED_APPS=[
             "test_app",
             "django_oso",

--- a/languages/python/django-oso/tests/test_app/models.py
+++ b/languages/python/django-oso/tests/test_app/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django_oso.manager import OsoManager
 
 
 class TestRegistration(models.Model):
@@ -7,5 +8,16 @@ class TestRegistration(models.Model):
 
 
 class TestRegistration2(models.Model):
+    class Meta:
+        app_label = "test_app"
+
+
+class TestScope(models.Model):
+    public = models.BooleanField()
+    user = models.CharField(max_length=256)
+
+    objects = models.Manager()
+    authorized_objects = OsoManager()
+
     class Meta:
         app_label = "test_app"

--- a/languages/python/django-oso/tests/test_app/policy/test3.polar
+++ b/languages/python/django-oso/tests/test_app/policy/test3.polar
@@ -1,6 +1,4 @@
 policy_load_test(3);
 
-allow_scope(user, _, test_app::TestScope, filter) if
-    filter = new Q(user: user);
-allow_scope(_, "GET", test_app::TestScope, filter) if
-    filter = new Q(public: true);
+allow_scope(user, _, test_app::TestScope, new Q(user: user));
+allow_scope(_, "GET", test_app::TestScope, new Q(public: true));

--- a/languages/python/django-oso/tests/test_app/policy/test3.polar
+++ b/languages/python/django-oso/tests/test_app/policy/test3.polar
@@ -1,0 +1,6 @@
+policy_load_test(3);
+
+allow_scope(user, _, test_app::TestScope, filter) if
+    filter = new Q(user: user);
+allow_scope(_, "GET", test_app::TestScope, filter) if
+    filter = new Q(public: true);


### PR DESCRIPTION
Making filters easier to use with django: create an `OsoManager` that runs approved filters on the object set.

This works fairly well with the Django `Q` class. But an alternative would be to return strings, and have the user provided a dictionary from filter name to the filter operation (a lambda on the recordset?)

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
