### PR TITLE
Rust result and option method calls

### DIFF
--- a/languages/rust/oso/src/host/class.rs
+++ b/languages/rust/oso/src/host/class.rs
@@ -5,10 +5,9 @@ use polar_core::terms::{Symbol, Term};
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::fmt;
-use std::fmt::Debug;
 use std::sync::Arc;
 
-use crate::{FromPolar, ToPolar};
+use crate::FromPolar;
 
 use super::class_method::{ClassMethod, Constructor, InstanceMethod};
 use super::method::{Function, Method};

--- a/languages/rust/oso/src/host/class.rs
+++ b/languages/rust/oso/src/host/class.rs
@@ -5,6 +5,7 @@ use polar_core::terms::{Symbol, Term};
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::fmt;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::{FromPolar, ToPolar};
@@ -127,6 +128,19 @@ impl<T> Class<T> {
     {
         self.instance_methods
             .insert(Symbol(name.to_string()), InstanceMethod::new(f));
+        self
+    }
+
+    pub fn add_result_method<F, Args, R, E>(mut self, name: &str, f: F) -> Self
+    where
+        Args: FromPolar,
+        F: Method<T, Args, Result = Result<R, E>> + 'static,
+        R: ToPolar + 'static,
+        E: Debug + 'static,
+        T: 'static,
+    {
+        self.instance_methods
+            .insert(Symbol(name.to_string()), InstanceMethod::new_result(f));
         self
     }
 

--- a/languages/rust/oso/src/host/class.rs
+++ b/languages/rust/oso/src/host/class.rs
@@ -12,6 +12,7 @@ use crate::{FromPolar, ToPolar};
 
 use super::class_method::{ClassMethod, Constructor, InstanceMethod};
 use super::method::{Function, Method};
+use super::to_polar::ToPolarIter;
 use super::Host;
 
 type ClassMethods = HashMap<Symbol, ClassMethod>;
@@ -106,7 +107,7 @@ impl<T> Class<T> {
     pub fn add_attribute_getter<F, R>(mut self, name: &str, f: F) -> Self
     where
         F: Method<T, Result = R> + 'static,
-        R: ToPolar + 'static,
+        R: ToPolarIter + 'static,
         T: 'static,
     {
         self.attributes
@@ -123,7 +124,7 @@ impl<T> Class<T> {
     where
         Args: FromPolar,
         F: Method<T, Args, Result = R> + 'static,
-        R: ToPolar + 'static,
+        R: ToPolarIter + 'static,
         T: 'static,
     {
         self.instance_methods
@@ -131,36 +132,36 @@ impl<T> Class<T> {
         self
     }
 
-    pub fn add_result_method<F, Args, R, E>(mut self, name: &str, f: F) -> Self
-    where
-        Args: FromPolar,
-        F: Method<T, Args, Result = Result<R, E>> + 'static,
-        R: ToPolar + 'static,
-        E: Debug + 'static,
-        T: 'static,
-    {
-        self.instance_methods
-            .insert(Symbol(name.to_string()), InstanceMethod::new_result(f));
-        self
-    }
+    // pub fn add_result_method<F, Args, R, E>(mut self, name: &str, f: F) -> Self
+    // where
+    //     Args: FromPolar,
+    //     F: Method<T, Args, Result = Result<R, E>> + 'static,
+    //     R: ToPolar + 'static,
+    //     E: Debug + 'static,
+    //     T: 'static,
+    // {
+    //     self.instance_methods
+    //         .insert(Symbol(name.to_string()), InstanceMethod::new_result(f));
+    //     self
+    // }
 
-    pub fn add_option_method<F, Args, R>(mut self, name: &str, f: F) -> Self
-    where
-        Args: FromPolar,
-        F: Method<T, Args, Result = Option<R>> + 'static,
-        R: ToPolar + 'static,
-        T: 'static,
-    {
-        self.instance_methods
-            .insert(Symbol(name.to_string()), InstanceMethod::new_option(f));
-        self
-    }
+    // pub fn add_option_method<F, Args, R>(mut self, name: &str, f: F) -> Self
+    // where
+    //     Args: FromPolar,
+    //     F: Method<T, Args, Result = Option<R>> + 'static,
+    //     R: ToPolar + 'static,
+    //     T: 'static,
+    // {
+    //     self.instance_methods
+    //         .insert(Symbol(name.to_string()), InstanceMethod::new_option(f));
+    //     self
+    // }
 
     pub fn add_class_method<F, Args, R>(mut self, name: &str, f: F) -> Self
     where
         F: Function<Args, Result = R> + 'static,
         Args: FromPolar + 'static,
-        R: ToPolar + 'static,
+        R: ToPolarIter + 'static,
     {
         self.class_methods
             .insert(Symbol(name.to_string()), ClassMethod::new(f));

--- a/languages/rust/oso/src/host/class.rs
+++ b/languages/rust/oso/src/host/class.rs
@@ -144,6 +144,18 @@ impl<T> Class<T> {
         self
     }
 
+    pub fn add_option_method<F, Args, R>(mut self, name: &str, f: F) -> Self
+    where
+        Args: FromPolar,
+        F: Method<T, Args, Result = Option<R>> + 'static,
+        R: ToPolar + 'static,
+        T: 'static,
+    {
+        self.instance_methods
+            .insert(Symbol(name.to_string()), InstanceMethod::new_option(f));
+        self
+    }
+
     pub fn add_class_method<F, Args, R>(mut self, name: &str, f: F) -> Self
     where
         F: Function<Args, Result = R> + 'static,

--- a/languages/rust/oso/src/host/class.rs
+++ b/languages/rust/oso/src/host/class.rs
@@ -132,31 +132,6 @@ impl<T> Class<T> {
         self
     }
 
-    // pub fn add_result_method<F, Args, R, E>(mut self, name: &str, f: F) -> Self
-    // where
-    //     Args: FromPolar,
-    //     F: Method<T, Args, Result = Result<R, E>> + 'static,
-    //     R: ToPolar + 'static,
-    //     E: Debug + 'static,
-    //     T: 'static,
-    // {
-    //     self.instance_methods
-    //         .insert(Symbol(name.to_string()), InstanceMethod::new_result(f));
-    //     self
-    // }
-
-    // pub fn add_option_method<F, Args, R>(mut self, name: &str, f: F) -> Self
-    // where
-    //     Args: FromPolar,
-    //     F: Method<T, Args, Result = Option<R>> + 'static,
-    //     R: ToPolar + 'static,
-    //     T: 'static,
-    // {
-    //     self.instance_methods
-    //         .insert(Symbol(name.to_string()), InstanceMethod::new_option(f));
-    //     self
-    // }
-
     pub fn add_class_method<F, Args, R>(mut self, name: &str, f: F) -> Self
     where
         F: Function<Args, Result = R> + 'static,

--- a/languages/rust/oso/src/host/class_method.rs
+++ b/languages/rust/oso/src/host/class_method.rs
@@ -65,60 +65,6 @@ impl InstanceMethod {
         ))
     }
 
-    // pub fn new_result<T, F, Args, R, E>(f: F) -> Self
-    // where
-    //     Args: FromPolar,
-    //     F: Method<T, Args, Result = Result<R, E>> + 'static,
-    //     R: ToPolarIter + 'static,
-    //     E: Debug + 'static,
-    //     T: 'static,
-    // {
-    //     Self(Arc::new(
-    //         move |receiver: &dyn Any, args: Vec<Term>, host: &mut Host| {
-    //             let receiver = receiver
-    //                 .downcast_ref()
-    //                 .ok_or_else(|| crate::OsoError::InvalidReceiver);
-
-    //             let args = Args::from_polar_list(&args, host);
-
-    //             join(receiver, args).and_then(|(receiver, args)| match f.invoke(receiver, args) {
-    //                 Ok(result) => Ok(Arc::new(result) as Arc<dyn ToPolar>),
-    //                 Err(e) => Err(crate::OsoError::Custom {
-    //                     message: format!("Error calling function: {:?}", e),
-    //                 }),
-    //             })
-    //         },
-    //     ))
-    // }
-
-    // pub fn new_option<T, F, Args, R>(f: F) -> Self
-    // where
-    //     Args: FromPolar,
-    //     F: Method<T, Args, Result = Option<R>> + 'static,
-    //     R: ToPolarIter + 'static,
-    //     T: 'static,
-    // {
-    //     Self(Arc::new(
-    //         move |receiver: &dyn Any, args: Vec<Term>, host: &mut Host| {
-    //             let receiver = receiver
-    //                 .downcast_ref()
-    //                 .ok_or_else(|| crate::OsoError::InvalidReceiver);
-
-    //             let args = Args::from_polar_list(&args, host);
-
-    //             join(receiver, args).and_then(|(receiver, args)| match f.invoke(receiver, args) {
-    //                 Some(result) => Ok(Arc::new(result) as Arc<dyn ToPolar>),
-    //                 // @TODO: We want to actually return 0 results.
-    //                 // I think returning an empty iterator would be the easiest way to accomplish that but
-    //                 // we haven't implemented those yet.
-    //                 None => Err(crate::OsoError::Custom {
-    //                     message: "Error calling function, got None".to_owned(),
-    //                 }),
-    //             })
-    //         },
-    //     ))
-    // }
-
     pub fn invoke(
         &self,
         receiver: &dyn Any,

--- a/languages/rust/oso/src/host/class_method.rs
+++ b/languages/rust/oso/src/host/class_method.rs
@@ -2,11 +2,10 @@
 use polar_core::terms::{Symbol, Term};
 
 use std::any::Any;
-use std::fmt::Debug;
 use std::sync::Arc;
 
 use super::to_polar::ToPolarIter;
-use crate::{FromPolar, ToPolar};
+use crate::FromPolar;
 
 use super::class::Class;
 use super::method::{Function, Method};

--- a/languages/rust/oso/src/host/class_method.rs
+++ b/languages/rust/oso/src/host/class_method.rs
@@ -5,6 +5,7 @@ use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use super::to_polar::ToPolarIter;
 use crate::{FromPolar, ToPolar};
 
 use super::class::Class;
@@ -39,14 +40,14 @@ impl Constructor {
 }
 
 #[derive(Clone)]
-pub struct InstanceMethod(TypeErasedMethod<dyn ToPolar>);
+pub struct InstanceMethod(TypeErasedMethod<dyn ToPolarIter>);
 
 impl InstanceMethod {
     pub fn new<T, F, Args>(f: F) -> Self
     where
         Args: FromPolar,
         F: Method<T, Args> + 'static,
-        F::Result: ToPolar + 'static,
+        F::Result: ToPolarIter + 'static,
         T: 'static,
     {
         Self(Arc::new(
@@ -57,72 +58,73 @@ impl InstanceMethod {
 
                 let args = Args::from_polar_list(&args, host);
 
-                join(receiver, args)
-                    .map(|(receiver, args)| Arc::new(f.invoke(receiver, args)) as Arc<dyn ToPolar>)
-            },
-        ))
-    }
-
-    pub fn new_result<T, F, Args, R, E>(f: F) -> Self
-    where
-        Args: FromPolar,
-        F: Method<T, Args, Result = Result<R, E>> + 'static,
-        R: ToPolar + 'static,
-        E: Debug + 'static,
-        T: 'static,
-    {
-        Self(Arc::new(
-            move |receiver: &dyn Any, args: Vec<Term>, host: &mut Host| {
-                let receiver = receiver
-                    .downcast_ref()
-                    .ok_or_else(|| crate::OsoError::InvalidReceiver);
-
-                let args = Args::from_polar_list(&args, host);
-
-                join(receiver, args).and_then(|(receiver, args)| match f.invoke(receiver, args) {
-                    Ok(result) => Ok(Arc::new(result) as Arc<dyn ToPolar>),
-                    Err(e) => Err(crate::OsoError::Custom {
-                        message: format!("Error calling function: {:?}", e),
-                    }),
+                join(receiver, args).map(|(receiver, args)| {
+                    Arc::new(f.invoke(receiver, args)) as Arc<dyn ToPolarIter>
                 })
             },
         ))
     }
 
-    pub fn new_option<T, F, Args, R>(f: F) -> Self
-    where
-        Args: FromPolar,
-        F: Method<T, Args, Result = Option<R>> + 'static,
-        R: ToPolar + 'static,
-        T: 'static,
-    {
-        Self(Arc::new(
-            move |receiver: &dyn Any, args: Vec<Term>, host: &mut Host| {
-                let receiver = receiver
-                    .downcast_ref()
-                    .ok_or_else(|| crate::OsoError::InvalidReceiver);
+    // pub fn new_result<T, F, Args, R, E>(f: F) -> Self
+    // where
+    //     Args: FromPolar,
+    //     F: Method<T, Args, Result = Result<R, E>> + 'static,
+    //     R: ToPolarIter + 'static,
+    //     E: Debug + 'static,
+    //     T: 'static,
+    // {
+    //     Self(Arc::new(
+    //         move |receiver: &dyn Any, args: Vec<Term>, host: &mut Host| {
+    //             let receiver = receiver
+    //                 .downcast_ref()
+    //                 .ok_or_else(|| crate::OsoError::InvalidReceiver);
 
-                let args = Args::from_polar_list(&args, host);
+    //             let args = Args::from_polar_list(&args, host);
 
-                join(receiver, args).and_then(|(receiver, args)| match f.invoke(receiver, args) {
-                    Some(result) => Ok(Arc::new(result) as Arc<dyn ToPolar>),
-                    // @TODO: We want to actually return 0 results.
-                    // I think returning an empty iterator would be the easiest way to accomplish that but
-                    // we haven't implemented those yet.
-                    None => Err(crate::OsoError::Custom {
-                        message: "Error calling function, got None".to_owned(),
-                    }),
-                })
-            },
-        ))
-    }
+    //             join(receiver, args).and_then(|(receiver, args)| match f.invoke(receiver, args) {
+    //                 Ok(result) => Ok(Arc::new(result) as Arc<dyn ToPolar>),
+    //                 Err(e) => Err(crate::OsoError::Custom {
+    //                     message: format!("Error calling function: {:?}", e),
+    //                 }),
+    //             })
+    //         },
+    //     ))
+    // }
+
+    // pub fn new_option<T, F, Args, R>(f: F) -> Self
+    // where
+    //     Args: FromPolar,
+    //     F: Method<T, Args, Result = Option<R>> + 'static,
+    //     R: ToPolarIter + 'static,
+    //     T: 'static,
+    // {
+    //     Self(Arc::new(
+    //         move |receiver: &dyn Any, args: Vec<Term>, host: &mut Host| {
+    //             let receiver = receiver
+    //                 .downcast_ref()
+    //                 .ok_or_else(|| crate::OsoError::InvalidReceiver);
+
+    //             let args = Args::from_polar_list(&args, host);
+
+    //             join(receiver, args).and_then(|(receiver, args)| match f.invoke(receiver, args) {
+    //                 Some(result) => Ok(Arc::new(result) as Arc<dyn ToPolar>),
+    //                 // @TODO: We want to actually return 0 results.
+    //                 // I think returning an empty iterator would be the easiest way to accomplish that but
+    //                 // we haven't implemented those yet.
+    //                 None => Err(crate::OsoError::Custom {
+    //                     message: "Error calling function, got None".to_owned(),
+    //                 }),
+    //             })
+    //         },
+    //     ))
+    // }
 
     pub fn invoke(
         &self,
         receiver: &dyn Any,
         args: Vec<Term>,
         host: &mut Host,
-    ) -> crate::Result<Arc<dyn ToPolar>> {
+    ) -> crate::Result<Arc<dyn ToPolarIter>> {
         self.0(receiver, args, host)
     }
 
@@ -146,22 +148,22 @@ impl InstanceMethod {
 }
 
 #[derive(Clone)]
-pub struct ClassMethod(TypeErasedFunction<dyn ToPolar>);
+pub struct ClassMethod(TypeErasedFunction<dyn ToPolarIter>);
 
 impl ClassMethod {
     pub fn new<F, Args>(f: F) -> Self
     where
         Args: FromPolar,
         F: Function<Args> + 'static,
-        F::Result: ToPolar + 'static,
+        F::Result: ToPolarIter + 'static,
     {
         Self(Arc::new(move |args: Vec<Term>, host: &mut Host| {
             Args::from_polar_list(&args, host)
-                .map(|args| Arc::new(f.invoke(args)) as Arc<dyn ToPolar>)
+                .map(|args| Arc::new(f.invoke(args)) as Arc<dyn ToPolarIter>)
         }))
     }
 
-    pub fn invoke(&self, args: Vec<Term>, host: &mut Host) -> crate::Result<Arc<dyn ToPolar>> {
+    pub fn invoke(&self, args: Vec<Term>, host: &mut Host) -> crate::Result<Arc<dyn ToPolarIter>> {
         self.0(args, host)
     }
 }

--- a/languages/rust/oso/src/host/class_method.rs
+++ b/languages/rust/oso/src/host/class_method.rs
@@ -89,6 +89,34 @@ impl InstanceMethod {
         ))
     }
 
+    pub fn new_option<T, F, Args, R>(f: F) -> Self
+    where
+        Args: FromPolar,
+        F: Method<T, Args, Result = Option<R>> + 'static,
+        R: ToPolar + 'static,
+        T: 'static,
+    {
+        Self(Arc::new(
+            move |receiver: &dyn Any, args: Vec<Term>, host: &mut Host| {
+                let receiver = receiver
+                    .downcast_ref()
+                    .ok_or_else(|| crate::OsoError::InvalidReceiver);
+
+                let args = Args::from_polar_list(&args, host);
+
+                join(receiver, args).and_then(|(receiver, args)| match f.invoke(receiver, args) {
+                    Some(result) => Ok(Arc::new(result) as Arc<dyn ToPolar>),
+                    // @TODO: We want to actually return 0 results.
+                    // I think returning an empty iterator would be the easiest way to accomplish that but
+                    // we haven't implemented those yet.
+                    None => Err(crate::OsoError::Custom {
+                        message: "Error calling function, got None".to_owned(),
+                    }),
+                })
+            },
+        ))
+    }
+
     pub fn invoke(
         &self,
         receiver: &dyn Any,

--- a/languages/rust/oso/src/host/mod.rs
+++ b/languages/rust/oso/src/host/mod.rs
@@ -13,7 +13,7 @@ mod to_polar;
 
 pub use class::{Class, Instance};
 pub use from_polar::FromPolar;
-pub use to_polar::ToPolar;
+pub use to_polar::{PolarIter, ToPolar};
 
 /// The meta class - the class of all classess (except itself)
 #[derive(Clone, Default)]

--- a/languages/rust/oso/src/host/to_polar.rs
+++ b/languages/rust/oso/src/host/to_polar.rs
@@ -143,3 +143,15 @@ impl<C: 'static + Clone + super::HostClass> ToPolar for C {
         })
     }
 }
+
+use std::iter;
+
+pub trait ToPolarIter {
+    fn to_polar_iter(&self) -> Box<dyn Iterator<Item = Box<dyn ToPolar>>>;
+}
+
+impl<C: 'static + Sized + Clone + ToPolar> ToPolarIter for C {
+    fn to_polar_iter(&self) -> Box<dyn Iterator<Item = Box<dyn ToPolar>>> {
+        Box::new(iter::once(Box::new(self.clone()) as Box<dyn ToPolar>))
+    }
+}

--- a/languages/rust/oso/src/query.rs
+++ b/languages/rust/oso/src/query.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use crate::host::Instance;
+use crate::host::{Instance, PolarIter};
 use crate::{FromPolar, ToPolar};
 
 use polar_core::events::*;
@@ -16,10 +16,7 @@ impl Iterator for Query {
 
 pub struct Query {
     inner: polar_core::polar::Query,
-    calls: HashMap<
-        u64,
-        Box<dyn Iterator<Item = Result<Box<dyn crate::host::ToPolar>, crate::OsoError>>>,
-    >,
+    calls: HashMap<u64, PolarIter>,
     host: Arc<Mutex<crate::host::Host>>,
 }
 
@@ -176,7 +173,7 @@ impl Query {
                 Ok(r) => self.call_result(call_id, r),
                 Err(e) => {
                     self.application_error(e);
-                    return self.call_result_none(call_id);
+                    self.call_result_none(call_id)
                 }
             }
         } else {

--- a/languages/rust/oso/tests/test_polar.rs
+++ b/languages/rust/oso/tests/test_polar.rs
@@ -421,10 +421,10 @@ fn test_results_and_options() {
         .register_class(
             Foo::get_polar_class_builder()
                 .set_constructor(Foo::new)
-                .add_result_method("ok", |recv: &Foo| recv.ok())
-                .add_result_method("err", |recv: &Foo| recv.err())
-                .add_option_method("some", |recv: &Foo| recv.some())
-                .add_option_method("none", |recv: &Foo| recv.none())
+                .add_method("ok", |recv: &Foo| recv.ok())
+                .add_method("err", |recv: &Foo| recv.err())
+                .add_method("some", |recv: &Foo| recv.some())
+                .add_method("none", |recv: &Foo| recv.none())
                 .build(),
         )
         .unwrap();
@@ -432,5 +432,6 @@ fn test_results_and_options() {
     test.qvar_one(r#"new Foo().ok() = x"#, "x", 1);
     test.query_err("new Foo().err()");
     test.qvar_one(r#"new Foo().some() = x"#, "x", 1);
-    test.query_err("new Foo().none()");
+    let results = test.query("new Foo().none()");
+    assert!(results.is_empty());
 }

--- a/languages/rust/oso/tests/test_polar.rs
+++ b/languages/rust/oso/tests/test_polar.rs
@@ -386,3 +386,39 @@ fn test_tuple_structs() {
 
     test.qvar_one(r#"foo = new Foo(1,2) and foo.i0 + foo.i1 = x"#, "x", 3);
 }
+
+#[test]
+fn test_results() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    #[derive(PolarClass)]
+    struct Foo;
+
+    impl Foo {
+        fn new() -> Self {
+            Self
+        }
+
+        fn good_result_int(&self) -> Result<i32, String> {
+            Ok(1)
+        }
+
+        fn bad_result_int(&self) -> Result<i32, &'static str> {
+            Err("Some sort of error")
+        }
+    }
+
+    let mut test = OsoTest::new();
+    test.oso
+        .register_class(
+            Foo::get_polar_class_builder()
+                .set_constructor(Foo::new)
+                .add_result_method("ok", |recv: &Foo| recv.good_result_int())
+                .add_result_method("err", |recv: &Foo| recv.bad_result_int())
+                .build(),
+        )
+        .unwrap();
+
+    test.qvar_one(r#"new Foo().ok() = x"#, "x", 1);
+    test.query_err("new Foo().err()");
+}

--- a/languages/rust/oso/tests/test_polar.rs
+++ b/languages/rust/oso/tests/test_polar.rs
@@ -421,10 +421,10 @@ fn test_results_and_options() {
         .register_class(
             Foo::get_polar_class_builder()
                 .set_constructor(Foo::new)
-                .add_method("ok", |recv: &Foo| recv.ok())
-                .add_method("err", |recv: &Foo| recv.err())
-                .add_method("some", |recv: &Foo| recv.some())
-                .add_method("none", |recv: &Foo| recv.none())
+                .add_method("ok", Foo::ok)
+                .add_method("err", Foo::err)
+                .add_method("some", Foo::some)
+                .add_method("none", Foo::none)
                 .build(),
         )
         .unwrap();

--- a/languages/rust/oso/tests/test_polar.rs
+++ b/languages/rust/oso/tests/test_polar.rs
@@ -388,7 +388,7 @@ fn test_tuple_structs() {
 }
 
 #[test]
-fn test_results() {
+fn test_results_and_options() {
     let _ = tracing_subscriber::fmt::try_init();
 
     #[derive(PolarClass)]
@@ -399,12 +399,20 @@ fn test_results() {
             Self
         }
 
-        fn good_result_int(&self) -> Result<i32, String> {
+        fn ok(&self) -> Result<i32, String> {
             Ok(1)
         }
 
-        fn bad_result_int(&self) -> Result<i32, &'static str> {
+        fn err(&self) -> Result<i32, &'static str> {
             Err("Some sort of error")
+        }
+
+        fn some(&self) -> Option<i32> {
+            Some(1)
+        }
+
+        fn none(&self) -> Option<i32> {
+            None
         }
     }
 
@@ -413,12 +421,16 @@ fn test_results() {
         .register_class(
             Foo::get_polar_class_builder()
                 .set_constructor(Foo::new)
-                .add_result_method("ok", |recv: &Foo| recv.good_result_int())
-                .add_result_method("err", |recv: &Foo| recv.bad_result_int())
+                .add_result_method("ok", |recv: &Foo| recv.ok())
+                .add_result_method("err", |recv: &Foo| recv.err())
+                .add_option_method("some", |recv: &Foo| recv.some())
+                .add_option_method("none", |recv: &Foo| recv.none())
                 .build(),
         )
         .unwrap();
 
     test.qvar_one(r#"new Foo().ok() = x"#, "x", 1);
     test.query_err("new Foo().err()");
+    test.qvar_one(r#"new Foo().some() = x"#, "x", 1);
+    test.query_err("new Foo().none()");
 }


### PR DESCRIPTION
Errors if the result is Err, returns the value if it's Ok

I did it in calling the method rather than just implementing `ToPolar` for `Result<x,y>`. Doing it by implementing `ToPolar` would work fine in this case (returning the value on success and erring on error) but it wouldn't work for the `Option` case. In the `Option` case I think we want to return the value if it's Some and not return anything if it's None. By the time we get to serialization it's too late for that.

The option case works like the result case right now and throws an error if it's `None`. I don't think that's correct though, it should probably return nothing if it's a None. I think the easiest way to do that would just be return an empty iterator but we don't have those yet.