### PR TITLE
Fix Python quickstart line numbers

### DIFF
--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -120,7 +120,7 @@ arguments, **actor**, **action**, and **resource**:
 
     .. literalinclude:: /examples/quickstart/python/allow-01.py
       :language: python
-      :lines: 11-13
+      :lines: 12-14
 
   .. group-tab:: Ruby
 


### PR DESCRIPTION
Added a line to the relevant file in #401 but didn't bump these line numbers