### PR TITLE
Log messages from polar-core using log crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
+ "log",
  "maplit",
  "permute",
  "pipe",

--- a/polar-core/Cargo.toml
+++ b/polar-core/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.4.0"
 regex = "1.3.7"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
+log = "0.4.11"
 
 [build_dependencies]
 lalrpop = { version = "0.18.1", features = ["lexer"] }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -4,6 +4,8 @@ use std::rc::Rc;
 use std::string::ToString;
 use std::sync::{Arc, RwLock};
 
+use ::log::trace;
+
 use super::debugger::{DebugEvent, Debugger};
 use super::error::{self, PolarResult};
 use super::events::*;
@@ -690,8 +692,10 @@ impl PolarVirtualMachine {
     }
 
     /// Print a message to the output stream.
-    fn print(&self, message: &str) {
-        self.messages.push(MessageKind::Print, message.to_owned());
+    fn print<S: Into<String>>(&self, message: S) {
+        let message = message.into();
+        trace!("{}", &message);
+        self.messages.push(MessageKind::Print, message);
     }
 
     fn log(&self, message: &str, terms: &[&Term]) {
@@ -723,10 +727,9 @@ impl PolarVirtualMachine {
                             .join(", ")
                     ));
                 }
-                self.messages.push(MessageKind::Print, msg);
+                self.print(msg);
                 for line in &lines[1..] {
-                    self.messages
-                        .push(MessageKind::Print, format!("[debug] {}{}", &indent, line));
+                    self.print(format!("[debug] {}{}", &indent, line));
                 }
             }
         }


### PR DESCRIPTION
This is enough to get logs in the rust library tests since we initialize the
env logger.  I haven't gone through and done that in our tests for polar-core
yet.