### PR TITLE
Rust Docs

### DIFF
--- a/docs/download.rst
+++ b/docs/download.rst
@@ -150,6 +150,39 @@ oso is available as a library in several languages:
 
         .. _NPM: https://www.npmjs.com/package/oso
 
+    .. group-tab:: Rust
+
+        The rust version of oso is available on crates.io_. 
+        
+        Add oso and oso-derive as dependencies in your Cargo.toml
+
+        .. code-block:: toml
+
+            oso = "{release}"
+            oso-derive = "{release}"
+
+        For more information on the oso Rust library, see the
+        :doc:`library documentation </using/libraries/rust/index>`.
+
+        .. admonition:: What's next
+            :class: tip
+
+            After you've installed oso, check out the
+            :doc:`/getting-started/quickstart`.
+
+        **Requirements**
+
+        - Rust stable
+        - Supported platforms:
+            - Linux
+            - OS X
+            - Windows
+
+        .. _crates.io: https://crates.io/crates/oso
+
+        
+
+
 **Libraries coming soon:**
 
 - JavaScript in the browser

--- a/docs/examples/quickstart/polar/expenses-03-rust.polar
+++ b/docs/examples/quickstart/polar/expenses-03-rust.polar
@@ -1,0 +1,2 @@
+allow(actor: String, "GET", _expense: Expense) if
+    actor.ends_with("@example.com");

--- a/docs/examples/quickstart/rust/expenses.polar
+++ b/docs/examples/quickstart/rust/expenses.polar
@@ -1,2 +1,6 @@
 allow(actor: String, "GET", expense: Expense) if
-    expense.submitted_by = actor;
+    actor.ends_with("@example.com");
+
+
+# allow(actor: String, "GET", expense: Expense) if
+#     expense.submitted_by = actor;

--- a/docs/examples/quickstart/rust/src/expenses.rs
+++ b/docs/examples/quickstart/rust/src/expenses.rs
@@ -1,4 +1,5 @@
 use lazy_static::lazy_static;
+use std::fmt;
 use std::string::ToString;
 
 use oso::*;
@@ -26,5 +27,15 @@ impl Expense {
             description: description.to_string(),
             submitted_by: submitted_by.to_string(),
         }
+    }
+}
+
+impl fmt::Display for Expense {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Expense(amount={}, description='{}', submitted_by='{}')",
+            self.amount, &self.description, &self.submitted_by
+        )
     }
 }

--- a/docs/examples/quickstart/rust/src/server.rs
+++ b/docs/examples/quickstart/rust/src/server.rs
@@ -27,7 +27,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for User {
 fn hello(oso: State<OsoState>, user: User, id: usize) -> Result<Option<String>, Status> {
     if let Some(expense) = EXPENSES.get(id) {
         if oso.is_allowed(user.0, "GET", expense.clone()) {
-            Ok(Some(format!("{:?}", expense)))
+            Ok(Some(format!("{}", expense)))
         } else {
             Err(Status::Unauthorized)
         }

--- a/docs/getting-started/policies/application-types.rst
+++ b/docs/getting-started/policies/application-types.rst
@@ -31,7 +31,7 @@ make it possible to take advantage of an app's existing domain model. For exampl
                     self.is_admin = is_admin
 
             user = User("alice", True)
-            assert(oso.is_allowed(user, "foo", "bar))
+            assert(oso.is_allowed(user, "foo", "bar"))
 
         The code above provides a ``User`` object as the *actor* for our ``allow`` rule. Since ``User`` has an attribute
         called ``is_admin``, it is evaluated by the policy and found to be true.
@@ -127,6 +127,33 @@ make it possible to take advantage of an app's existing domain model. For exampl
         The code above provides a ``User`` instance as the *actor* for our
         ``allow`` rule. Since ``User`` has a field called ``isAdmin``, it is
         evaluated by the Polar rule and found to be true.
+
+    .. group-tab:: Rust
+
+        .. code-block:: polar
+            :caption: :fa:`oso` policy.polar
+
+            allow(actor, action, resource) if actor.is_admin;
+
+        The above rule expects the ``actor`` variable to be a Rust instance with the attribute ``is_admin``.
+        The Rust instance is passed into oso with a call to ``oso.is_allowed``:
+
+        .. code-block:: rust
+            :caption: :fab:`rust` main.rs
+
+            #[derive(Clone, PolarClass)]
+            struct User {
+                #[polar(attribute)]
+                name: String,
+                #[polar(attribute)]
+                is_admin: bool,
+            }
+            oso.register_class(User::get_polar_class())?;
+            let user = User { name: "alice".to_string(), is_admin: true };
+            assert!(oso.is_allowed(user, "foo", "bar")?);
+
+        The code above provides a ``User`` object as the *actor* for our ``allow`` rule. Since ``User`` has an attribute
+        called ``is_admin``, it is evaluated by the policy and found to be true.
 
 In addition to accessing attributes, you can also call methods on application
 instances in a policy:
@@ -246,6 +273,52 @@ using the :ref:`operator-new` operator if the class has been **registered**:
         We must pass positional arguments to the class constructor because
         JavaScript does not support keyword arguments.
 
+    .. group-tab:: Rust
+        We can register a Rust struct or enum using ``Oso::register_class``.
+        ``register_class`` takes as input a ``Class``, which can be constructed
+        either using the ``#[derive(PolarClass)]`` proc-macro, or manually using
+        ``Class::new::<T>()``:
+
+        .. code-block:: rust
+            :caption: :fab:`rust` main.rs
+
+            #[derive(Clone, PolarClass)]
+            struct User {
+                #[polar(attribute)]
+                name: String,
+                #[polar(attribute)]
+                is_admin: bool,
+            }
+
+            impl User {
+                fn new(name: String, is_admin: bool) -> Self {
+                    Self { name, is_admin }
+                }
+
+                fn is_called_alice(&self) -> bool {
+                    self.name == "alice"
+                }
+            }
+
+            oso.register_class(
+               User::get_polar_class_builder()
+                    .set_constructor(User::new)
+                    .add_method("is_called_alice", User::is_called_alice)
+                    .build(),
+            )?;
+
+        Once the class is registered, we can make a ``User`` object in Polar.
+        This can be helpful for writing inline test queries:
+
+        .. code-block:: polar
+            :caption: :fa:`oso` policy.polar
+
+            ?= allow(new User("bob", true), "foo", "bar");
+            ?= new User("alice", true).is_called_alice();
+
+        The Rust library only supports calling constructors and methods with positional
+        arguments, since Rust itself does not have keyword arguments.
+
 Registering classes also makes it possible to use :ref:`specialization`
 and the :ref:`operator-matches` with the registered class. Here's what
 specialization on an application type looks like.
@@ -318,6 +391,23 @@ Either way, using the rule could look like this:
               assert.equal(false, await oso.isAllowed("notauser", "foo", "bar"));
             })();
 
+    .. group-tab:: Rust
+
+        .. code-block:: rust
+            :caption: :fab:`rust` main.rs
+
+            #[derive(Clone, PolarClass)]
+            struct User {
+                #[polar(attribute)]
+                name: String,
+                #[polar(attribute)]
+                is_admin: bool,
+            }
+            oso.register_class(User::get_polar_class())?;
+
+            let user = User::new("alice", True);
+            assert!(oso.is_allowed(user, "foo", "bar")?);
+            assert!(!oso.is_allowed("notauser", "foo", "bar")?);
 
 .. note::
     Type specializers automatically respect the
@@ -417,6 +507,42 @@ Once a class is registered, class or static methods can also be called from oso 
             const user = new User('alice', true);
 
             (async () => assert(await oso.isAllowed(user, "foo", "bar")))();
+
+    .. group-tab:: Rust
+
+        .. code-block:: polar
+            :caption: :fa:`oso` policy.polar
+
+            allow(actor: User, action, resource) if actor.name in User.superusers();
+
+        .. code-block:: rust
+            :caption: :fab:`rust` main.rs
+
+            #[derive(Clone, PolarClass)]
+            struct User {
+                #[polar(attribute)]
+                name: String,
+            }
+
+            impl User {
+                fn superusers() -> Vec<String> {
+                    vec![
+                        "alice".to_string(),
+                        "bhavik".to_string(),
+                        "clarice".to_string(),
+                    ]
+                }
+            }
+
+            oso.register_class(
+                User::get_polar_class_builder()
+                    .add_class_method("superusers". User::superusers)
+                    .build(),
+            )?;
+
+            let user = User { name: "alice".to_string() };
+            assert!(oso.is_allowed(user, "foo", "bar)?);
+
 
 .. _built-in-types:
 

--- a/docs/getting-started/policies/application-types.rst
+++ b/docs/getting-started/policies/application-types.rst
@@ -405,7 +405,7 @@ Either way, using the rule could look like this:
             }
             oso.register_class(User::get_polar_class())?;
 
-            let user = User::new("alice", True);
+            let user = User { name: "alice".to_string(), is_admin: true };
             assert!(oso.is_allowed(user, "foo", "bar")?);
             assert!(!oso.is_allowed("notauser", "foo", "bar")?);
 

--- a/docs/more/dev-tools/repl.rst
+++ b/docs/more/dev-tools/repl.rst
@@ -83,6 +83,18 @@ Once oso is installed, launch the REPL from the terminal:
             $ npm run oso
             query>
 
+    .. group-tab:: Rust
+
+        To install the oso REPL, you can use ``cargo install --features=cli oso``
+        to download + install it from crates.io. Or run ``cargo run --features=cli``
+        from the ``languages/rust/oso`` directory in the `GitHub repository <https://github.com/osohq/oso>`_.
+
+        .. code-block:: console
+            :caption: :fab:`rust` Launch the REPL
+
+            $ oso
+            query>
+
 .. todo:: test above
 
 At the ``query>`` prompt, type a Polar expression and press ``Enter``.

--- a/docs/more/faq.rst
+++ b/docs/more/faq.rst
@@ -114,7 +114,7 @@ topic, please see our :doc:`use cases page <use-cases>`.
 What languages and frameworks do you support?
 ---------------------------------------------
 
-We currently support Python, Ruby, Java and Node.js, and are actively working on supporting more languages.
+We currently support Python, Ruby, Java and Node.js, Rust, and are actively working on supporting more languages.
 We have framework integrations for Flask & Django see :doc:`here
 </using/frameworks/index>`.
 

--- a/docs/more/faq.rst
+++ b/docs/more/faq.rst
@@ -114,7 +114,7 @@ topic, please see our :doc:`use cases page <use-cases>`.
 What languages and frameworks do you support?
 ---------------------------------------------
 
-We currently support Python, Ruby, Java and Node.js, Rust, and are actively working on supporting more languages.
+We currently support Python, Ruby, Java, Node.js and Rust, and are actively working on supporting more languages.
 We have framework integrations for Flask & Django see :doc:`here
 </using/frameworks/index>`.
 

--- a/docs/spelling_allowed_words.txt
+++ b/docs/spelling_allowed_words.txt
@@ -60,8 +60,6 @@ arity
 NaN
 constructable
 precommit
-enums
-proc
 
 ## Product names
 sqlite
@@ -102,3 +100,6 @@ structs
 usize
 vec
 toml
+enums
+proc
+io

--- a/docs/spelling_allowed_words.txt
+++ b/docs/spelling_allowed_words.txt
@@ -60,6 +60,8 @@ arity
 NaN
 constructable
 precommit
+enums
+proc
 
 ## Product names
 sqlite

--- a/docs/spelling_allowed_words.txt
+++ b/docs/spelling_allowed_words.txt
@@ -92,3 +92,11 @@ amongst
 # Release specifiers
 rc
 dev
+
+
+# Rust terms
+struct
+structs
+usize
+vec
+toml

--- a/docs/using/libraries/index.rst
+++ b/docs/using/libraries/index.rst
@@ -10,5 +10,6 @@ Libraries
     ruby/index
     java/index
     node/index
+    rust/index
 
     ../frameworks/index

--- a/docs/using/libraries/rust/index.rst
+++ b/docs/using/libraries/rust/index.rst
@@ -7,7 +7,7 @@ oso is packaged as a :doc:`cargo</download>` package for use in rust application
 .. toctree::
     :hidden:
 
-    /rust/index
+    index
 
 To install, see :doc:`installation instructions </download>`.
 

--- a/docs/using/libraries/rust/index.rst
+++ b/docs/using/libraries/rust/index.rst
@@ -7,8 +7,6 @@ oso is packaged as a :doc:`cargo</download>` package for use in rust application
 .. toctree::
     :hidden:
 
-    index
-
 To install, see :doc:`installation instructions </download>`.
 
 Working with Rust Types

--- a/docs/using/libraries/rust/index.rst
+++ b/docs/using/libraries/rust/index.rst
@@ -1,0 +1,77 @@
+============================
+Rust Authorization Library
+============================
+
+oso is packaged as a :doc:`cargo</download>` package for use in rust applications.
+
+.. toctree::
+    :hidden:
+
+    /rust/index
+
+To install, see :doc:`installation instructions </download>`.
+
+Working with Rust Types
+===========================
+
+oso's Rust authorization library allows you to write policy rules over rust types directly.
+This document explains how different rust types can be used in oso policies.
+
+.. note::
+  More detailed examples of working with application objects can be found in :doc:`/using/examples/index`.
+
+Structs
+^^^^^^^^^^^^^^^^
+Rust struct types can be registered with oso which lets you pass them in and access their methods and fields. (see :ref:`application-types`).
+
+Rust structs can also be constructed from inside an oso policy using the :ref:`operator-new` operator if the type has been given a constructor when registered.
+
+Numbers and Booleans
+^^^^^^^^^^^^^^^^^^^^
+Polar supports both integer and floating point numbers, as well as booleans (see :ref:`basic-types`).
+
+Strings
+^^^^^^^
+Rust strings are mapped to Polar :ref:`strings`. Many of rust's string methods may be called in policies:
+
+.. code-block:: polar
+  :caption: :fa:`oso` policy.polar
+
+  allow(actor, action, resource) if actor.username.ends_with("example.com");
+
+.. code-block:: rust
+  :caption: :fas:`rust` main.rs
+
+  #[derive(PolarClass)]
+  struct User {
+    #[polar(attribute)]
+    pub username: String
+  }
+
+  oso.register_class(User::get_polar_class()).unwrap();
+
+  let user = User{username: "alice@example.com".to_owned()};
+  assert!(oso.is_allowed(user, "foo", "bar");
+
+.. warning::
+  Polar does not support methods that mutate strings in place.
+
+Summary
+^^^^^^^
+
+.. list-table:: Rust -> Polar Types Summary
+  :width: 500 px
+  :header-rows: 1
+
+  * - Rust type
+    - Polar type
+  * - i32, i64, usize
+    - Number (Integer)
+  * - f32, f64
+    - Number (Float)
+  * - bool
+    - Boolean
+  * - Vec
+    - List
+  * - HashMap
+    - Dictionary

--- a/docs/using/libraries/rust/index.rst
+++ b/docs/using/libraries/rust/index.rst
@@ -2,7 +2,7 @@
 Rust Authorization Library
 ============================
 
-oso is packaged as a :doc:`cargo</download>` package for use in rust applications.
+oso is packaged as a :doc:`cargo</download>` crate for use in Rust applications.
 
 .. toctree::
     :hidden:
@@ -12,15 +12,16 @@ To install, see :doc:`installation instructions </download>`.
 Working with Rust Types
 ===========================
 
-oso's Rust authorization library allows you to write policy rules over rust types directly.
-This document explains how different rust types can be used in oso policies.
+oso's Rust authorization library allows you to write policy rules over Rust types directly.
+This document explains how different Rust types can be used in oso policies.
 
 .. note::
   More detailed examples of working with application objects can be found in :doc:`/using/examples/index`.
 
-Structs
-^^^^^^^^^^^^^^^^
-Rust struct types can be registered with oso which lets you pass them in and access their methods and fields. (see :ref:`application-types`).
+Structs + Enums
+^^^^^^^^^^^^^^^
+
+Rust structs and enums can be registered with oso which lets you pass them in and access their methods and fields. (see :ref:`application-types`).
 
 Rust structs can also be constructed from inside an oso policy using the :ref:`operator-new` operator if the type has been given a constructor when registered.
 
@@ -30,7 +31,7 @@ Polar supports both integer and floating point numbers, as well as booleans (see
 
 Strings
 ^^^^^^^
-Rust strings are mapped to Polar :ref:`strings`. Many of rust's string methods may be called in policies:
+Rust's `String <https://doc.rust-lang.org/std/string/struct.String.html>_`s are mapped to Polar :ref:`strings`. Many of rust's string methods may be called in policies:
 
 .. code-block:: polar
   :caption: :fa:`oso` policy.polar
@@ -38,21 +39,114 @@ Rust strings are mapped to Polar :ref:`strings`. Many of rust's string methods m
   allow(actor, action, resource) if actor.username.ends_with("example.com");
 
 .. code-block:: rust
-  :caption: :fas:`rust` main.rs
+  :caption: :fab:`rust` main.rs
 
-  #[derive(PolarClass)]
+  #[derive(Clone, PolarClass)]
   struct User {
     #[polar(attribute)]
     pub username: String
   }
 
-  oso.register_class(User::get_polar_class()).unwrap();
+  oso.register_class(User::get_polar_class())?;
 
   let user = User{username: "alice@example.com".to_owned()};
-  assert!(oso.is_allowed(user, "foo", "bar");
+  assert!(oso.is_allowed(user, "foo", "bar")?);
 
 .. warning::
   Polar does not support methods that mutate strings in place.
+
+
+Vectors
+^^^^^^^
+`Vec<T> <https://doc.rust-lang.org/std/vec/struct.Vec.html>`_ is mapped to Polar :ref:`Lists <lists>`, given that ``T: ToPolar``. 
+
+Currently, no methods on ``Vec`` are exposed to Polar.
+
+.. code-block:: polar
+  :caption: :fa:`oso` policy.polar
+
+  allow(actor, action, resource) if "HR" in actor.groups;
+
+.. code-block:: rust
+  :caption: :fab:`rust` main.rs
+
+  #[derive(Clone, PolarClass)]
+  struct User {
+      #[polar(attribute)]
+      pub groups: Vec<String>,
+  }
+
+  oso.register_class(User::get_polar_class())?;
+
+  let user = User { groups: vec!["HR".to_string(), "payroll".to_string()] };
+  assert!(oso.is_allowed(user, "foo", "bar")?);
+
+.. warning::
+  Polar does not support methods that mutate lists in place, unless the list is also returned from the method.
+
+
+HashMaps
+^^^^^^^^ 
+
+Rust `HashMap`s are mapped to Polar :ref:`dictionaries`:
+
+.. code-block:: polar
+  :caption: :fa:`oso` policy.polar
+
+  allow(actor, action, resource) if actor.roles.project1 = "admin";
+
+.. code-block:: rust
+  :caption: :fab:`rust` main.rs
+
+  #[derive(Clone, PolarClass)]
+  struct User {
+      #[polar(attribute)]
+      pub roles: HashMap<String, String>,
+  }
+
+  oso.register_class(User::get_polar_class())?;
+
+  let user = User { roles: maplit::hashmap!{ "project1".to_string() => "admin".to_string() } };
+  assert!(oso.is_allowed(user, "foo", "bar")?);
+
+Likewise, dictionaries constructed in Polar may be passed into Ruby methods.
+
+Iterators
+^^^^^^^^^
+
+oso handles Rust `iterators <https://doc.rust-lang.org/std/iter/index.html>`_ by evaluating the
+yielded values one at a time. To register methods returning iterators, you need to use the
+``Class::add_iterator_method`` call.
+
+.. code-block:: polar
+  :caption: :fa:`oso` policy.polar
+
+  allow(actor, action, resource) if actor.get_group() = "payroll";
+
+.. code-block:: rust
+  :caption: :fab:`rust` main.rs
+
+    #[derive(Clone, PolarClass)]
+    struct User {
+        groups: Vec<String>,
+    }
+
+    oso.register_class(
+        User::get_polar_class_builder()
+            .add_iterator_method("get_group", |u: &User| u.groups.clone().into_iter())
+            .build(),
+    )
+    .unwrap();
+
+    let user = User {
+        groups: vec!["HR".to_string(), "payroll".to_string()],
+    };
+    assert!(oso.is_allowed(user, "foo", "bar")?);
+
+In the policy above, the body of the `allow` rule will first evaluate ``"HR" = "payroll"`` and then
+``"payroll" = "payroll"``. Because the latter evaluation succeeds, the call to ``oso.is_allowed`` will succeed.
+Note that if ``get_group`` returned an array instead of an iterator, the rule would fail because it would be comparing an array (``["HR", "payroll"]``) against a string (``"payroll"``).
+
 
 Summary
 ^^^^^^^

--- a/docs/using/libraries/rust/index.rst
+++ b/docs/using/libraries/rust/index.rst
@@ -4,6 +4,9 @@ Rust Authorization Library
 
 oso is packaged as a :doc:`cargo</download>` crate for use in Rust applications.
 
+API documentation for the crate lives `on docs.rs <https://docs.rs/oso/>`_.
+
+
 .. toctree::
     :hidden:
 
@@ -31,7 +34,7 @@ Polar supports both integer and floating point numbers, as well as booleans (see
 
 Strings
 ^^^^^^^
-Rust's `String <https://doc.rust-lang.org/std/string/struct.String.html>_`s are mapped to Polar :ref:`strings`. Many of rust's string methods may be called in policies:
+Rust `Strings <https://doc.rust-lang.org/std/string/struct.String.html>`_ are mapped to Polar :ref:`strings`. Many of rust's string methods may be called in policies:
 
 .. code-block:: polar
   :caption: :fa:`oso` policy.polar
@@ -88,7 +91,8 @@ Currently, no methods on ``Vec`` are exposed to Polar.
 HashMaps
 ^^^^^^^^ 
 
-Rust `HashMap`s are mapped to Polar :ref:`dictionaries`:
+Rust `HashMaps <https://doc.rust-lang.org/std/collections/struct.HashMap.html>`_ are mapped to Polar :ref:`dictionaries`,
+but require that the ``HashMap`` key is a ``String``:
 
 .. code-block:: polar
   :caption: :fa:`oso` policy.polar
@@ -163,6 +167,8 @@ Summary
     - Number (Float)
   * - bool
     - Boolean
+  * - String, &'static str, str
+    - String
   * - Vec
     - List
   * - HashMap

--- a/languages/rust/Makefile
+++ b/languages/rust/Makefile
@@ -1,6 +1,7 @@
 test:
 	cargo test -p oso
 	cargo test -p oso-derive
+	cargo run --example lib_guide
 
 fmt:
 	cd ../.. && cargo fmt

--- a/languages/rust/oso/Cargo.toml
+++ b/languages/rust/oso/Cargo.toml
@@ -31,6 +31,6 @@ anyhow = "1.0"
 oso-derive = { path = "../oso-derive", version = "=0.6.0-alpha" }
 
 [features]
-default = []
+default = ["derive"]
 cli = ["rustyline", "rustyline-derive", "anyhow"]
 derive = ["oso-derive"]

--- a/languages/rust/oso/Cargo.toml
+++ b/languages/rust/oso/Cargo.toml
@@ -17,7 +17,7 @@ required-features = ["cli"]
 [dependencies]
 maplit = "1.0.2"
 polar-core = { path = "../../../polar-core", version = "=0.6.0" }
-oso-derive = { path = "../oso-derive", version = "=0.6.0-alpha", optional=true }
+oso-derive = { path = "../oso-derive", version = "=0.6.0-alpha", optional = true }
 thiserror = "1.0.20"
 tracing = { version = "0.1.19", features = ["log"] }
 tracing-subscriber = { version = "0.2.11", features = ["fmt"] }
@@ -27,6 +27,7 @@ rustyline = { version = "6.2", optional = true }
 rustyline-derive = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
+anyhow = "1.0"
 oso-derive = { path = "../oso-derive", version = "=0.6.0-alpha" }
 
 [features]

--- a/languages/rust/oso/examples/lib_guide.rs
+++ b/languages/rust/oso/examples/lib_guide.rs
@@ -1,5 +1,4 @@
 use oso::{Oso, PolarClass};
-use oso_derive::*;
 
 use std::collections::HashMap;
 

--- a/languages/rust/oso/examples/lib_guide.rs
+++ b/languages/rust/oso/examples/lib_guide.rs
@@ -1,0 +1,125 @@
+use oso::{Oso, PolarClass};
+use oso_derive::*;
+
+use std::collections::HashMap;
+
+fn strings() -> anyhow::Result<()> {
+    let mut oso = Oso::new();
+
+    #[derive(PolarClass, Clone)]
+    struct User {
+        #[polar(attribute)]
+        pub username: String,
+    }
+
+    oso.register_class(User::get_polar_class())?;
+
+    oso.load_str(r#"allow(actor, action, resource) if actor.username.ends_with("example.com");"#)?;
+
+    let user = User {
+        username: "alice@example.com".to_owned(),
+    };
+    assert!(oso.is_allowed(user, "foo", "bar")?);
+
+    Ok(())
+}
+
+fn vecs() -> anyhow::Result<()> {
+    let mut oso = Oso::new();
+
+    #[derive(Clone, PolarClass)]
+    struct User {
+        #[polar(attribute)]
+        pub groups: Vec<String>,
+    }
+
+    oso.register_class(User::get_polar_class()).unwrap();
+
+    oso.load_str(r#"allow(actor, action, resource) if "HR" in actor.groups;"#)?;
+
+    let user = User {
+        groups: vec!["HR".to_string(), "payroll".to_string()],
+    };
+    assert!(oso.is_allowed(user, "foo", "bar")?);
+    Ok(())
+}
+
+fn maps() -> anyhow::Result<()> {
+    let mut oso = Oso::new();
+
+    #[derive(Clone, PolarClass)]
+    struct User {
+        #[polar(attribute)]
+        pub roles: HashMap<String, String>,
+    }
+
+    oso.register_class(User::get_polar_class())?;
+    oso.load_str(r#"allow(actor, action, resource) if actor.roles.project1 = "admin";"#)?;
+
+    let user = User {
+        roles: maplit::hashmap! { "project1".to_string() => "admin".to_string() },
+    };
+    assert!(oso.is_allowed(user, "foo", "bar")?);
+
+    Ok(())
+}
+
+fn enums() -> anyhow::Result<()> {
+    let mut oso = Oso::new();
+
+    #[derive(Clone)]
+    enum UserType {
+        Admin,
+        Guest,
+    }
+
+    impl oso::HostClass for UserType {}
+
+    oso.register_class(
+        oso::Class::<UserType>::new()
+            .add_method("is_admin", |u: &UserType| matches!(u, UserType::Admin))
+            .build(),
+    )?;
+    oso.load_str(r#"allow(actor, action, resource) if actor.is_admin();"#)?;
+
+    let user = UserType::Admin;
+    assert!(oso.is_allowed(user, "foo", "bar")?);
+    assert!(!oso.is_allowed(UserType::Guest, "foo", "bar")?);
+
+    Ok(())
+}
+
+fn iters() -> anyhow::Result<()> {
+    let mut oso = Oso::new();
+
+    #[derive(Clone, PolarClass)]
+    struct User {
+        groups: Vec<String>,
+    }
+
+    oso.register_class(
+        User::get_polar_class_builder()
+            .add_iterator_method("get_group", |u: &User| u.groups.clone().into_iter())
+            .build(),
+    )
+    .unwrap();
+
+    oso.load_str(r#"allow(actor, action, resource) if actor.get_group() = "payroll";"#)?;
+
+    let user = User {
+        groups: vec!["HR".to_string(), "payroll".to_string()],
+    };
+    assert!(oso.is_allowed(user, "foo", "bar")?);
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    strings()?;
+    vecs()?;
+    maps()?;
+    enums()?;
+    iters()?;
+    println!("Examples passed");
+
+    Ok(())
+}

--- a/languages/rust/oso/examples/lib_guide.rs
+++ b/languages/rust/oso/examples/lib_guide.rs
@@ -2,6 +2,71 @@ use oso::{Oso, PolarClass};
 
 use std::collections::HashMap;
 
+fn types() -> anyhow::Result<()> {
+    let mut oso = Oso::new();
+
+    #[derive(Clone, PolarClass)]
+    struct User1 {
+        #[polar(attribute)]
+        name: String,
+        #[polar(attribute)]
+        is_admin: bool,
+    }
+    oso.register_class(User1::get_polar_class())?;
+    oso.load_str(r#"allow(actor: User1, action, resource) if actor.is_admin;"#)?;
+    let user1 = User1 {
+        name: "alice".to_string(),
+        is_admin: true,
+    };
+    assert!(oso.is_allowed(user1, "foo", "bar")?);
+
+    #[derive(Clone, PolarClass)]
+    struct User2 {
+        #[polar(attribute)]
+        name: String,
+        #[polar(attribute)]
+        is_admin: bool,
+    }
+
+    impl User2 {
+        fn new(name: String, is_admin: bool) -> Self {
+            Self { name, is_admin }
+        }
+
+        fn is_called_alice(&self) -> bool {
+            self.name == "alice"
+        }
+    }
+
+    oso.register_class(
+        User2::get_polar_class_builder()
+            .set_constructor(User2::new)
+            .add_method("is_called_alice", User2::is_called_alice)
+            .build(),
+    )?;
+    oso.load_str(r#"allow(user: User2, _, _) if user.is_admin;"#)?;
+    oso.load_str(r#"?= allow(new User2("bob", true), "foo", "bar");"#)?;
+    oso.load_str(r#"?= new User2("alice", true).is_called_alice();"#)?;
+
+    #[derive(Clone, PolarClass)]
+    struct User3 {
+        #[polar(attribute)]
+        name: String,
+        #[polar(attribute)]
+        is_admin: bool,
+    }
+    oso.register_class(User3::get_polar_class())?;
+    oso.load_str(r#"allow(actor, action, resource) if actor matches User3{name: "alice"};"#)?;
+    let user3 = User3 {
+        name: "alice".to_string(),
+        is_admin: true,
+    };
+    assert!(oso.is_allowed(user3, "foo", "bar")?);
+    assert!(!oso.is_allowed("notauser", "foo", "bar")?);
+
+    Ok(())
+}
+
 fn strings() -> anyhow::Result<()> {
     let mut oso = Oso::new();
 
@@ -118,6 +183,7 @@ fn main() -> anyhow::Result<()> {
     maps()?;
     enums()?;
     iters()?;
+    types()?;
     println!("Examples passed");
 
     Ok(())

--- a/languages/rust/oso/src/repl.rs
+++ b/languages/rust/oso/src/repl.rs
@@ -42,10 +42,10 @@ struct InputValidator {}
 
 impl Validator for InputValidator {
     fn validate(&self, ctx: &mut ValidationContext) -> Result<ValidationResult, ReadlineError> {
-        let input = ctx.input();
-        if !input.ends_with(';') {
-            return Ok(ValidationResult::Incomplete);
-        }
+        let _input = ctx.input();
+        // if !input.ends_with(';') {
+        //     return Ok(ValidationResult::Incomplete);
+        // }
         Ok(ValidationResult::Valid(None))
     }
 }
@@ -84,9 +84,9 @@ impl Repl {
     }
 
     pub fn oso_input(&mut self, prompt: &str) -> anyhow::Result<String> {
-        let mut input = self.editor.readline(prompt)?;
+        let input = self.editor.readline(prompt)?;
         self.editor.add_history_entry(input.as_str());
-        input.pop(); // remove the trailing ';'
+        // input.pop(); // remove the trailing ';'
         Ok(input)
     }
 

--- a/languages/rust/oso/tests/test_polar.rs
+++ b/languages/rust/oso/tests/test_polar.rs
@@ -3,11 +3,6 @@
 use maplit::hashmap;
 
 use oso::{Class, HostClass, Oso, PolarClass, ToPolar};
-// I don't know how to get this to work in this test without this import.
-// You get the macros from oso directly when you use the derive feature which is how people
-// will really do it.
-#[allow(unused_imports)]
-use oso_derive::*;
 
 struct OsoTest {
     oso: Oso,


### PR DESCRIPTION
- [x] Quickstart
- [x] Rust Authorization Library
- [x] Install docs
---

- [ ] Rust API docs (incomplete)
- [x] Rust version of Quickstart
- [x] Rust version of Application Types
- [x] Working with Rust Types
- [ ] Rust version of RBAC
- [ ] Rust version of ABAC
- [ ] Rust version of Context
- [ ] Rust version of Multiple Actor Types
- [ ] Rust version of Resources with Inheritance
- [x] Rust version of REPL docs
- [x] Grep docs to ensure "Rust" is added anywhere we currently enumerate supported languages.
- [x] Automate build of Rust API docs
- [x] Link built Rust API docs on Libraries page
- [ ] Added changelog entry.
- [x] Install instructions
- [x] Rust Library Page