### PR TITLE
Rust error handling

### DIFF
--- a/languages/rust/oso/src/errors.rs
+++ b/languages/rust/oso/src/errors.rs
@@ -88,7 +88,6 @@ impl OsoError {
     }
 }
 
-
 /// These are conditions that should never occur, and indicate a bug in oso.
 #[derive(Error, Debug)]
 pub enum InvariantError {
@@ -120,7 +119,7 @@ impl TypeError {
     pub fn expected<T: Into<String>>(expected: T) -> Self {
         Self {
             got: None,
-            expected: expected.into()
+            expected: expected.into(),
         }
     }
 

--- a/languages/rust/oso/src/errors.rs
+++ b/languages/rust/oso/src/errors.rs
@@ -117,16 +117,16 @@ impl fmt::Display for TypeError {
 
 impl TypeError {
     /// Create a type error with expected type `expected`.
-    pub fn expected(expected: String) -> Self {
+    pub fn expected<T: Into<String>>(expected: T) -> Self {
         Self {
             got: None,
-            expected
+            expected: expected.into()
         }
     }
 
     /// Set `got` on self.
-    pub fn got(mut self, got: String) -> Self {
-        self.got.replace(got);
+    pub fn got<T: Into<String>>(mut self, got: T) -> Self {
+        self.got.replace(got.into());
         self
     }
 

--- a/languages/rust/oso/src/host/class.rs
+++ b/languages/rust/oso/src/host/class.rs
@@ -387,9 +387,10 @@ impl Instance {
             })
             .unwrap_or_else(|| std::any::type_name::<T>().to_owned());
 
-        self.inner.as_ref().downcast_ref().ok_or_else(|| {
-            crate::errors::TypeError::expected(expected_name).got(name)
-        })
+        self.inner
+            .as_ref()
+            .downcast_ref()
+            .ok_or_else(|| crate::errors::TypeError::expected(expected_name).got(name))
     }
 }
 

--- a/languages/rust/oso/src/host/class_method.rs
+++ b/languages/rust/oso/src/host/class_method.rs
@@ -50,7 +50,9 @@ impl AttributeGetter {
         R: crate::ToPolar,
     {
         Self(Arc::new(move |receiver, host: &mut Host| {
-            let receiver = receiver.downcast(Some(&host)).map_err(|e| e.invariant().into());
+            let receiver = receiver
+                .downcast(Some(&host))
+                .map_err(|e| e.invariant().into());
             receiver.map(&f).map(|v| v.to_polar(host))
         }))
     }
@@ -73,7 +75,9 @@ impl InstanceMethod {
     {
         Self(Arc::new(
             move |receiver: &Instance, args: Vec<Term>, host: &mut Host| {
-                let receiver = receiver.downcast(Some(&host)).map_err(|e| e.invariant().into());
+                let receiver = receiver
+                    .downcast(Some(&host))
+                    .map_err(|e| e.invariant().into());
 
                 let args = Args::from_polar_list(&args, host);
 
@@ -94,7 +98,9 @@ impl InstanceMethod {
     {
         Self(Arc::new(
             move |receiver: &Instance, args: Vec<Term>, host: &mut Host| {
-                let receiver = receiver.downcast(Some(&host)).map_err(|e| e.invariant().into());
+                let receiver = receiver
+                    .downcast(Some(&host))
+                    .map_err(|e| e.invariant().into());
 
                 let args = Args::from_polar_list(&args, host);
 

--- a/languages/rust/oso/src/host/class_method.rs
+++ b/languages/rust/oso/src/host/class_method.rs
@@ -50,7 +50,7 @@ impl AttributeGetter {
         R: crate::ToPolar,
     {
         Self(Arc::new(move |receiver, host: &mut Host| {
-            let receiver = receiver.downcast().map_err(|e| e.invariant().into());
+            let receiver = receiver.downcast(Some(&host)).map_err(|e| e.invariant().into());
             receiver.map(&f).map(|v| v.to_polar(host))
         }))
     }
@@ -73,7 +73,7 @@ impl InstanceMethod {
     {
         Self(Arc::new(
             move |receiver: &Instance, args: Vec<Term>, host: &mut Host| {
-                let receiver = receiver.downcast().map_err(|e| e.invariant().into());
+                let receiver = receiver.downcast(Some(&host)).map_err(|e| e.invariant().into());
 
                 let args = Args::from_polar_list(&args, host);
 
@@ -94,7 +94,7 @@ impl InstanceMethod {
     {
         Self(Arc::new(
             move |receiver: &Instance, args: Vec<Term>, host: &mut Host| {
-                let receiver = receiver.downcast().map_err(|e| e.invariant().into());
+                let receiver = receiver.downcast(Some(&host)).map_err(|e| e.invariant().into());
 
                 let args = Args::from_polar_list(&args, host);
 
@@ -121,7 +121,7 @@ impl InstanceMethod {
         Self(Arc::new(
             move |receiver: &Instance, args: Vec<Term>, host: &mut Host| {
                 receiver
-                    .downcast::<Class>()
+                    .downcast::<Class>(Some(&host))
                     .map_err(|e| e.invariant().into())
                     .and_then(|class| {
                         tracing::trace!(class = %class.name, method=%name, "class_method");

--- a/languages/rust/oso/src/host/from_polar.rs
+++ b/languages/rust/oso/src/host/from_polar.rs
@@ -3,10 +3,11 @@
 //! Polar types back to Rust types.
 
 use impl_trait_for_tuples::*;
-use polar_core::terms::{self, Term};
+use polar_core::terms::{self, Term, Value, Numeric};
 
 use super::class::Instance;
 use super::Host;
+use crate::errors::TypeError;
 
 /// Convert Polar types to Rust types.
 ///
@@ -31,17 +32,47 @@ use super::Host;
 /// any borrows.
 pub trait FromPolar: Clone + Sized + 'static {
     fn from_polar(term: &Term, host: &Host) -> crate::Result<Self> {
-        match term.value() {
-            terms::Value::ExternalInstance(terms::ExternalInstance { instance_id, .. }) => host
+        let wrong_value = match term.value() {
+            terms::Value::ExternalInstance(terms::ExternalInstance { instance_id, .. }) => return host
                 .get_instance(*instance_id)
                 .and_then(|instance| {
                     instance
-                        .downcast::<Self>()
+                        .downcast::<Self>(Some(&host))
+                         // TODO (dhatch): This might be user.
                         .map_err(|e| e.invariant().into())
                 })
                 .map(Clone::clone),
-            _ => Err(crate::OsoError::FromPolar),
+            val => val
+        };
+
+        let expected = host.get_class_from_type::<Self>()
+            .map(|class| class.name.clone())
+            .ok()
+            .unwrap_or_else(|| std::any::type_name::<Self>().to_owned());
+
+        // TODO (dhatch): Should this operate on our oso value type instead of
+        // the polar core value type?
+        let got = match wrong_value {
+            Value::Number(Numeric::Integer(_)) => Some("Integer"),
+            Value::Number(Numeric::Float(_)) => Some("Float"),
+            Value::String(_) => Some("String"),
+            Value::Boolean(_) => Some("Boolean"),
+            Value::List(_) => Some("List"),
+            Value::Dictionary(_) => Some("Dictionary"),
+            Value::Variable(_) => Some("Variable"),
+            Value::Call(_) => Some("Predicate"),
+            // Other types are unexpected and therefore do not make their
+            // way into the error message.
+            _ => None
+        };
+
+        let mut type_error = TypeError::expected(expected);
+
+        if let Some(got) = got {
+            type_error = type_error.got(got.to_owned());
         }
+
+        Err(type_error.user())
     }
 }
 
@@ -92,9 +123,21 @@ impl FromPolar for Instance {
 impl FromPolarList for Tuple {
     fn from_polar_list(terms: &[Term], host: &Host) -> crate::Result<Self> {
         let mut iter = terms.iter();
-        Ok((for_tuples!(
+        let result = Ok((for_tuples!(
             #( Tuple::from_polar(iter.next().expect("not enough arguments provided"), host)? ),*
-        )))
+        )));
+
+        if iter.len() > 0 {
+            // TODO (dhatch): Debug this!!!
+            tracing::warn!("Remaining items in iterator after conversion.");
+            for item in iter {
+                tracing::trace!("Remaining item {}", item);
+            }
+
+            return Err(crate::OsoError::FromPolar);
+        }
+
+        result
     }
 }
 

--- a/languages/rust/oso/src/host/from_polar.rs
+++ b/languages/rust/oso/src/host/from_polar.rs
@@ -124,7 +124,10 @@ impl FromPolarList for Tuple {
     fn from_polar_list(terms: &[Term], host: &Host) -> crate::Result<Self> {
         let mut iter = terms.iter();
         let result = Ok((for_tuples!(
-            #( Tuple::from_polar(iter.next().expect("not enough arguments provided"), host)? ),*
+            #( Tuple::from_polar(iter.next().ok_or(
+                // TODO better error type
+                crate::OsoError::FromPolar
+            )?, host)? ),*
         )));
 
         if iter.len() > 0 {

--- a/languages/rust/oso/src/host/mod.rs
+++ b/languages/rust/oso/src/host/mod.rs
@@ -124,8 +124,7 @@ impl Host {
         fields: Vec<Term>,
         id: u64,
     ) -> crate::Result<()> {
-        // @TODO: Handle the error if the class doesn't exist.
-        let class = self.get_class(name).unwrap().clone();
+        let class = self.get_class(name)?.clone();
         debug_assert!(self.instances.get(&id).is_none());
         let fields = fields;
         let instance = class.init(fields, self)?;

--- a/languages/rust/oso/src/host/to_polar.rs
+++ b/languages/rust/oso/src/host/to_polar.rs
@@ -194,8 +194,9 @@ impl<C: 'static + Sized + ToPolar> ToPolarResults for C {
 }
 
 impl<C, E> ToPolarResults for Result<C, E>
-    where C: ToPolarResults,
-          E: std::error::Error + 'static + Send + Sync
+where
+    C: ToPolarResults,
+    E: std::error::Error + 'static + Send + Sync,
 {
     fn to_polar_results(self, host: &mut Host) -> PolarResultIter {
         match self {
@@ -203,7 +204,7 @@ impl<C, E> ToPolarResults for Result<C, E>
             Err(e) => Box::new(iter::once(Err(crate::OsoError::ApplicationError {
                 source: Box::new(e),
                 type_name: None,
-                attr: None
+                attr: None,
             }))),
         }
     }

--- a/languages/rust/oso/src/host/value.rs
+++ b/languages/rust/oso/src/host/value.rs
@@ -56,10 +56,9 @@ impl PolarValue {
             }
             Value::Variable(Symbol(sym)) => PolarValue::Variable(sym.clone()),
             _ => {
-                return Err(TypeError {
-                    expected: "Unsupported Value Type".to_owned(),
-                }
-                .user())
+                return Err(crate::OsoError::Custom {
+                    message: "Unsupported value type".to_owned(),
+                })
             }
         };
         Ok(val)
@@ -118,10 +117,7 @@ macro_rules! polar_to_int {
                 if let PolarValue::Integer(i) = val {
                     <$i>::try_from(i).map_err(|_| crate::OsoError::FromPolar)
                 } else {
-                    Err(TypeError {
-                        expected: "Integer".to_owned(),
-                    }
-                    .user())
+                    Err(TypeError::expected("Integer").user())
                 }
             }
         }
@@ -142,12 +138,9 @@ where
 {
     fn from_polar_value(val: PolarValue) -> crate::Result<Self> {
         if let PolarValue::Instance(instance) = val {
-            Ok(instance.downcast::<T>()?.clone())
+            Ok(instance.downcast::<T>(None).map_err(|e| e.user())?.clone())
         } else {
-            Err(TypeError {
-                expected: "Instance".to_owned(),
-            }
-            .user())
+            Err(TypeError::expected("Instance").user())
         }
     }
 }
@@ -157,10 +150,7 @@ impl FromPolarValue for f64 {
         if let PolarValue::Float(f) = val {
             Ok(f)
         } else {
-            Err(TypeError {
-                expected: "Float".to_owned(),
-            }
-            .user())
+            Err(TypeError::expected("Float").user())
         }
     }
 }
@@ -170,10 +160,7 @@ impl FromPolarValue for String {
         if let PolarValue::String(s) = val {
             Ok(s)
         } else {
-            Err(TypeError {
-                expected: "String".to_owned(),
-            }
-            .user())
+            Err(TypeError::expected("String").user())
         }
     }
 }
@@ -183,10 +170,7 @@ impl FromPolarValue for bool {
         if let PolarValue::Boolean(b) = val {
             Ok(b)
         } else {
-            Err(TypeError {
-                expected: "Boolean".to_owned(),
-            }
-            .user())
+            Err(TypeError::expected("Boolean").user())
         }
     }
 }
@@ -201,10 +185,7 @@ impl<T: FromPolarValue> FromPolarValue for HashMap<String, T> {
             }
             Ok(result)
         } else {
-            Err(TypeError {
-                expected: "Map".to_owned(),
-            }
-            .user())
+            Err(TypeError::expected("Map").user())
         }
     }
 }
@@ -218,10 +199,7 @@ impl<T: FromPolarValue> FromPolarValue for Vec<T> {
             }
             Ok(result)
         } else {
-            Err(TypeError {
-                expected: "List".to_owned(),
-            }
-            .user())
+            Err(TypeError::expected("List").user())
         }
     }
 }

--- a/languages/rust/oso/src/lib.rs
+++ b/languages/rust/oso/src/lib.rs
@@ -75,7 +75,7 @@
 pub mod macros;
 
 pub(crate) mod builtins;
-mod errors;
+pub mod errors;
 mod host;
 mod oso;
 mod query;

--- a/languages/rust/oso/src/oso.rs
+++ b/languages/rust/oso/src/oso.rs
@@ -122,6 +122,7 @@ impl Oso {
     /// ```ignore
     /// oso.query_rule("is_admin", vec![User{name: "steve"}]);
     /// ```
+    #[must_use = "Query that is not consumed does nothing."]
     pub fn query_rule(&mut self, name: &str, args: impl ToPolarList) -> crate::Result<Query> {
         let mut query_host = self.host.clone();
         let args = args.to_polar_list(&mut query_host);

--- a/languages/rust/oso/src/query.rs
+++ b/languages/rust/oso/src/query.rs
@@ -96,7 +96,7 @@ impl Query {
                     if let Err(e) = self.application_error(call_error) {
                         return Some(Err(e));
                     }
-                },
+                }
                 // All others get returned.
                 Err(err) => return Some(Err(err)),
                 // Continue on ok
@@ -185,7 +185,7 @@ impl Query {
                 Ok(r) => self.call_result(call_id, r),
                 Err(e) => {
                     self.call_result_none(call_id)?;
-                    return Err(e);
+                    Err(e)
                 }
             }
         } else {

--- a/languages/rust/oso/src/query.rs
+++ b/languages/rust/oso/src/query.rs
@@ -129,8 +129,12 @@ impl Query {
 
     fn handle_make_external(&mut self, instance_id: u64, constructor: Term) -> crate::Result<()> {
         match constructor.value() {
-            Value::Call(Call { name, args, .. }) => {
-                self.host.make_instance(name, args.clone(), instance_id)
+            Value::Call(Call { name, args, kwargs }) => {
+                if !kwargs.is_none() {
+                    lazy_error!("keyword args for constructor not supported.")
+                } else {
+                    self.host.make_instance(name, args.clone(), instance_id)
+                }
             }
             _ => lazy_error!("invalid type for constructing an instance -- internal error"),
         }

--- a/languages/rust/oso/src/query.rs
+++ b/languages/rust/oso/src/query.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
+use crate::errors::OsoError;
 use crate::host::{Host, Instance, PolarResultIter};
 use crate::{FromPolar, PolarValue};
 
@@ -87,12 +88,19 @@ impl Query {
                 QueryEvent::Debug { message } => self.handle_debug(message),
                 event => unimplemented!("Unhandled event {:?}", event),
             };
-            if let Err(e) = result {
-                // TODO (dhatch): These seem to be getting swallowed
-                tracing::error!("application error {}", e);
-                if let Err(e) = self.application_error(e) {
-                    return Some(Err(e));
-                }
+
+            match result {
+                // Only call errors get passed back.
+                Err(call_error @ OsoError::InvalidCallError { .. }) => {
+                    tracing::error!("application invalid call error {}", call_error);
+                    if let Err(e) = self.application_error(call_error) {
+                        return Some(Err(e));
+                    }
+                },
+                // All others get returned.
+                Err(err) => return Some(Err(err)),
+                // Continue on ok
+                Ok(_) => {}
             }
         }
     }
@@ -109,6 +117,12 @@ impl Query {
         Ok(self.inner.call_result(call_id, None)?)
     }
 
+    /// Return an application error to Polar.
+    ///
+    /// NOTE: This should only be used for InvalidCallError.
+    /// TODO (dhatch): Refactor Polar API so this is clear.
+    ///
+    /// All other errors must be returned directly from query.
     fn application_error(&mut self, error: crate::OsoError) -> crate::Result<()> {
         Ok(self.inner.application_error(error.to_string())?)
     }
@@ -158,16 +172,16 @@ impl Query {
         }
         let instance = Instance::from_polar(&instance, &self.host).unwrap();
         if let Err(e) = self.register_call(call_id, instance, name, args) {
-            self.application_error(e)?;
-            return self.call_result_none(call_id);
+            self.call_result_none(call_id)?;
+            return Err(e);
         }
 
         if let Some(result) = self.next_call_result(call_id) {
             match result {
                 Ok(r) => self.call_result(call_id, r),
                 Err(e) => {
-                    self.application_error(e)?;
-                    self.call_result_none(call_id)
+                    self.call_result_none(call_id)?;
+                    return Err(e);
                 }
             }
         } else {

--- a/languages/rust/oso/tests/common/mod.rs
+++ b/languages/rust/oso/tests/common/mod.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use oso::Oso;
 
 pub struct OsoTest {
@@ -13,7 +14,6 @@ impl OsoTest {
         self.oso.load_str(policy).unwrap();
     }
 
-    #[allow(dead_code)]
     pub fn load_file(&mut self, here: &str, name: &str) -> oso::Result<()> {
         // hack because `file!()` starts from workspace root
         // https://github.com/rust-lang/cargo/issues/3946

--- a/languages/rust/oso/tests/test_errors.rs
+++ b/languages/rust/oso/tests/test_errors.rs
@@ -569,3 +569,10 @@ fn test_operator_unimplemented() -> oso::Result<()> {
 }
 
 // TODO (dhatch): Test errors for application method failures.
+
+// TODO (dhatch): What would happen for something like
+// val matches Foo { x: 1 } where val.x is not an integer.
+//
+// This would raise a type error (if we did one-sided external unification,
+// but we want the matches to just fail.  This wouldn't be caught by the
+// current application error implementation.

--- a/languages/rust/oso/tests/test_errors.rs
+++ b/languages/rust/oso/tests/test_errors.rs
@@ -509,26 +509,21 @@ fn test_operator_unimplemented() -> oso::Result<()> {
 
     let mut oso = OsoTest::new();
 
-    #[derive(PolarClass)]
+    #[derive(PolarClass, PartialOrd, PartialEq)]
     struct Foo(i64);
 
     let foo_class = Foo::get_polar_class_builder()
+        .with_equality_check()
         .build();
 
     oso.oso.register_class(foo_class)?;
 
+    oso.load_str("lt(a, b) if a < b;");
+    oso.qeval("lt(1, 2)");
+
+    assert!(Foo(0) < Foo(1));
+    let mut query = oso.oso.query_rule("lt", (Foo(0), Foo(1))).unwrap();
+    assert!(query.next().unwrap().is_err());
+
     Ok(())
-}
-
-/// Test that auto-registration when possible succeeds:
-///
-/// - attribute lookup
-/// - method call
-/// - nested method call
-/// - external unification
-/// - isa'ing
-/// - is_subspecializer
-#[test]
-fn test_auto_registration() {
-
 }

--- a/languages/rust/oso/tests/test_errors.rs
+++ b/languages/rust/oso/tests/test_errors.rs
@@ -1,0 +1,310 @@
+/// Tests that errors are raised & correct.
+mod common;
+
+use oso::{PolarClass, Value};
+use polar_core::terms::Symbol;
+use common::OsoTest;
+
+// TODO in all tests, check type of error & message
+
+/// Test that external unification on raises error on:
+/// - Same type that doesn't support unification
+/// - Type that does unified with a different type
+#[test]
+fn test_unify_external_not_supported() -> oso::Result<()> {
+    common::setup();
+
+    #[derive(PolarClass)]
+    struct Foo(pub i64);
+
+    let mut oso = OsoTest::new();
+
+    oso.oso.register_class(Foo::get_polar_class())?;
+
+    oso.load_str("unify(x, y) if x = y;");
+
+    // Type that doesn't support unification.
+    let mut query = oso.oso.query_rule("unify", (Foo(1), Foo(1)))?;
+    query.next().unwrap().expect_err("Should be an error");
+
+    // Type that does support unification with a type that doesn't.
+    #[derive(PolarClass, PartialEq)]
+    struct EqFoo(i64);
+
+    impl PartialEq<Foo> for EqFoo {
+        fn eq(&self, other: &Foo) -> bool {
+            self.0 == other.0
+        }
+    }
+
+    let eq_foo_class = EqFoo::get_polar_class_builder()
+        .with_equality_check()
+        .build();
+
+    oso.oso.register_class(eq_foo_class)?;
+
+    let mut query = oso.oso.query_rule("unify", (EqFoo(1), Foo(1)))?;
+    // TODO Actually should it? Not totally sure?
+    query.next().unwrap().expect_err("Should error");
+
+    Ok(())
+}
+
+/// Test that lookup of attribute that doesn't exist raises error.
+#[test]
+fn test_attribute_does_not_exist() -> oso::Result<()> {
+    common::setup();
+
+    let mut oso = OsoTest::new();
+
+    #[derive(PolarClass)]
+    struct Foo;
+
+    oso.oso.register_class(Foo::get_polar_class())?;
+    oso.load_str("getattr(x, y, val) if val = x.(y);");
+
+    // TODO dhatch: Query API for variables needs improvement.
+    let mut query = oso.oso.query_rule("getattr", (Foo, "bar", Value::Variable(Symbol("a".to_owned()))))?;
+    query.next().unwrap().expect_err("Attribute does not exist.");
+
+    Ok(())
+}
+
+/// Test that lookup of method that doesn't exist raises error.
+#[test]
+fn test_method_does_not_exist() -> oso::Result<()> {
+    common::setup();
+
+    let mut oso = OsoTest::new();
+
+    #[derive(PolarClass)]
+    struct Foo;
+
+    impl Foo {
+        fn a(&self) -> i64 {
+            1
+        }
+    }
+
+    let foo_class = Foo::get_polar_class_builder()
+        .add_method("a", Foo::a)
+        .build();
+
+    oso.oso.register_class(foo_class)?;
+    oso.load_str("getmethod_b(x, val) if val = x.b();");
+
+    let mut query = oso.oso.query_rule("getmethod_b", (Foo, 1))?;
+    query.next().unwrap().expect_err("Should return error");
+
+    Ok(())
+}
+
+/// Test that lookup of class method that doesn't exist raises error.
+#[test]
+fn test_class_method_does_not_exist() -> oso::Result<()> {
+    common::setup();
+
+    let mut oso = OsoTest::new();
+
+    #[derive(PolarClass)]
+    struct Foo;
+
+    impl Foo {
+        fn a() -> i64 {
+            1
+        }
+    }
+
+    let foo_class = Foo::get_polar_class_builder()
+        .add_class_method("a", Foo::a)
+        .build();
+
+    oso.oso.register_class(foo_class)?;
+    oso.load_str("getmethod_b(val) if val = Foo.b();");
+
+    let mut query = oso.oso.query_rule("getmethod_b", (1,))?;
+    query.next().unwrap().expect_err("Should return error");
+
+    Ok(())
+}
+
+/// Test that method call with incorrect type raises error:
+/// - Wrong type of arguments
+/// - Arguments that are not registered
+#[test]
+fn test_wrong_argument_types() {
+    common::setup();
+
+    let mut oso = OsoTest::new();
+
+    #[derive(PolarClass)]
+    struct Foo;
+
+    impl Foo {
+        fn a(&self) -> i64 {
+            1
+        }
+
+        fn bar(&self, _bar: Bar) -> i64 {
+            2
+        }
+
+        fn bar_x(&self, _x: i64, _bar: Bar) -> i64 {
+            3
+        }
+
+        fn int(&self, _x: u8) -> i64 {
+            4
+        }
+    }
+
+    // TODO (dhatch): Note for memory mgmt PR. Clone is required to use a type
+    // as a method argument! But not otherwise (see Foo doesn't need Clone).
+    #[derive(PolarClass, Clone)]
+    struct Bar;
+
+    #[derive(PolarClass)]
+    struct Unregistered;
+
+    let foo_class = Foo::get_polar_class_builder()
+        .add_method("a", Foo::a)
+        .add_method("bar", Foo::bar)
+        .add_method("bar_x", Foo::bar_x)
+        .add_method("int", Foo::int)
+        .build();
+
+    oso.oso.register_class(foo_class).unwrap();
+    oso.oso.register_class(Bar::get_polar_class()).unwrap();
+
+    oso.load_str("a(f, v) if v = f.a();");
+    oso.load_str("bar(f, arg) if _v = f.bar(arg);");
+    oso.load_str("bar_x(f, arg, arg1) if _v = f.bar_x(arg, arg1);");
+    oso.load_str("int(f, arg) if _v = f.int(arg, arg1);");
+
+    let mut query = oso.oso.query_rule("a", (Foo, 1)).unwrap();
+    assert_eq!(query.next().unwrap().unwrap().keys().count(), 0);
+
+    let mut query = oso.oso.query_rule("bar", (Foo, Bar)).unwrap();
+    assert_eq!(query.next().unwrap().unwrap().keys().count(), 0);
+
+    // Wrong type of argument.
+    let mut query = oso.oso.query_rule("bar", (Foo, 1)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Wrong type of argument.
+    let mut query = oso.oso.query_rule("bar", (Foo, Foo)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Unregistered argument.
+    let mut query = oso.oso.query_rule("bar", (Foo, Unregistered)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    let mut query = oso.oso.query_rule("bar_x", (Foo, 1, Bar)).unwrap();
+    assert_eq!(query.next().unwrap().unwrap().keys().count(), 0);
+
+    // Wrong type of argument.
+    let mut query = oso.oso.query_rule("bar_x", (Foo, Foo, 1)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Wrong type of argument.
+    let mut query = oso.oso.query_rule("bar_x", (Foo, Bar, 1)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Wrong type of argument.
+    let mut query = oso.oso.query_rule("bar_x", (Foo, Bar, Bar)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Unregistered argument.
+    let mut query = oso.oso.query_rule("bar_x", (Foo, Bar, Unregistered)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Wrong type of argument.
+    let mut query = oso.oso.query_rule("int", (Foo, 0)).unwrap();
+    assert_eq!(query.next().unwrap().unwrap().keys().count(), 0);
+
+    // Wrong type of argument.
+    let mut query = oso.oso.query_rule("int", (Foo, Bar)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Wrong type of argument.
+    let mut query = oso.oso.query_rule("int", (Foo, 0.)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Out of bound argument.
+    let mut query = oso.oso.query_rule("int", (Foo, i64::MAX)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Out of bound argument.
+    let mut query = oso.oso.query_rule("int", (Foo, -1 as i8)).unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Out of bound argument.
+    let mut query = oso.oso.query("int(-1)").unwrap();
+    assert!(query.next().unwrap().is_err());
+
+    // Out of bound argument.
+    let mut query = oso.oso.query("int(256)").unwrap();
+    assert!(query.next().unwrap().is_err());
+}
+
+/// Test that constructor call with incorrect type raises error:
+/// - Wrong type of arguments
+/// - Arguments that are not registered
+#[test]
+fn test_wrong_argument_types_constructor() {
+
+}
+
+/// Test match with non-existent attributes does not raise error
+#[test]
+fn test_match_attribute_does_not_exist() {
+
+}
+
+/// Test that match with class that doesn't exist raises error
+#[test]
+fn test_match_non_existent_class() {
+
+}
+
+/// Test that incorrect number of arguments raises error:
+/// - Incorrect number of arguments on method
+/// - Incorrect number of arguments for constructor
+#[test]
+fn test_wrong_argument_arity() {
+
+}
+
+/// Test that constructing a class that is not registered raises error
+#[test]
+fn test_class_does_not_exist() {
+
+}
+
+/// Test that using keyword arguments for constructor raises error:
+/// - Keyword args only
+/// - Mixed parameters
+#[test]
+fn test_mixed_keyword_arguments_error() {
+
+}
+
+/// Test operator raises not implemented error
+/// Operators are unimplemented, make sure all return error.
+#[test]
+fn test_operator_unimplemented() {
+
+}
+
+/// Test that auto-registration when possible succeeds:
+///
+/// - attribute lookup
+/// - method call
+/// - nested method call
+/// - external unification
+/// - isa'ing
+/// - is_subspecializer
+#[test]
+fn test_auto_registration() {
+
+}

--- a/languages/rust/oso/tests/test_errors.rs
+++ b/languages/rust/oso/tests/test_errors.rs
@@ -504,7 +504,7 @@ fn test_class_does_not_exist() {
 
     oso.oso.register_class(foo_class).unwrap();
 
-    oso.load_str("bar(b) if b = new Bar()");
+    oso.load_str("bar(b) if b = new Bar();");
     let mut query = oso.oso.query("bar(b)").unwrap();
     assert!(query.next().unwrap().is_err());
 }

--- a/languages/rust/oso/tests/test_errors.rs
+++ b/languages/rust/oso/tests/test_errors.rs
@@ -254,7 +254,7 @@ fn test_wrong_argument_types() {
     oso.load_str("a(f, v) if v = f.a();");
     oso.load_str("bar(f, arg) if _v = f.bar(arg);");
     oso.load_str("bar_x(f, arg, arg1) if _v = f.bar_x(arg, arg1);");
-    oso.load_str("int(f, arg) if _v = f.int(arg, arg1);");
+    oso.load_str("int(f, arg) if _v = f.int(arg);");
 
     let mut query = oso.oso.query_rule("a", (Foo, 1)).unwrap();
     assert_eq!(query.next().unwrap().unwrap().keys().count(), 0);
@@ -264,16 +264,18 @@ fn test_wrong_argument_types() {
 
     // Wrong type of argument.
     let mut query = oso.oso.query_rule("bar", (Foo, 1)).unwrap();
-    let error = query.next().unwrap().unwrap_err();
-    if let OsoError::TypeError(TypeError {
-        got: Some(got),
-        expected
-    }) = &error {
-        assert_eq!(got, "Integer");
-        assert_eq!(expected, "Bar");
-    } else {
-        panic!("Error type {} doesn't match expected", error);
-    }
+    assert!(query.next().unwrap().is_err());
+
+    // TODO test type error like this
+    //if let OsoError::TypeError(TypeError {
+        //got: Some(got),
+        //expected
+    //}) = &error {
+        //assert_eq!(got, "Integer");
+        //assert_eq!(expected, "Bar");
+    //} else {
+        //panic!("Error type {} doesn't match expected", error);
+    //}
 
 
     // Wrong type of argument.
@@ -324,14 +326,6 @@ fn test_wrong_argument_types() {
 
     // Out of bound argument.
     let mut query = oso.oso.query_rule("int", (Foo, -1 as i8)).unwrap();
-    assert!(query.next().unwrap().is_err());
-
-    // Out of bound argument.
-    let mut query = oso.oso.query("int(-1)").unwrap();
-    assert!(query.next().unwrap().is_err());
-
-    // Out of bound argument.
-    let mut query = oso.oso.query("int(256)").unwrap();
     assert!(query.next().unwrap().is_err());
 }
 
@@ -578,13 +572,13 @@ fn test_method_keyword_arguments_error() -> oso::Result<()> {
 
     oso.oso.register_class(foo_class)?;
 
-    let mut query = oso.oso.query("x = new Foo(1).a(1)").unwrap();
-    assert_eq!(query.next().unwrap()?.get_typed::<i64>("x")?, 1);
+    let mut query = oso.oso.query("x = new Foo().a(1)").unwrap();
+    assert_eq!(query.next().unwrap().unwrap().get_typed::<i64>("x")?, 1);
 
-    let mut query = oso.oso.query("x = new Foo(1).a(x: 1)").unwrap();
+    let mut query = oso.oso.query("x = new Foo().a(x: 1)").unwrap();
     assert!(query.next().unwrap().is_err());
 
-    let mut query = oso.oso.query("x = new Foo(1).a(1, x: 1)").unwrap();
+    let mut query = oso.oso.query("x = new Foo().a(1, x: 1)").unwrap();
     assert!(query.next().unwrap().is_err());
 
     Ok(())

--- a/languages/rust/oso/tests/test_errors.rs
+++ b/languages/rust/oso/tests/test_errors.rs
@@ -5,10 +5,10 @@ use common::OsoTest;
 use oso::errors::polar::{
     ErrorKind as PolarErrorKind, PolarError, RuntimeError as PolarRuntimeError,
 };
-use oso::{OsoError, errors::TypeError, PolarClass};
+use oso::{OsoError, PolarClass};
 
-use polar_core::terms::Value;
 use polar_core::terms::Symbol;
+use polar_core::terms::Value;
 
 // TODO in all tests, check type of error & message
 
@@ -79,14 +79,14 @@ fn test_unify_external_not_supported() -> oso::Result<()> {
     //let mut query = oso.oso.query_rule("unify", (EqFoo(1), 1))?;
     //let error = query.next().unwrap().unwrap_err();
     //assert!(
-        //matches!(
-            //&error,
-            //OsoError::TypeError(oso::errors::TypeError {
-                //expected,
-                //got
-            //}) if expected == "EqFoo" && got.as_deref() == Some("Integer")),
-        //"{} doesn't match expected error",
-        //error
+    //matches!(
+    //&error,
+    //OsoError::TypeError(oso::errors::TypeError {
+    //expected,
+    //got
+    //}) if expected == "EqFoo" && got.as_deref() == Some("Integer")),
+    //"{} doesn't match expected error",
+    //error
     //);
 
     Ok(())
@@ -268,15 +268,14 @@ fn test_wrong_argument_types() {
 
     // TODO test type error like this
     //if let OsoError::TypeError(TypeError {
-        //got: Some(got),
-        //expected
+    //got: Some(got),
+    //expected
     //}) = &error {
-        //assert_eq!(got, "Integer");
-        //assert_eq!(expected, "Bar");
+    //assert_eq!(got, "Integer");
+    //assert_eq!(expected, "Bar");
     //} else {
-        //panic!("Error type {} doesn't match expected", error);
+    //panic!("Error type {} doesn't match expected", error);
     //}
-
 
     // Wrong type of argument.
     let mut query = oso.oso.query_rule("bar", (Foo, Foo)).unwrap();

--- a/languages/rust/oso/tests/test_errors.rs
+++ b/languages/rust/oso/tests/test_errors.rs
@@ -5,8 +5,9 @@ use common::OsoTest;
 use oso::errors::polar::{
     ErrorKind as PolarErrorKind, PolarError, RuntimeError as PolarRuntimeError,
 };
-use oso::{OsoError, errors::TypeError, PolarClass, Value};
+use oso::{OsoError, errors::TypeError, PolarClass};
 
+use polar_core::terms::Value;
 use polar_core::terms::Symbol;
 
 // TODO in all tests, check type of error & message

--- a/languages/rust/oso/tests/test_polar_rust.rs
+++ b/languages/rust/oso/tests/test_polar_rust.rs
@@ -2,6 +2,7 @@
 /// Tests that are unique to the Rust implementation of oso, testing things like
 /// rust class handling.
 use maplit::hashmap;
+use thiserror::Error;
 
 use oso::{ClassBuilder, PolarClass};
 
@@ -343,17 +344,21 @@ fn test_results_and_options() {
     #[derive(PolarClass)]
     struct Foo;
 
+    #[derive(Error, Debug)]
+    #[error("Test error")]
+    struct Error;
+
     impl Foo {
         fn new() -> Self {
             Self
         }
 
-        fn ok(&self) -> Result<i32, String> {
+        fn ok(&self) -> Result<i32, Error> {
             Ok(1)
         }
 
-        fn err(&self) -> Result<i32, &'static str> {
-            Err("Some sort of error")
+        fn err(&self) -> Result<i32, Error> {
+            Err(Error)
         }
 
         fn some(&self) -> Option<i32> {

--- a/languages/rust/oso/tests/test_polar_rust.rs
+++ b/languages/rust/oso/tests/test_polar_rust.rs
@@ -379,6 +379,8 @@ fn test_results_and_options() {
         .unwrap();
 
     test.qvar_one(r#"new Foo().ok() = x"#, "x", 1);
+    // TODO (dhatch): Assert type of error
+    // TODO (dhatch): Check nested method error
     test.query_err("new Foo().err()");
     test.qvar_one(r#"new Foo().some() = x"#, "x", 1);
 


### PR DESCRIPTION
So far, have gone through and enumerated all things that *could* be errors.  The Rust library is a bit different from other libraries in the sense that there are more issues that could come up that may need an error that are not problems in other libraries.

Our current error handling logic for application errors (that go back into oso & get checked depending on the current operation) allows some operations to raise errors when invalid attributes or methods are accessed, and others to silently fail.  The idea behind this is to prevent policies with rules that cannot match to fail in a prolog-style (backtrack), instead of blowing up execution.

We've made the call that invalid attribute access (`x.attr`) should raise an error & be protected by specializers.  Attribute access during a match `x matches {attr: y}` should not.

Error cases:

- External unify on type that does not support it:

  ```
  x = y
  ```

  Where one of `x` or `y` is an external instance.

  In the Rust library, not all types are comparable (do not implement `PartialEq`), and due to limitations in the class implementation (no generics) we cannot compare mixed types.

  In other libraries, a failed unification does not result in an error.  I could see a case for an error in Rust so that the user knows to call `ClassBuilder::with_equality_check()` to make the equality available to Rust.

- Attribute doesn't exist

  Raise an error in Rust library & other libraries.

- Method does not exist.

  Raise error in rust & other libraries.

- Class method does not exist

  Raise error in Rust & other libraries.

- Wrong argument types

  Raise type error in Rust library.  In other libraries, the language itself would have this error.

- Match with attribute that does not exist.

  Fail with backtrack instead (since this is used to detect if a class has an attribute)

- Match with non-existent class

  Class not found error (not sure what happens for other libraries)

- Wrong argument arity for method and constructor

  Error in Rust library, language would raise in others

- Class does not exist for construction

  Class does not exist error

- Use of keyword arguments

  Not supported, raise unsupported operation.

- Operators

  Unsupported operation


PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.