### PR TITLE
Identify list operand in 'in' operator error message

### DIFF
--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -666,7 +666,7 @@ describe('errors', () => {
     foo(1,2)
   in rule foo at line 1, column 13
     a in b
-Type error: can only use \`in\` on a list, this is Variable(Symbol("_a_3")) at line 1, column 13`
+Type error: can only use \`in\` on a list, this is Number(Integer(2)) at line 1, column 7`
       );
     });
 

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -421,7 +421,7 @@ def test_runtime_errors(polar, query):
     foo(1,2)
   in rule foo at line 2, column 17
     a in b
-Type error: can only use `in` on a list, this is Variable(Symbol("_a_3")) at line 2, column 17"""
+Type error: can only use `in` on a list, this is Number(Integer(2)) at line 1, column 7"""
     )
 
 

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -754,7 +754,7 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
               foo(1,2)
             in rule foo at line 1, column 13
               a in b
-          Type error: can only use `in` on a list, this is Variable(Symbol("_a_3")) at line 1, column 13
+          Type error: can only use `in` on a list, this is Number(Integer(2)) at line 1, column 7
         TRACE
         expect(e.message).to eq(error)
       end

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -1445,8 +1445,8 @@ impl PolarVirtualMachine {
                     }
                     _ => {
                         return Err(self.type_error(
-                            item,
-                            format!("can only use `in` on a list, this is {:?}", item.value()),
+                            &list,
+                            format!("can only use `in` on a list, this is {:?}", list.value()),
                         ));
                     }
                 }


### PR DESCRIPTION
We're currently `match`ing on the `list` value but then reporting the `item` value in the error message.