### PR TITLE
Fix macOS CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
     branches:
-      - main
+      - steve/ci
 
 jobs:
   version:
@@ -15,7 +15,7 @@ jobs:
       - name: Set version env
         run: echo "::set-env name=oso_version::$(cat VERSION)"
       - name: Check github ref matches
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/steve/ci'
         env:
           github_ref: ${{ github.ref }}
         run: grep "${github_ref/refs\/tags\/v/}" VERSION
@@ -45,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
+        if: runner.os != 'macOS'
         with:
           path: |
             ~/.cargo/registry
@@ -170,6 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
+        if: runner.os != 'macOS'
         with:
           path: |
             ~/.cargo/registry
@@ -458,7 +460,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/steve/ci'
     needs:
       [
         build_wheels,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
     branches:
-      - steve/ci
+      - main
 
 jobs:
   version:
@@ -15,7 +15,7 @@ jobs:
       - name: Set version env
         run: echo "::set-env name=oso_version::$(cat VERSION)"
       - name: Check github ref matches
-        if: github.ref != 'refs/heads/steve/ci'
+        if: github.ref != 'refs/heads/main'
         env:
           github_ref: ${{ github.ref }}
         run: grep "${github_ref/refs\/tags\/v/}" VERSION
@@ -460,7 +460,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/steve/ci'
+    if: github.ref != 'refs/heads/main'
     needs:
       [
         build_wheels,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
     branches:
-      - main
+      - steve/ci
 
 jobs:
   version:
@@ -15,7 +15,7 @@ jobs:
       - name: Set version env
         run: echo "::set-env name=oso_version::$(cat VERSION)"
       - name: Check github ref matches
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/steve/ci'
         env:
           github_ref: ${{ github.ref }}
         run: grep "${github_ref/refs\/tags\/v/}" VERSION
@@ -458,7 +458,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/steve/ci'
     needs:
       [
         build_wheels,
@@ -611,8 +611,8 @@ jobs:
       - uses: rtCamp/action-slack-notify@master
         env:
           SLACK_CHANNEL: firehose
-          SLACK_COLOR: 'danger'
+          SLACK_COLOR: "danger"
           SLACK_MESSAGE: "${{ github.event.head_commit.url }}"
-          SLACK_TITLE: 'Release job failed.'
+          SLACK_TITLE: "Release job failed."
           SLACK_USERNAME: github-actions
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TO_FIREHOSE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
     branches:
-      - steve/ci
+      - main
 
 jobs:
   version:
@@ -15,7 +15,7 @@ jobs:
       - name: Set version env
         run: echo "::set-env name=oso_version::$(cat VERSION)"
       - name: Check github ref matches
-        if: github.ref != 'refs/heads/steve/ci'
+        if: github.ref != 'refs/heads/main'
         env:
           github_ref: ${{ github.ref }}
         run: grep "${github_ref/refs\/tags\/v/}" VERSION
@@ -458,7 +458,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/steve/ci'
+    if: github.ref != 'refs/heads/main'
     needs:
       [
         build_wheels,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,13 @@ jobs:
         os: [ubuntu-18.04, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+      # - uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       ~/.cargo/registry
+      #       ~/.cargo/git
+      #       target
+      #     key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,13 @@ jobs:
         os: [ubuntu-18.04, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.cargo/registry
-      #       ~/.cargo/git
-      #       target
-      #     key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -169,13 +169,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+      # - uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       ~/.cargo/registry
+      #       ~/.cargo/git
+      #       target
+      #     key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/setup-python@v2
         name: Install Python
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,13 +169,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.cargo/registry
-      #       ~/.cargo/git
-      #       target
-      #     key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/setup-python@v2
         name: Install Python
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "proptest",
  "regex",
  "serde",
+ "serde_derive",
  "serde_json",
 ]
 

--- a/polar-core/Cargo.toml
+++ b/polar-core/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.116", features = ["derive", "rc"] }
 serde_json = "1.0.58"
 
 [build_dependencies]
+serde_derive = "1.0"
 lalrpop = { version = "0.19.1", features = ["lexer"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Not sure why but `lalrpop` can't pick up `serde_derive` from the `derive` feature on `serde`. Maybe something to do with one being a dev dep and one a normal dep? IDK all I know is adding the `serde_derive` crate explicitly fixed the osx build.