### PR TITLE
Improve post-rewrite expression formatting

### DIFF
--- a/polar-core/src/formatting.rs
+++ b/polar-core/src/formatting.rs
@@ -409,17 +409,22 @@ pub mod to_polar {
                         )
                     }
                 }
-                // `Dot` sometimes formats as a predicate
+                // Lookup operator
                 Dot => {
-                    if self.args.len() == 2 {
-                        let call_term = if let Value::String(s) = self.args[1].value() {
-                            s.to_string()
-                        } else {
-                            self.args[1].to_polar()
-                        };
-                        format!("{}.{}", self.args[0].to_polar(), call_term)
+                    let call_term = if let Value::String(s) = self.args[1].value() {
+                        s.to_string()
                     } else {
-                        format!(".({})", format_args(self.operator, &self.args, ", "))
+                        self.args[1].to_polar()
+                    };
+                    match self.args.len() {
+                        2 => format!("{}.{}", self.args[0].to_polar(), call_term),
+                        3 => format!(
+                            "{}.{} = {}",
+                            self.args[0].to_polar(),
+                            call_term,
+                            self.args[2].to_polar()
+                        ),
+                        _ => panic!("Invalid lookup operation: {:?}", self),
                     }
                 }
                 // Unary operators
@@ -430,12 +435,22 @@ pub mod to_polar {
                 ),
                 // Binary operators
                 Mul | Div | Add | Sub | Eq | Geq | Leq | Neq | Gt | Lt | Unify | Isa | In
-                | Assign => format!(
-                    "{} {} {}",
-                    to_polar_parens(self.operator, &self.args[0]),
-                    self.operator.to_polar(),
-                    to_polar_parens(self.operator, &self.args[1])
-                ),
+                | Assign => match self.args.len() {
+                    2 => format!(
+                        "{} {} {}",
+                        to_polar_parens(self.operator, &self.args[0]),
+                        self.operator.to_polar(),
+                        to_polar_parens(self.operator, &self.args[1]),
+                    ),
+                    3 => format!(
+                        "{} {} {} = {}",
+                        to_polar_parens(self.operator, &self.args[0]),
+                        self.operator.to_polar(),
+                        to_polar_parens(self.operator, &self.args[1]),
+                        to_polar_parens(self.operator, &self.args[2]),
+                    ),
+                    _ => panic!("Invalid operation: {:?}", self),
+                },
                 // n-ary operators
                 And => format_args(
                     self.operator,

--- a/polar-core/src/formatting.rs
+++ b/polar-core/src/formatting.rs
@@ -424,7 +424,8 @@ pub mod to_polar {
                             call_term,
                             self.args[2].to_polar()
                         ),
-                        _ => panic!("Invalid lookup operation: {:?}", self),
+                        // Invalid
+                        _ => format!(".({})", format_args(self.operator, &self.args, ", ")),
                     }
                 }
                 // Unary operators
@@ -449,7 +450,12 @@ pub mod to_polar {
                         to_polar_parens(self.operator, &self.args[1]),
                         to_polar_parens(self.operator, &self.args[2]),
                     ),
-                    _ => panic!("Invalid operation: {:?}", self),
+                    // Invalid
+                    _ => format!(
+                        "{}({})",
+                        self.operator.to_polar(),
+                        format_args(self.operator, &self.args, ", ")
+                    ),
                 },
                 // n-ary operators
                 And => format_args(

--- a/polar-core/src/rewrites.rs
+++ b/polar-core/src/rewrites.rs
@@ -284,6 +284,22 @@ mod tests {
     }
 
     #[test]
+    fn rewrite_expressions() {
+        let mut kb = KnowledgeBase::new();
+
+        let mut term = parse_query("0 - 0 = 0");
+        assert_eq!(term.to_polar(), "0 - 0 = 0");
+        rewrite_term(&mut term, &mut kb);
+        assert_eq!(term.to_polar(), "0 - 0 = _op_1 and _op_1 = 0");
+
+        let rules = parse_rules("sum(a, b, a + b);");
+        let mut rule = rules[0].clone();
+        assert_eq!(rule.to_polar(), "sum(a, b, a + b);");
+        rewrite_rule(&mut rule, &mut kb);
+        assert_eq!(rule.to_polar(), "sum(a, b, _op_2) if a + b = _op_2;");
+    }
+
+    #[test]
     fn rewrite_nested_literal() {
         let mut kb = KnowledgeBase::new();
         let mut term = parse_query("new Foo(x: bar.y)");


### PR DESCRIPTION
Three-arg variants of operations like `.` and `+` were previously formatted poorly, either as `.(x, y, z)` or just `a + b`, both of which are confusing and/or misleading. We now format them as `a.b = c` or `a + b = c`.