### PR TITLE
Fail on all unsupported partial operations except Not

### DIFF
--- a/polar-core/src/macros.rs
+++ b/polar-core/src/macros.rs
@@ -65,6 +65,16 @@ macro_rules! instance {
 }
 
 #[macro_export]
+macro_rules! partial {
+    ($arg:expr) => {
+        Value::Partial(Constraints {
+            variable: sym!($arg),
+            operations: vec![],
+        })
+    };
+}
+
+#[macro_export]
 macro_rules! sym {
     ($arg:expr) => {
         $crate::macros::TestHelper::<Symbol>::from($arg).0

--- a/polar-core/src/partial/constraints.rs
+++ b/polar-core/src/partial/constraints.rs
@@ -488,6 +488,32 @@ mod test {
         assert!(matches!(error, PolarError {
             kind: ErrorKind::Runtime(RuntimeError::Unsupported { .. }), ..}));
 
+        // Multiple interacting query partials.
+        // Unification.
+        polar.load_str(r#"h(x, y) if x = y;"#)?;
+        let mut query = polar.new_query_from_term(
+            term!(call!(
+                "h",
+                [Constraints::new(sym!("a")), Constraints::new(sym!("b"))]
+            )),
+            false,
+        );
+        let error = query.next_event().unwrap_err();
+        assert!(matches!(error, PolarError {
+            kind: ErrorKind::Runtime(RuntimeError::Unsupported { .. }), ..}));
+
+        // Comparison.
+        polar.load_str(r#"i(x, y) if x > y;"#)?;
+        let mut query = polar.new_query_from_term(
+            term!(call!(
+                "i",
+                [Constraints::new(sym!("a")), Constraints::new(sym!("b"))]
+            )),
+            false,
+        );
+        let error = query.next_event().unwrap_err();
+        assert!(matches!(error, PolarError {
+            kind: ErrorKind::Runtime(RuntimeError::Unsupported { .. }), ..}));
         Ok(())
     }
 }

--- a/polar-core/src/partial/constraints.rs
+++ b/polar-core/src/partial/constraints.rs
@@ -452,6 +452,23 @@ mod test {
     }
 
     #[test]
+    fn test_multiple_partials() -> TestResult {
+        let polar = Polar::new();
+        polar.load_str(r#"f(x, y) if x = 1 and y = 2;"#)?;
+        let mut query = polar.new_query_from_term(
+            term!(call!(
+                "f",
+                [Constraints::new(sym!("a")), Constraints::new(sym!("b"))]
+            )),
+            false,
+        );
+        let next = next_binding(&mut query)?;
+        assert_eq!(next[&sym!("a")], term!(1));
+        assert_eq!(next[&sym!("b")], term!(2));
+        Ok(())
+    }
+
+    #[test]
     fn test_unsupported_ops_on_partial() -> TestResult {
         let polar = Polar::new();
 

--- a/polar-core/src/partial/constraints.rs
+++ b/polar-core/src/partial/constraints.rs
@@ -597,4 +597,25 @@ mod test {
         assert!(matches!(query.next_event()?, QueryEvent::Done { .. }));
         Ok(())
     }
+
+    #[test]
+    fn test_assignment_to_partial() -> TestResult {
+        let polar = Polar::new();
+        polar.load_str(
+            r#"f(x) if x := 1;
+               g(x) if x = 1 and y := x;"#,
+        )?;
+        let mut query =
+            polar.new_query_from_term(term!(call!("f", [Constraints::new(sym!("a"))])), false);
+        let error = query.next_event().unwrap_err();
+        assert!(matches!(error, PolarError {
+            kind: ErrorKind::Runtime(RuntimeError::TypeError { .. }), ..}));
+
+        let mut query =
+            polar.new_query_from_term(term!(call!("g", [Constraints::new(sym!("a"))])), false);
+        let next = next_binding(&mut query)?;
+        assert_eq!(next[&sym!("a")], term!(1));
+        assert!(matches!(query.next_event()?, QueryEvent::Done { .. }));
+        Ok(())
+    }
 }

--- a/polar-core/src/partial/constraints.rs
+++ b/polar-core/src/partial/constraints.rs
@@ -539,6 +539,25 @@ mod test {
     }
 
     #[test]
+    fn test_trivial_partials() -> TestResult {
+        let polar = Polar::new();
+        polar.load_str(
+            r#"f(x);
+               g(x) if false;"#,
+        )?;
+        let mut query =
+            polar.new_query_from_term(term!(call!("f", [Constraints::new(sym!("a"))])), false);
+        let next = next_binding(&mut query)?;
+        assert_eq!(next[&sym!("a")], term!(true));
+        assert!(matches!(query.next_event()?, QueryEvent::Done { .. }));
+
+        let mut query =
+            polar.new_query_from_term(term!(call!("g", [Constraints::new(sym!("a"))])), false);
+        assert!(matches!(query.next_event()?, QueryEvent::Done { .. }));
+        Ok(())
+    }
+
+    #[test]
     fn test_cut_with_partial() -> TestResult {
         let polar = Polar::new();
         polar.load_str(

--- a/polar-core/src/partial/constraints.rs
+++ b/polar-core/src/partial/constraints.rs
@@ -327,6 +327,18 @@ mod test {
     }
 
     #[test]
+    fn test_partial_isa_with_fields() -> TestResult {
+        let polar = Polar::new();
+        polar.load_str(r#"f(x: Post{id: 1});"#)?;
+
+        let mut query = polar.new_query_from_term(term!(call!("f", [partial!("a")])), false);
+        let error = query.next_event().unwrap_err();
+        assert!(matches!(error, PolarError {
+            kind: ErrorKind::Runtime(RuntimeError::Unsupported { .. }), ..}));
+        Ok(())
+    }
+
+    #[test]
     fn test_partial_isa_two_rule() -> TestResult {
         let polar = Polar::new();
         polar.load_str(r#"f(x: Post) if x.foo = 0 and g(x);"#)?;

--- a/polar-core/src/partial/constraints.rs
+++ b/polar-core/src/partial/constraints.rs
@@ -526,6 +526,19 @@ mod test {
     }
 
     #[test]
+    fn test_in_with_partial() -> TestResult {
+        let polar = Polar::new();
+        polar.load_str(r#"f(x) if x in [1, 2];"#)?;
+        let mut query = polar.new_query_from_term(term!(call!("f", [partial!("a")])), false);
+        let next = next_binding(&mut query)?;
+        assert_eq!(next[&sym!("a")], term!(1));
+        let next = next_binding(&mut query)?;
+        assert_eq!(next[&sym!("a")], term!(2));
+        assert!(matches!(query.next_event()?, QueryEvent::Done { .. }));
+        Ok(())
+    }
+
+    #[test]
     fn test_that_cut_with_partial_errors() -> TestResult {
         let polar = Polar::new();
         polar.load_str(r#"f(x) if cut;"#)?;

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -30,6 +30,10 @@ pub struct Simplifier;
 impl Folder for Simplifier {
     fn fold_term(&mut self, t: Term) -> Term {
         match t.value() {
+            Value::Partial(Constraints { operations, .. }) if operations.is_empty() => {
+                t.clone_with_value(Value::Boolean(true))
+            }
+
             Value::Partial(Constraints { operations, .. }) if operations.len() == 1 => {
                 fn is_this_arg(t: &Term) -> bool {
                     matches!(t.value(), Value::Variable(v) if v.is_this_var())
@@ -56,9 +60,11 @@ impl Folder for Simplifier {
                         assert_eq!(args.len(), 1, "should have exactly 1 non-_this operand");
                         fold_term(args.pop().unwrap(), self)
                     }
+
                     _ => fold_term(t, self),
                 }
             }
+
             _ => fold_term(t, self),
         }
     }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -892,6 +892,8 @@ impl PolarVirtualMachine {
         );
 
         match (&left.value(), &right.value()) {
+            (_, Value::Partial(_)) => unreachable!("cannot match against a partial"),
+
             (Value::List(left), Value::List(right)) => {
                 self.unify_lists(left, right, |(left, right)| Goal::Isa {
                     left: left.clone(),

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -1597,10 +1597,17 @@ impl PolarVirtualMachine {
                 })?;
             }
             Value::Partial(partial) => {
+                if matches!(field.value(), Value::Call(_)) {
+                    return Err(self.set_error_context(
+                        &object,
+                        error::RuntimeError::Unsupported {
+                            msg: format!("cannot call method on partial {}", object.to_polar()),
+                        },
+                    ));
+                }
+
                 let mut partial = partial.clone();
-
                 let value_partial = partial.lookup(field, value.clone());
-
                 let lookup_result_var = value.value().as_symbol().unwrap();
                 self.bind(lookup_result_var, value_partial);
                 self.bind(partial.name(), partial.clone().into_term());
@@ -1679,10 +1686,7 @@ impl PolarVirtualMachine {
                 return Err(self.set_error_context(
                     term,
                     error::RuntimeError::Unsupported {
-                        msg: format!(
-                            "numeric operation only supported on numbers, you have {}",
-                            term.to_polar()
-                        ),
+                        msg: format!("unsupported arithmetic operands: {}", term.to_polar()),
                     },
                 ))
             }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -980,10 +980,23 @@ impl PolarVirtualMachine {
             }
 
             (Value::Partial(partial), _) => {
+                if matches!(right.value(), Value::Pattern(Pattern::Instance(InstanceLiteral {
+                    fields,
+                    ..
+                })) if !fields.is_empty())
+                {
+                    return Err(self.set_error_context(
+                        &right,
+                        error::RuntimeError::Unsupported {
+                            msg:
+                                "cannot yet match a partial against an instance pattern with fields"
+                                    .to_string(),
+                        },
+                    ));
+                }
+
                 let mut partial = partial.clone();
-
                 let compatibility = partial.isa(right.clone());
-
                 let name = partial.name().clone();
 
                 // Run compatibility check

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1449,19 +1449,16 @@ fn test_unify_rule_head() {
 #[test]
 fn test_cut() {
     let mut polar = Polar::new();
-    polar.load_str("a(x) if x = 1 or x = 2;").unwrap();
-    polar.load_str("b(x) if x = 3 or x = 4;").unwrap();
     polar
-        .load_str("bcut(x) if x = 3 or x = 4 and cut;")
-        .unwrap();
-
-    polar.load_str("c(a, b) if a(a) and b(b) and cut;").unwrap();
-    polar.load_str("c_no_cut(a, b) if a(a) and b(b);").unwrap();
-    polar
-        .load_str("c_partial_cut(a, b) if a(a) and bcut(b);")
-        .unwrap();
-    polar
-        .load_str("c_another_partial_cut(a, b) if a(a) and cut and b(b);")
+        .load_str(
+            r#"a(x) if x = 1 or x = 2;
+               b(x) if x = 3 or x = 4;
+               bcut(x) if x = 3 or x = 4 and cut;
+               c(a, b) if a(a) and b(b) and cut;
+               c_no_cut(a, b) if a(a) and b(b);
+               c_partial_cut(a, b) if a(a) and bcut(b);
+               c_another_partial_cut(a, b) if a(a) and cut and b(b);"#,
+        )
         .unwrap();
 
     // Ensure we return multiple results without a cut.

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -517,12 +517,7 @@ fn test_not() {
     assert!(qnull(&mut polar, "h(2)"));
     assert!(qnull(&mut polar, "h(3)"));
 
-    assert!(qeval(
-        &mut polar,
-        "
-        d = {x: 1} and not d.x = 2
-    "
-    ));
+    assert!(qeval(&mut polar, "d = {x: 1} and not d.x = 2"));
 }
 
 #[test]


### PR DESCRIPTION
We now error on:

- [x] comparison of two partials
- [x] unification of two partials
- [x] partial as the RHS of `matches` (not currently parse-able)
- [x] method calls on a partial
- [x] arithmetic ops
- [x] cut in the presence of 1+ partials
- [x] dot lookups where the field is a partial

Added tests for:

- [x] `in`
- [x] `==` (additional comparison op test)
- [x] multiple partials passed into the same rule
- [x] the two trivial partials (`f(x);` and `g(x) if false;`) reducing to `true`/`false`
- [x] some uses of `cut`, which are all currently `#[ignore]`-ed pending future `cut` work.
- [x] assignment to and from a partial