### PR TITLE
Clean up / standardize integration tests

### DIFF
--- a/polar-core/src/macros.rs
+++ b/polar-core/src/macros.rs
@@ -28,6 +28,16 @@ macro_rules! value {
 }
 
 #[macro_export]
+macro_rules! values {
+    ($([$($args:expr),*]),*) => {
+        vec![$(values!($($args),*)),*]
+    };
+    ($($args:expr),*) => {
+        vec![$(value!($args)),*]
+    };
+}
+
+#[macro_export]
 macro_rules! term {
     ($($expr:tt)*) => {
         $crate::macros::TestHelper::<Term>::from(value!($($expr)*)).0

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -51,7 +51,7 @@ fn no_is_subspecializer(_: u64, _: Symbol, _: Symbol) -> bool {
 }
 
 fn query_results<F, G, H, I, J, K>(
-    mut query: Query,
+    mut q: Query,
     mut external_call_handler: F,
     mut make_external_handler: H,
     mut external_isa_handler: I,
@@ -69,8 +69,8 @@ where
 {
     let mut results = vec![];
     loop {
-        let event = query.next_event().unwrap();
-        while let Some(msg) = query.next_message() {
+        let event = q.next_event().unwrap();
+        while let Some(msg) = q.next_message() {
             message_handler(&msg)
         }
         match event {
@@ -91,12 +91,11 @@ where
                 args,
                 kwargs,
             } => {
-                query
-                    .call_result(
-                        call_id,
-                        external_call_handler(call_id, instance, attribute, args, kwargs),
-                    )
-                    .unwrap();
+                q.call_result(
+                    call_id,
+                    external_call_handler(call_id, instance, attribute, args, kwargs),
+                )
+                .unwrap();
             }
             QueryEvent::MakeExternal {
                 instance_id,
@@ -106,7 +105,7 @@ where
                 call_id,
                 instance,
                 class_tag,
-            } => query
+            } => q
                 .question_result(call_id, external_isa_handler(instance, class_tag))
                 .unwrap(),
             QueryEvent::ExternalIsSubSpecializer {
@@ -114,7 +113,7 @@ where
                 instance_id,
                 left_class_tag,
                 right_class_tag,
-            } => query
+            } => q
                 .question_result(
                     call_id,
                     external_is_subspecializer_handler(
@@ -125,7 +124,7 @@ where
                 )
                 .unwrap(),
             QueryEvent::Debug { ref message } => {
-                query.debug_command(&debug_handler(message)).unwrap();
+                q.debug_command(&debug_handler(message)).unwrap();
             }
             _ => {}
         }
@@ -180,11 +179,11 @@ macro_rules! query_results {
     };
 }
 
-fn query_results_with_externals(query: Query) -> (QueryResults, MockExternal) {
+fn query_results_with_externals(q: Query) -> (QueryResults, MockExternal) {
     let mock = RefCell::new(MockExternal::new());
     (
         query_results(
-            query,
+            q,
             |a, b, c, d, e| mock.borrow_mut().external_call(a, b, c, d, e),
             |a, b| mock.borrow_mut().make_external(a, b),
             |a, b| mock.borrow_mut().external_isa(a, b),
@@ -198,37 +197,37 @@ fn query_results_with_externals(query: Query) -> (QueryResults, MockExternal) {
 
 #[track_caller]
 #[must_use = "test results need to be asserted"]
-fn qeval(polar: &mut Polar, query_str: &str) -> bool {
-    let query = polar.new_query(query_str, false).unwrap();
-    !query_results!(query).is_empty()
+fn qeval(p: &mut Polar, query_str: &str) -> bool {
+    let q = p.new_query(query_str, false).unwrap();
+    !query_results!(q).is_empty()
 }
 
 #[track_caller]
 #[must_use = "test results need to be asserted"]
-fn qnull(polar: &mut Polar, query_str: &str) -> bool {
-    let query = polar.new_query(query_str, false).unwrap();
-    query_results!(query).is_empty()
+fn qnull(p: &mut Polar, query_str: &str) -> bool {
+    let q = p.new_query(query_str, false).unwrap();
+    query_results!(q).is_empty()
 }
 
 #[track_caller]
 #[must_use = "test results need to be asserted"]
-fn qext(polar: &mut Polar, query_str: &str, external_results: Vec<Value>) -> QueryResults {
+fn qext(p: &mut Polar, query_str: &str, external_results: Vec<Value>) -> QueryResults {
     let mut external_results: Vec<Term> = external_results
         .into_iter()
         .map(Term::new_from_test)
         .rev()
         .collect();
-    let query = polar.new_query(query_str, false).unwrap();
-    query_results!(query, |_, _, _, _, _| external_results.pop())
+    let q = p.new_query(query_str, false).unwrap();
+    query_results!(q, |_, _, _, _, _| external_results.pop())
 }
 
 #[track_caller]
 #[must_use = "test results need to be asserted"]
-fn qvar(polar: &mut Polar, query_str: &str, var: &str) -> Vec<Value> {
-    let query = polar
+fn qvar(p: &mut Polar, query_str: &str, var: &str) -> Vec<Value> {
+    let q = p
         .new_query(query_str, false)
         .expect("Expected result for var, got None");
-    query_results!(query)
+    query_results!(q)
         .iter()
         .map(|bindings| bindings.0.get(&Symbol(var.to_string())).unwrap().clone())
         .collect()
@@ -236,10 +235,10 @@ fn qvar(polar: &mut Polar, query_str: &str, var: &str) -> Vec<Value> {
 
 #[track_caller]
 #[must_use = "test results need to be asserted"]
-fn qvars(polar: &mut Polar, query_str: &str, vars: &[&str]) -> Vec<Vec<Value>> {
-    let query = polar.new_query(query_str, false).unwrap();
+fn qvars(p: &mut Polar, query_str: &str, vars: &[&str]) -> Vec<Vec<Value>> {
+    let q = p.new_query(query_str, false).unwrap();
 
-    query_results!(query)
+    query_results!(q)
         .iter()
         .map(|bindings| {
             vars.iter()
@@ -249,34 +248,38 @@ fn qvars(polar: &mut Polar, query_str: &str, vars: &[&str]) -> Vec<Vec<Value>> {
         .collect()
 }
 
+type TestResult = Result<(), PolarError>;
+
 /// Adapted from <http://web.cse.ohio-state.edu/~stiff.4/cse3521/prolog-resolution.html>
 #[test]
-fn test_functions() {
-    let mut polar = Polar::new();
-    polar
-        .load_str("f(1); f(2); g(1); g(2); h(2); k(x) if f(x) and h(x) and g(x);")
-        .unwrap();
-
-    assert!(qnull(&mut polar, "k(1)"));
-    assert!(qeval(&mut polar, "k(2)"));
-    assert!(qnull(&mut polar, "k(3)"));
-    assert_eq!(qvar(&mut polar, "k(a)", "a"), vec![value!(2)]);
+fn test_functions() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(1);
+           f(2);
+           g(1);
+           g(2);
+           h(2);
+           k(x) if f(x) and h(x) and g(x);"#,
+    )?;
+    assert!(qnull(&mut p, "k(1)"));
+    assert!(qeval(&mut p, "k(2)"));
+    assert!(qnull(&mut p, "k(3)"));
+    assert_eq!(qvar(&mut p, "k(a)", "a"), vec![value!(2)]);
+    Ok(())
 }
 
 /// Adapted from <http://web.cse.ohio-state.edu/~stiff.4/cse3521/prolog-resolution.html>
 #[test]
-fn test_jealous() {
-    let polar = Polar::new();
-    polar
-        .load_str(
-            r#"loves("vincent", "mia");
-               loves("marcellus", "mia");
-               jealous(a, b) if loves(a, c) and loves(b, c);"#,
-        )
-        .unwrap();
-
-    let query = polar.new_query("jealous(who, of)", false).unwrap();
-    let results = query_results!(query);
+fn test_jealous() -> TestResult {
+    let p = Polar::new();
+    p.load_str(
+        r#"loves("vincent", "mia");
+           loves("marcellus", "mia");
+           jealous(a, b) if loves(a, c) and loves(b, c);"#,
+    )?;
+    let q = p.new_query("jealous(who, of)", false)?;
+    let results = query_results!(q);
     let jealous = |who: &str, of: &str| {
         assert!(
             &results.iter().any(|(r, _)| r
@@ -291,60 +294,79 @@ fn test_jealous() {
     jealous("vincent", "marcellus");
     jealous("marcellus", "vincent");
     jealous("marcellus", "marcellus");
+    Ok(())
 }
 
 #[test]
-fn test_trace() {
-    let polar = Polar::new();
-    polar
-        .load_str("f(x) if x = 1 and x = 1; f(y) if y = 1;")
-        .unwrap();
-    let query = polar.new_query("f(1)", true).unwrap();
-    let results = query_results!(query);
+fn test_trace() -> TestResult {
+    let p = Polar::new();
+    p.load_str(
+        r#"f(x) if x = 1 and x = 1;
+           f(y) if y = 1;"#,
+    )?;
+    let q = p.new_query("f(1)", true)?;
+    let results = query_results!(q);
     let trace = results[0].1.as_ref().unwrap();
-    let expected = r#"f(1) [
-  f(x) if x = 1 and x = 1; [
-      x = 1 []
-      x = 1 []
-  ]
-]
-"#;
+    let expected = indoc!(
+        r#"
+        f(1) [
+          f(x) if x = 1 and x = 1; [
+              x = 1 []
+              x = 1 []
+          ]
+        ]
+        "#
+    );
     assert_eq!(trace.formatted, expected);
     let trace = results[1].1.as_ref().unwrap();
-    let expected = r#"f(1) [
-  f(y) if y = 1; [
-      y = 1 []
-  ]
-]
-"#;
+    let expected = indoc!(
+        r#"
+        f(1) [
+          f(y) if y = 1; [
+              y = 1 []
+          ]
+        ]
+        "#
+    );
     assert_eq!(trace.formatted, expected);
+    Ok(())
 }
 
 #[test]
-fn test_nested_rule() {
-    let mut polar = Polar::new();
-    polar
-        .load_str("f(x) if g(x); g(x) if h(x); h(2); g(x) if j(x); j(4);")
-        .unwrap();
-
-    assert!(qeval(&mut polar, "f(2)"));
-    assert!(qnull(&mut polar, "f(3)"));
-    assert!(qeval(&mut polar, "f(4)"));
-    assert!(qeval(&mut polar, "j(4)"));
+fn test_nested_rule() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(x) if g(x);
+           g(x) if h(x);
+           h(2);
+           g(x) if j(x);
+           j(4);"#,
+    )?;
+    assert!(qeval(&mut p, "f(2)"));
+    assert!(qnull(&mut p, "f(3)"));
+    assert!(qeval(&mut p, "f(4)"));
+    assert!(qeval(&mut p, "j(4)"));
+    Ok(())
 }
 
 /// A functions permutation that is known to fail.
 #[test]
-fn test_bad_functions() {
-    let mut polar = Polar::new();
-    polar
-        .load_str("f(2); f(1); g(1); g(2); h(2); k(x) if f(x) and h(x) and g(x);")
-        .unwrap();
-    assert_eq!(qvar(&mut polar, "k(a)", "a"), vec![value!(2)]);
+fn test_bad_functions() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(2);
+           f(1);
+           g(1);
+           g(2);
+           h(2);
+           k(x) if f(x) and h(x) and g(x);"#,
+    )?;
+    assert_eq!(qvar(&mut p, "k(a)", "a"), vec![value!(2)]);
+    Ok(())
 }
 
 #[test]
-fn test_functions_reorder() {
+fn test_functions_reorder() -> TestResult {
     // TODO (dhatch): Reorder f(x), h(x), g(x)
     let parts = vec![
         "f(1)",
@@ -356,25 +378,25 @@ fn test_functions_reorder() {
     ];
 
     for (i, permutation) in permute(parts).into_iter().enumerate() {
-        let mut polar = Polar::new();
+        let mut p = Polar::new();
 
         let mut joined = permutation.join(";");
         joined.push(';');
-        polar.load_str(&joined).unwrap();
+        p.load_str(&joined)?;
 
         assert!(
-            qnull(&mut polar, "k(1)"),
+            qnull(&mut p, "k(1)"),
             "k(1) was true for permutation {:?}",
             &permutation
         );
         assert!(
-            qeval(&mut polar, "k(2)"),
+            qeval(&mut p, "k(2)"),
             "k(2) failed for permutation {:?}",
             &permutation
         );
 
         assert_eq!(
-            qvar(&mut polar, "k(a)", "a"),
+            qvar(&mut p, "k(a)", "a"),
             vec![value!(2)],
             "k(a) failed for permutation {:?}",
             &permutation
@@ -382,20 +404,26 @@ fn test_functions_reorder() {
 
         println!("permute: {}", i);
     }
+    Ok(())
 }
 
 #[test]
-fn test_results() {
-    let mut polar = Polar::new();
-    polar.load_str("foo(1); foo(2); foo(3);").unwrap();
+fn test_results() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"foo(1);
+           foo(2);
+           foo(3);"#,
+    )?;
     assert_eq!(
-        qvar(&mut polar, "foo(a)", "a"),
+        qvar(&mut p, "foo(a)", "a"),
         vec![value!(1), value!(2), value!(3)]
     );
+    Ok(())
 }
 
 #[test]
-fn test_result_permutations() {
+fn test_result_permutations() -> TestResult {
     let parts = vec![
         (1, "foo(1)"),
         (2, "foo(2)"),
@@ -405,24 +433,28 @@ fn test_result_permutations() {
     ];
     for permutation in permute(parts).into_iter() {
         eprintln!("{:?}", permutation);
-        let mut polar = Polar::new();
+        let mut p = Polar::new();
         let (results, rules): (Vec<_>, Vec<_>) = permutation.into_iter().unzip();
-        polar.load_str(&format!("{};", rules.join(";"))).unwrap();
+        p.load_str(&format!("{};", rules.join(";")))?;
         assert_eq!(
-            qvar(&mut polar, "foo(a)", "a"),
+            qvar(&mut p, "foo(a)", "a"),
             results.into_iter().map(|v| value!(v)).collect::<Vec<_>>()
         );
     }
+    Ok(())
 }
 
 #[test]
-fn test_multi_arg_method_ordering() {
-    let mut polar = Polar::new();
-    polar
-        .load_str("bar(2, 1); bar(1, 1); bar(1, 2); bar(2, 2);")
-        .unwrap();
+fn test_multi_arg_method_ordering() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"bar(2, 1);
+           bar(1, 1);
+           bar(1, 2);
+           bar(2, 2);"#,
+    )?;
     assert_eq!(
-        qvars(&mut polar, "bar(a, b)", &["a", "b"]),
+        qvars(&mut p, "bar(a, b)", &["a", "b"]),
         vec![
             vec![value!(2), value!(1)],
             vec![value!(1), value!(1)],
@@ -430,282 +462,303 @@ fn test_multi_arg_method_ordering() {
             vec![value!(2), value!(2)],
         ]
     );
+    Ok(())
 }
 
 #[test]
-fn test_no_applicable_rules() {
-    let mut polar = Polar::new();
-    assert!(qnull(&mut polar, "f()"));
-
-    polar.load_str("f(_);").unwrap();
-    assert!(qnull(&mut polar, "f()"));
+fn test_no_applicable_rules() -> TestResult {
+    let mut p = Polar::new();
+    assert!(qnull(&mut p, "f()"));
+    p.load_str("f(_);")?;
+    assert!(qnull(&mut p, "f()"));
+    Ok(())
 }
 
 /// From Aït-Kaci's WAM tutorial (1999), page 34.
 #[test]
-fn test_ait_kaci_34() {
-    let mut polar = Polar::new();
-    polar
-        .load_str(
-            r#"a() if b(x) and c(x);
-               b(x) if e(x);
-               c(1);
-               e(x) if f(x);
-               e(x) if g(x);
-               f(2);
-               g(1);"#,
-        )
-        .unwrap();
-    assert!(qeval(&mut polar, "a()"));
+fn test_ait_kaci_34() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"a() if b(x) and c(x);
+           b(x) if e(x);
+           c(1);
+           e(x) if f(x);
+           e(x) if g(x);
+           f(2);
+           g(1);"#,
+    )?;
+    assert!(qeval(&mut p, "a()"));
+    Ok(())
 }
 
 #[test]
-fn test_constants() {
-    let mut polar = Polar::new();
+fn test_constants() -> TestResult {
+    let mut p = Polar::new();
     {
-        let mut kb = polar.kb.write().unwrap();
+        let mut kb = p.kb.write().unwrap();
         kb.constant(sym!("one"), term!(1));
         kb.constant(sym!("two"), term!(2));
         kb.constant(sym!("three"), term!(3));
     }
-    polar
-        .load_str(
-            r#"one(x) if one = one and one = x and x < two;
-               two(x) if one < x and two = two and two = x and two < three;
-               three(x) if three = three and three = x;"#,
-        )
-        .unwrap();
-    assert!(qeval(&mut polar, "one(1)"));
-    assert!(qnull(&mut polar, "two(1)"));
-    assert!(qeval(&mut polar, "two(2)"));
-    assert!(qnull(&mut polar, "three(2)"));
-    assert!(qeval(&mut polar, "three(3)"));
+    p.load_str(
+        r#"one(x) if one = one and one = x and x < two;
+           two(x) if one < x and two = two and two = x and two < three;
+           three(x) if three = three and three = x;"#,
+    )?;
+    assert!(qeval(&mut p, "one(1)"));
+    assert!(qnull(&mut p, "two(1)"));
+    assert!(qeval(&mut p, "two(2)"));
+    assert!(qnull(&mut p, "three(2)"));
+    assert!(qeval(&mut p, "three(3)"));
+    Ok(())
 }
 
 #[test]
-fn test_not() {
-    let mut polar = Polar::new();
-    polar.load_str("odd(1); even(2);").unwrap();
-    assert!(qeval(&mut polar, "odd(1)"));
-    assert!(qnull(&mut polar, "not odd(1)"));
-    assert!(qnull(&mut polar, "even(1)"));
-    assert!(qeval(&mut polar, "not even(1)"));
-    assert!(qnull(&mut polar, "odd(2)"));
-    assert!(qeval(&mut polar, "not odd(2)"));
-    assert!(qeval(&mut polar, "even(2)"));
-    assert!(qnull(&mut polar, "not even(2)"));
-    assert!(qnull(&mut polar, "even(3)"));
-    assert!(qeval(&mut polar, "not even(3)"));
+fn test_not() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str("odd(1); even(2);")?;
+    assert!(qeval(&mut p, "odd(1)"));
+    assert!(qnull(&mut p, "not odd(1)"));
+    assert!(qnull(&mut p, "even(1)"));
+    assert!(qeval(&mut p, "not even(1)"));
+    assert!(qnull(&mut p, "odd(2)"));
+    assert!(qeval(&mut p, "not odd(2)"));
+    assert!(qeval(&mut p, "even(2)"));
+    assert!(qnull(&mut p, "not even(2)"));
+    assert!(qnull(&mut p, "even(3)"));
+    assert!(qeval(&mut p, "not even(3)"));
 
-    polar
-        .load_str("f(x) if not a(x); a(1); b(2); g(x) if not (a(x) or b(x));")
-        .unwrap();
+    p.load_str(
+        r#"f(x) if not a(x);
+           a(1);
+           b(2);
+           g(x) if not (a(x) or b(x));"#,
+    )?;
 
-    assert!(qnull(&mut polar, "f(1)"));
-    assert!(qeval(&mut polar, "f(2)"));
+    assert!(qnull(&mut p, "f(1)"));
+    assert!(qeval(&mut p, "f(2)"));
 
-    assert!(qnull(&mut polar, "g(1)"));
-    assert!(qnull(&mut polar, "g(2)"));
-    assert!(qeval(&mut polar, "g(3)"));
-    assert!(qnull(&mut polar, "g(x) and x=3")); // this should fail because unbound x means g(x) always fails
-    assert!(qeval(&mut polar, "x=3 and g(x)"));
+    assert!(qnull(&mut p, "g(1)"));
+    assert!(qnull(&mut p, "g(2)"));
+    assert!(qeval(&mut p, "g(3)"));
+    assert!(qnull(&mut p, "g(x) and x=3")); // this should fail because unbound x means g(x) always fails
+    assert!(qeval(&mut p, "x=3 and g(x)"));
 
-    polar
-        .load_str("h(x) if not (not (x = 1 or x = 3) or x = 3);")
-        .unwrap();
-    assert!(qeval(&mut polar, "h(1)"));
-    assert!(qnull(&mut polar, "h(2)"));
-    assert!(qnull(&mut polar, "h(3)"));
+    p.load_str("h(x) if not (not (x = 1 or x = 3) or x = 3);")?;
+    assert!(qeval(&mut p, "h(1)"));
+    assert!(qnull(&mut p, "h(2)"));
+    assert!(qnull(&mut p, "h(3)"));
 
-    assert!(qeval(&mut polar, "d = {x: 1} and not d.x = 2"));
+    assert!(qeval(&mut p, "d = {x: 1} and not d.x = 2"));
+    Ok(())
 }
 
 #[test]
-fn test_and() {
-    let mut polar = Polar::new();
-    polar.load_str("f(1); f(2);").unwrap();
-    assert!(qeval(&mut polar, "f(1) and f(2)"));
-    assert!(qnull(&mut polar, "f(1) and f(2) and f(3)"));
+fn test_and() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(1);
+           f(2);"#,
+    )?;
+    assert!(qeval(&mut p, "f(1) and f(2)"));
+    assert!(qnull(&mut p, "f(1) and f(2) and f(3)"));
+    Ok(())
 }
 
 #[test]
 fn test_equality() {
-    let mut polar = Polar::new();
-    assert!(qeval(&mut polar, "1 = 1"));
-    assert!(qnull(&mut polar, "1 = 2"));
+    let mut p = Polar::new();
+    assert!(qeval(&mut p, "1 = 1"));
+    assert!(qnull(&mut p, "1 = 2"));
 }
 
 #[test]
 fn test_lookup() {
-    let mut polar = Polar::new();
-    assert!(qeval(&mut polar, "{x: 1}.x = 1"));
+    assert!(qeval(&mut Polar::new(), "{x: 1}.x = 1"));
 }
 
 #[test]
 fn test_instance_lookup() {
-    let mut polar = Polar::new();
     // Q: Not sure if this should be allowed? I can't get (new a{x: 1}).x to parse, but that might
     // be the only thing we should permit
     assert_eq!(
-        qext(&mut polar, "new a(x: 1).x = 1", vec![value!(1)]).len(),
+        qext(&mut Polar::new(), "new a(x: 1).x = 1", vec![value!(1)]).len(),
         1
     );
 }
 
 /// Adapted from <http://web.cse.ohio-state.edu/~stiff.4/cse3521/prolog-resolution.html>
 #[test]
-fn test_retries() {
-    let mut polar = Polar::new();
-    polar
-        .load_str("f(1); f(2); g(1); g(2); h(2); k(x) if f(x) and h(x) and g(x); k(3);")
-        .unwrap();
-
-    assert!(qnull(&mut polar, "k(1)"));
-    assert!(qeval(&mut polar, "k(2)"));
-    assert_eq!(qvar(&mut polar, "k(a)", "a"), vec![value!(2), value!(3)]);
-    assert!(qeval(&mut polar, "k(3)"));
+fn test_retries() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(1);
+           f(2);
+           g(1);
+           g(2);
+           h(2);
+           k(x) if f(x) and h(x) and g(x);
+           k(3);"#,
+    )?;
+    assert!(qnull(&mut p, "k(1)"));
+    assert!(qeval(&mut p, "k(2)"));
+    assert_eq!(qvar(&mut p, "k(a)", "a"), vec![value!(2), value!(3)]);
+    assert!(qeval(&mut p, "k(3)"));
+    Ok(())
 }
 
 #[test]
-fn test_two_rule_bodies_not_nested() {
-    let mut polar = Polar::new();
-    polar.load_str("f(x) if a(x); f(1);").unwrap();
-    assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1)]);
+fn test_two_rule_bodies_not_nested() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(x) if a(x);
+           f(1);"#,
+    )?;
+    assert_eq!(qvar(&mut p, "f(x)", "x"), vec![value!(1)]);
+    Ok(())
 }
 
 #[test]
-fn test_two_rule_bodies_nested() {
-    let mut polar = Polar::new();
-    polar.load_str("f(x) if a(x); f(1); a(x) if g(x);").unwrap();
-    assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1)]);
+fn test_two_rule_bodies_nested() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(x) if a(x);
+           f(1);
+           a(x) if g(x);"#,
+    )?;
+    assert_eq!(qvar(&mut p, "f(x)", "x"), vec![value!(1)]);
+    Ok(())
 }
 
 #[test]
-fn test_unify_and() {
-    let mut polar = Polar::new();
-    polar
-        .load_str("f(x, y) if a(x) and y = 2; a(1); a(3);")
-        .unwrap();
-    assert_eq!(qvar(&mut polar, "f(x, y)", "x"), vec![value!(1), value!(3)]);
-    assert_eq!(qvar(&mut polar, "f(x, y)", "y"), vec![value!(2), value!(2)]);
+fn test_unify_and() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(x, y) if a(x) and y = 2;
+           a(1);
+           a(3);"#,
+    )?;
+    assert_eq!(qvar(&mut p, "f(x, y)", "x"), vec![value!(1), value!(3)]);
+    assert_eq!(qvar(&mut p, "f(x, y)", "y"), vec![value!(2), value!(2)]);
+    Ok(())
 }
 
 #[test]
 fn test_symbol_lookup() {
-    let mut polar = Polar::new();
+    let mut p = Polar::new();
+    assert_eq!(qvar(&mut p, "{x: 1}.x = result", "result"), vec![value!(1)]);
     assert_eq!(
-        qvar(&mut polar, "{x: 1}.x = result", "result"),
-        vec![value!(1)]
-    );
-    assert_eq!(
-        qvar(&mut polar, "{x: 1} = dict and dict.x = result", "result"),
+        qvar(&mut p, "{x: 1} = dict and dict.x = result", "result"),
         vec![value!(1)]
     );
 }
 
 #[test]
-fn test_or() {
-    let mut polar = Polar::new();
-    polar.load_str("f(x) if a(x) or b(x); a(1); b(3);").unwrap();
+fn test_or() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(x) if a(x) or b(x);
+           a(1);
+           b(3);"#,
+    )?;
+    assert_eq!(qvar(&mut p, "f(x)", "x"), vec![value!(1), value!(3)]);
+    assert!(qeval(&mut p, "f(1)"));
+    assert!(qnull(&mut p, "f(2)"));
+    assert!(qeval(&mut p, "f(3)"));
 
-    assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1), value!(3)]);
-    assert!(qeval(&mut polar, "f(1)"));
-    assert!(qnull(&mut polar, "f(2)"));
-    assert!(qeval(&mut polar, "f(3)"));
-
-    polar
-        .load_str("g(x) if a(x) or b(x) or c(x); c(5);")
-        .unwrap();
+    p.load_str(
+        r#"g(x) if a(x) or b(x) or c(x);
+           c(5);"#,
+    )?;
     assert_eq!(
-        qvar(&mut polar, "g(x)", "x"),
+        qvar(&mut p, "g(x)", "x"),
         vec![value!(1), value!(3), value!(5)]
     );
-    assert!(qeval(&mut polar, "g(1)"));
-    assert!(qnull(&mut polar, "g(2)"));
-    assert!(qeval(&mut polar, "g(3)"));
-    assert!(qeval(&mut polar, "g(5)"));
+    assert!(qeval(&mut p, "g(1)"));
+    assert!(qnull(&mut p, "g(2)"));
+    assert!(qeval(&mut p, "g(3)"));
+    assert!(qeval(&mut p, "g(5)"));
+    Ok(())
 }
 
 #[test]
-fn test_dict_specializers() {
-    let mut polar = Polar::new();
-    polar.load_str("f({x: 1});").unwrap();
-    polar.load_str("g(_: {x: 1});").unwrap();
-
+fn test_dict_specializers() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f({x: 1});
+           g(_: {x: 1});"#,
+    )?;
     // Test unifying dicts against our rules.
-    assert!(qeval(&mut polar, "f({x: 1})"));
-    assert!(qnull(&mut polar, "f({x: 1, y: 2})"));
-    assert!(qnull(&mut polar, "f(1)"));
-    assert!(qnull(&mut polar, "f({})"));
-    assert!(qnull(&mut polar, "f({x: 2})"));
-    assert!(qnull(&mut polar, "f({y: 1})"));
+    assert!(qeval(&mut p, "f({x: 1})"));
+    assert!(qnull(&mut p, "f({x: 1, y: 2})"));
+    assert!(qnull(&mut p, "f(1)"));
+    assert!(qnull(&mut p, "f({})"));
+    assert!(qnull(&mut p, "f({x: 2})"));
+    assert!(qnull(&mut p, "f({y: 1})"));
 
-    assert!(qeval(&mut polar, "g({x: 1})"));
-    assert!(qeval(&mut polar, "g({x: 1, y: 2})"));
-    assert!(qnull(&mut polar, "g(1)"));
-    assert!(qnull(&mut polar, "g({})"));
-    assert!(qnull(&mut polar, "g({x: 2})"));
-    assert!(qnull(&mut polar, "g({y: 1})"));
+    assert!(qeval(&mut p, "g({x: 1})"));
+    assert!(qeval(&mut p, "g({x: 1, y: 2})"));
+    assert!(qnull(&mut p, "g(1)"));
+    assert!(qnull(&mut p, "g({})"));
+    assert!(qnull(&mut p, "g({x: 2})"));
+    assert!(qnull(&mut p, "g({y: 1})"));
 
     // Test unifying & isa-ing instances against our rules.
-    assert!(qnull(&mut polar, "f(new a(x: 1))"));
+    assert!(qnull(&mut p, "f(new a(x: 1))"));
     assert_eq!(
-        qext(&mut polar, "g(new a(x: 1))", vec![value!(1), value!(1)]).len(),
+        qext(&mut p, "g(new a(x: 1))", vec![value!(1), value!(1)]).len(),
         1
     );
-    assert!(qnull(&mut polar, "f(new a())"));
-    assert!(qnull(&mut polar, "f(new a(x: {}))"));
-    assert!(qext(&mut polar, "g(new a(x: 2))", vec![value!(2), value!(2)]).is_empty());
+    assert!(qnull(&mut p, "f(new a())"));
+    assert!(qnull(&mut p, "f(new a(x: {}))"));
+    assert!(qext(&mut p, "g(new a(x: 2))", vec![value!(2), value!(2)]).is_empty());
     assert_eq!(
-        qext(
-            &mut polar,
-            "g(new a(y: 2, x: 1))",
-            vec![value!(1), value!(1)]
-        )
-        .len(),
+        qext(&mut p, "g(new a(y: 2, x: 1))", vec![value!(1), value!(1)]).len(),
         1
     );
+    Ok(())
 }
 
 #[test]
-fn test_non_instance_specializers() {
-    let mut polar = Polar::new();
-    polar.load_str("f(x: 1) if x = 1;").unwrap();
-    assert!(qeval(&mut polar, "f(1)"));
-    assert!(qnull(&mut polar, "f(2)"));
+fn test_non_instance_specializers() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str("f(x: 1) if x = 1;")?;
+    assert!(qeval(&mut p, "f(1)"));
+    assert!(qnull(&mut p, "f(2)"));
 
-    polar.load_str("g(x: 1, y: [x]) if y = [1];").unwrap();
-    assert!(qeval(&mut polar, "g(1, [1])"));
-    assert!(qnull(&mut polar, "g(1, [2])"));
+    p.load_str("g(x: 1, y: [x]) if y = [1];")?;
+    assert!(qeval(&mut p, "g(1, [1])"));
+    assert!(qnull(&mut p, "g(1, [2])"));
 
-    polar.load_str("h(x: {y: y}, x.y) if y = 1;").unwrap();
-    assert!(qeval(&mut polar, "h({y: 1}, 1)"));
-    assert!(qnull(&mut polar, "h({y: 1}, 2)"));
+    p.load_str("h(x: {y: y}, x.y) if y = 1;")?;
+    assert!(qeval(&mut p, "h({y: 1}, 1)"));
+    assert!(qnull(&mut p, "h({y: 1}, 2)"));
+    Ok(())
 }
 
 #[test]
-fn test_bindings() {
-    let mut polar = Polar::new();
-    assert_eq!(qvar(&mut polar, "x=1", "x"), vec![value!(1)]);
-    assert_eq!(qvar(&mut polar, "x=x", "x"), vec![value!(sym!("x"))]);
-    assert_eq!(
-        qvar(&mut polar, "x=y and y=x", "x"),
-        vec![value!(sym!("y"))]
-    );
+fn test_bindings() -> TestResult {
+    let mut p = Polar::new();
+    assert_eq!(qvar(&mut p, "x=1", "x"), vec![value!(1)]);
+    assert_eq!(qvar(&mut p, "x=x", "x"), vec![value!(sym!("x"))]);
+    assert_eq!(qvar(&mut p, "x=y and y=x", "x"), vec![value!(sym!("y"))]);
 
-    polar
-        .load_str("f(x) if x = y and g(y); g(y) if y = 1;")
-        .unwrap();
-    assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1)]);
+    p.load_str(
+        r#"f(x) if x = y and g(y);
+           g(y) if y = 1;"#,
+    )?;
+    assert_eq!(qvar(&mut p, "f(x)", "x"), vec![value!(1)]);
+    Ok(())
 }
 
 #[test]
-fn test_lookup_derefs() {
-    let polar = Polar::new();
-    polar
-        .load_str("f(x) if x = y and g(y); g(y) if new Foo().get(y) = y;")
-        .unwrap();
-    let query = polar.new_query("f(1)", false).unwrap();
+fn test_lookup_derefs() -> TestResult {
+    let p = Polar::new();
+    p.load_str(
+        r#"f(x) if x = y and g(y);
+           g(y) if new Foo().get(y) = y;"#,
+    )?;
+    let q = p.new_query("f(1)", false)?;
     let mut foo_lookups = vec![term!(1)];
     let mock_foo = |_, _, _, args: Option<Vec<Term>>, _| {
         // check the argument is bound to an integer
@@ -713,7 +766,7 @@ fn test_lookup_derefs() {
         foo_lookups.pop()
     };
 
-    let results = query_results!(query, mock_foo);
+    let results = query_results!(q, mock_foo);
     assert!(foo_lookups.is_empty());
     assert_eq!(results.len(), 1);
 
@@ -722,56 +775,61 @@ fn test_lookup_derefs() {
         assert!(matches!(args.unwrap()[0].value(), Value::Number(_)));
         foo_lookups.pop()
     };
-    let query = polar.new_query("f(2)", false).unwrap();
-    let results = query_results!(query, mock_foo);
+    let q = p.new_query("f(2)", false)?;
+    let results = query_results!(q, mock_foo);
     assert!(results.is_empty());
+    Ok(())
 }
 
 #[test]
-fn unify_predicates() {
-    let mut polar = Polar::new();
-    polar
-        .load_str("f(g(_x)); k(x) if h(g(x), g(x)); h(g(1), g(1));")
-        .unwrap();
-
-    assert!(qeval(&mut polar, "f(g(1))"));
-    assert!(qnull(&mut polar, "f(1)"));
-    assert!(qeval(&mut polar, "k(1)"));
+fn unify_predicates() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(g(_x));
+           k(x) if h(g(x), g(x));
+           h(g(1), g(1));"#,
+    )?;
+    assert!(qeval(&mut p, "f(g(1))"));
+    assert!(qnull(&mut p, "f(1)"));
+    assert!(qeval(&mut p, "k(1)"));
+    Ok(())
 }
 
 /// Test that rules are executed in the correct order.
 #[test]
-fn test_rule_order() {
-    let mut polar = Polar::new();
-    polar.load_str("a(\"foo\");").unwrap();
-    polar.load_str("a(\"bar\");").unwrap();
-    polar.load_str("a(\"baz\");").unwrap();
-
+fn test_rule_order() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"a("foo");
+           a("bar");
+           a("baz");"#,
+    )?;
     assert_eq!(
-        qvar(&mut polar, "a(x)", "x"),
+        qvar(&mut p, "a(x)", "x"),
         vec![value!("foo"), value!("bar"), value!("baz")]
     );
+    Ok(())
 }
 
 #[test]
-fn test_load_str_with_query() {
-    let polar = Polar::new();
-    let src = "f(1); f(2); ?= f(1); ?= not f(3);";
-    polar.load_str(src).expect("load_str failed");
-
-    while let Some(query) = polar.next_inline_query(false) {
-        assert_eq!(query_results!(query).len(), 1);
+fn test_load_str_with_query() -> TestResult {
+    let p = Polar::new();
+    p.load_str(
+        r#"f(1);
+           f(2);
+           ?= f(1);
+           ?= not f(3);"#,
+    )?;
+    while let Some(q) = p.next_inline_query(false) {
+        assert_eq!(query_results!(q).len(), 1);
     }
+    Ok(())
 }
 
 /// Test using a constructor with positional + kwargs.
 #[test]
-fn test_make_external() {
-    let polar = Polar::new();
-    let query = polar
-        .new_query("x = new Bar(1, a: 2, b: 3)", false)
-        .unwrap();
-
+fn test_make_external() -> TestResult {
+    let q = Polar::new().new_query("x = new Bar(1, a: 2, b: 3)", false)?;
     let mock_make_bar = |_, constructor: Term| match constructor.value() {
         Value::Call(Call {
             name,
@@ -782,20 +840,19 @@ fn test_make_external() {
             && kwargs == &btreemap! {sym!("a") => term!(2), sym!("b") => term!(3)} => {}
         _ => panic!("Expected call with args and kwargs"),
     };
-    let results = query_results!(query, no_results, mock_make_bar, no_debug);
+    let results = query_results!(q, no_results, mock_make_bar, no_debug);
     assert_eq!(results.len(), 1);
+    Ok(())
 }
 
 /// Test external call with positional + kwargs.
 #[test]
-fn test_external_call() {
-    let polar = Polar::new();
-    polar.register_constant(sym!("Foo"), term!(true));
+fn test_external_call() -> TestResult {
+    let p = Polar::new();
+    p.register_constant(sym!("Foo"), term!(true));
     let mut foo_lookups = vec![term!(1)];
 
-    let query = polar
-        .new_query("(new Foo()).bar(1, a: 2, b: 3) = 1", false)
-        .unwrap();
+    let q = p.new_query("(new Foo()).bar(1, a: 2, b: 3) = 1", false)?;
 
     let mock_foo_lookup =
         |_, _, _, args: Option<Vec<Term>>, kwargs: Option<BTreeMap<Symbol, Term>>| {
@@ -806,122 +863,122 @@ fn test_external_call() {
             );
             foo_lookups.pop()
         };
-    let results = query_results!(query, mock_foo_lookup);
+    let results = query_results!(q, mock_foo_lookup);
     assert_eq!(results.len(), 1);
     assert!(foo_lookups.is_empty());
+    Ok(())
 }
 #[test]
 #[ignore] // ignore because this take a LONG time (could consider lowering the goal limit)
 #[should_panic(expected = "Goal count exceeded! MAX_EXECUTED_GOALS = 10000")]
 fn test_infinite_loop() {
-    let mut polar = Polar::new();
-    polar.load_str("f(x) if f(x);").unwrap();
-    assert!(qeval(&mut polar, "f(1)"));
+    let mut p = Polar::new();
+    p.load_str("f(x) if f(x);").unwrap();
+    assert!(qeval(&mut p, "f(1)"));
 }
 
 #[test]
-fn test_comparisons() {
-    let mut polar = Polar::new();
+fn test_comparisons() -> TestResult {
+    let mut p = Polar::new();
 
     // <
-    polar.load_str("lt(x, y) if x < y;").unwrap();
-    assert!(qnull(&mut polar, "lt(1,1)"));
-    assert!(qeval(&mut polar, "lt(1,2)"));
-    assert!(qnull(&mut polar, "lt(2,1)"));
-    assert!(qnull(&mut polar, "lt(+1,-1)"));
-    assert!(qeval(&mut polar, "lt(-1,+1)"));
-    assert!(qnull(&mut polar, "lt(-1,-1)"));
-    assert!(qeval(&mut polar, "lt(-2,-1)"));
-    assert!(qeval(&mut polar, "lt(1019,1e19)"));
-    assert!(qnull(&mut polar, "lt(1e19,1019)"));
-    assert!(qnull(&mut polar, "lt(9007199254740992,9007199254740992)")); // identical
-    assert!(qnull(&mut polar, "lt(9007199254740992,9007199254740992.0)")); // equal
-    assert!(qnull(&mut polar, "lt(9007199254740992,9007199254740993.0)")); // indistinguishable
-    assert!(qeval(&mut polar, "lt(9007199254740992,9007199254740994.0)")); // distinguishable
-    assert!(qeval(&mut polar, "lt(\"aa\",\"ab\")"));
-    assert!(qnull(&mut polar, "lt(\"aa\",\"aa\")"));
+    p.load_str("lt(x, y) if x < y;")?;
+    assert!(qnull(&mut p, "lt(1,1)"));
+    assert!(qeval(&mut p, "lt(1,2)"));
+    assert!(qnull(&mut p, "lt(2,1)"));
+    assert!(qnull(&mut p, "lt(+1,-1)"));
+    assert!(qeval(&mut p, "lt(-1,+1)"));
+    assert!(qnull(&mut p, "lt(-1,-1)"));
+    assert!(qeval(&mut p, "lt(-2,-1)"));
+    assert!(qeval(&mut p, "lt(1019,1e19)"));
+    assert!(qnull(&mut p, "lt(1e19,1019)"));
+    assert!(qnull(&mut p, "lt(9007199254740992,9007199254740992)")); // identical
+    assert!(qnull(&mut p, "lt(9007199254740992,9007199254740992.0)")); // equal
+    assert!(qnull(&mut p, "lt(9007199254740992,9007199254740993.0)")); // indistinguishable
+    assert!(qeval(&mut p, "lt(9007199254740992,9007199254740994.0)")); // distinguishable
+    assert!(qeval(&mut p, "lt(\"aa\",\"ab\")"));
+    assert!(qnull(&mut p, "lt(\"aa\",\"aa\")"));
 
     // <=
-    polar.load_str("leq(x, y) if x <= y;").unwrap();
-    assert!(qeval(&mut polar, "leq(1,1)"));
-    assert!(qeval(&mut polar, "leq(1,2)"));
-    assert!(qnull(&mut polar, "leq(2,1)"));
-    assert!(qnull(&mut polar, "leq(+1,-1)"));
-    assert!(qeval(&mut polar, "leq(-1,+1)"));
-    assert!(qeval(&mut polar, "leq(-1,-1)"));
-    assert!(qeval(&mut polar, "leq(-2,-1)"));
-    assert!(qeval(&mut polar, "leq(\"aa\",\"aa\")"));
-    assert!(qeval(&mut polar, "leq(\"aa\",\"ab\")"));
-    assert!(qnull(&mut polar, "leq(\"ab\",\"aa\")"));
+    p.load_str("leq(x, y) if x <= y;")?;
+    assert!(qeval(&mut p, "leq(1,1)"));
+    assert!(qeval(&mut p, "leq(1,2)"));
+    assert!(qnull(&mut p, "leq(2,1)"));
+    assert!(qnull(&mut p, "leq(+1,-1)"));
+    assert!(qeval(&mut p, "leq(-1,+1)"));
+    assert!(qeval(&mut p, "leq(-1,-1)"));
+    assert!(qeval(&mut p, "leq(-2,-1)"));
+    assert!(qeval(&mut p, "leq(\"aa\",\"aa\")"));
+    assert!(qeval(&mut p, "leq(\"aa\",\"ab\")"));
+    assert!(qnull(&mut p, "leq(\"ab\",\"aa\")"));
 
     // >
-    polar.load_str("gt(x, y) if x > y;").unwrap();
-    assert!(qnull(&mut polar, "gt(1,1)"));
-    assert!(qnull(&mut polar, "gt(1,2)"));
-    assert!(qeval(&mut polar, "gt(2,1)"));
-    assert!(qeval(&mut polar, "gt(+1,-1)"));
-    assert!(qnull(&mut polar, "gt(-1,+1)"));
-    assert!(qnull(&mut polar, "gt(-1,-1)"));
-    assert!(qeval(&mut polar, "gt(-1,-2)"));
-    assert!(qeval(&mut polar, "gt(\"ab\",\"aa\")"));
-    assert!(qnull(&mut polar, "gt(\"aa\",\"aa\")"));
+    p.load_str("gt(x, y) if x > y;")?;
+    assert!(qnull(&mut p, "gt(1,1)"));
+    assert!(qnull(&mut p, "gt(1,2)"));
+    assert!(qeval(&mut p, "gt(2,1)"));
+    assert!(qeval(&mut p, "gt(+1,-1)"));
+    assert!(qnull(&mut p, "gt(-1,+1)"));
+    assert!(qnull(&mut p, "gt(-1,-1)"));
+    assert!(qeval(&mut p, "gt(-1,-2)"));
+    assert!(qeval(&mut p, "gt(\"ab\",\"aa\")"));
+    assert!(qnull(&mut p, "gt(\"aa\",\"aa\")"));
 
     // >=
-    polar.load_str("geq(x, y) if x >= y;").unwrap();
-    assert!(qeval(&mut polar, "geq(1,1)"));
-    assert!(qnull(&mut polar, "geq(1,2)"));
-    assert!(qeval(&mut polar, "geq(2,1)"));
-    assert!(qeval(&mut polar, "geq(2,1)"));
-    assert!(qeval(&mut polar, "geq(+1,-1)"));
-    assert!(qnull(&mut polar, "geq(-1,+1)"));
-    assert!(qeval(&mut polar, "geq(-1,-1)"));
-    assert!(qeval(&mut polar, "geq(-1,-1.0)"));
-    assert!(qeval(&mut polar, "geq(\"ab\",\"aa\")"));
-    assert!(qeval(&mut polar, "geq(\"aa\",\"aa\")"));
+    p.load_str("geq(x, y) if x >= y;")?;
+    assert!(qeval(&mut p, "geq(1,1)"));
+    assert!(qnull(&mut p, "geq(1,2)"));
+    assert!(qeval(&mut p, "geq(2,1)"));
+    assert!(qeval(&mut p, "geq(2,1)"));
+    assert!(qeval(&mut p, "geq(+1,-1)"));
+    assert!(qnull(&mut p, "geq(-1,+1)"));
+    assert!(qeval(&mut p, "geq(-1,-1)"));
+    assert!(qeval(&mut p, "geq(-1,-1.0)"));
+    assert!(qeval(&mut p, "geq(\"ab\",\"aa\")"));
+    assert!(qeval(&mut p, "geq(\"aa\",\"aa\")"));
 
     // ==
-    polar.load_str("eq(x, y) if x == y;").unwrap();
-    assert!(qeval(&mut polar, "eq(1,1)"));
-    assert!(qnull(&mut polar, "eq(1,2)"));
-    assert!(qnull(&mut polar, "eq(2,1)"));
-    assert!(qnull(&mut polar, "eq(-1,+1)"));
-    assert!(qeval(&mut polar, "eq(-1,-1)"));
-    assert!(qeval(&mut polar, "eq(-1,-1.0)"));
-    assert!(qnull(&mut polar, "eq(1019,1e19)"));
-    assert!(qnull(&mut polar, "eq(1e19,1019)"));
-    assert!(qeval(&mut polar, "eq(9007199254740992,9007199254740992)")); // identical
-    assert!(qeval(&mut polar, "eq(9007199254740992,9007199254740992.0)")); // equal
-    assert!(qeval(&mut polar, "eq(9007199254740992,9007199254740993.0)")); // indistinguishable
-    assert!(qnull(&mut polar, "eq(9007199254740992,9007199254740994.0)")); // distinguishable
-    assert!(qeval(&mut polar, "eq(\"aa\", \"aa\")"));
-    assert!(qnull(&mut polar, "eq(\"ab\", \"aa\")"));
+    p.load_str("eq(x, y) if x == y;")?;
+    assert!(qeval(&mut p, "eq(1,1)"));
+    assert!(qnull(&mut p, "eq(1,2)"));
+    assert!(qnull(&mut p, "eq(2,1)"));
+    assert!(qnull(&mut p, "eq(-1,+1)"));
+    assert!(qeval(&mut p, "eq(-1,-1)"));
+    assert!(qeval(&mut p, "eq(-1,-1.0)"));
+    assert!(qnull(&mut p, "eq(1019,1e19)"));
+    assert!(qnull(&mut p, "eq(1e19,1019)"));
+    assert!(qeval(&mut p, "eq(9007199254740992,9007199254740992)")); // identical
+    assert!(qeval(&mut p, "eq(9007199254740992,9007199254740992.0)")); // equal
+    assert!(qeval(&mut p, "eq(9007199254740992,9007199254740993.0)")); // indistinguishable
+    assert!(qnull(&mut p, "eq(9007199254740992,9007199254740994.0)")); // distinguishable
+    assert!(qeval(&mut p, "eq(\"aa\", \"aa\")"));
+    assert!(qnull(&mut p, "eq(\"ab\", \"aa\")"));
 
     // !=
-    polar.load_str("neq(x, y) if x != y;").unwrap();
-    assert!(qnull(&mut polar, "neq(1,1)"));
-    assert!(qeval(&mut polar, "neq(1,2)"));
-    assert!(qeval(&mut polar, "neq(2,1)"));
-    assert!(qeval(&mut polar, "neq(-1,+1)"));
-    assert!(qnull(&mut polar, "neq(-1,-1)"));
-    assert!(qnull(&mut polar, "neq(-1,-1.0)"));
-    assert!(qnull(&mut polar, "neq(\"aa\", \"aa\")"));
-    assert!(qeval(&mut polar, "neq(\"ab\", \"aa\")"));
+    p.load_str("neq(x, y) if x != y;")?;
+    assert!(qnull(&mut p, "neq(1,1)"));
+    assert!(qeval(&mut p, "neq(1,2)"));
+    assert!(qeval(&mut p, "neq(2,1)"));
+    assert!(qeval(&mut p, "neq(-1,+1)"));
+    assert!(qnull(&mut p, "neq(-1,-1)"));
+    assert!(qnull(&mut p, "neq(-1,-1.0)"));
+    assert!(qnull(&mut p, "neq(\"aa\", \"aa\")"));
+    assert!(qeval(&mut p, "neq(\"ab\", \"aa\")"));
 
-    let mut query = polar.new_query("eq(bob, bob)", false).unwrap();
-    query
-        .next_event()
-        .expect_err("can't compare unbound variables");
+    let mut q = p.new_query("eq(bob, bob)", false)?;
+    q.next_event().expect_err("can't compare unbound variables");
 
-    assert!(qeval(&mut polar, "1.0 == 1"));
-    assert!(qeval(&mut polar, "0.99 < 1"));
-    assert!(qeval(&mut polar, "1.0 <= 1"));
-    assert!(qeval(&mut polar, "1 == 1"));
-    assert!(qeval(&mut polar, "0.0 == 0"));
+    assert!(qeval(&mut p, "1.0 == 1"));
+    assert!(qeval(&mut p, "0.99 < 1"));
+    assert!(qeval(&mut p, "1.0 <= 1"));
+    assert!(qeval(&mut p, "1 == 1"));
+    assert!(qeval(&mut p, "0.0 == 0"));
+    Ok(())
 }
 
-fn check_arithmetic_error(p: &mut Polar, query: &str) {
-    let mut query = p.new_query(query, false).unwrap();
-    let error = query.next_event().unwrap_err();
+fn check_arithmetic_error(p: &mut Polar, query_str: &str) {
+    let mut q = p.new_query(query_str, false).unwrap();
+    let error = q.next_event().unwrap_err();
     assert!(matches!(
         error.kind,
         ErrorKind::Runtime(RuntimeError::ArithmeticError { .. })
@@ -929,25 +986,25 @@ fn check_arithmetic_error(p: &mut Polar, query: &str) {
 }
 
 #[test]
-fn test_modulo_and_remainder() {
-    let mut polar = Polar::new();
-    assert!(qeval(&mut polar, "1 mod 1 == 0"));
-    assert!(qeval(&mut polar, "1 rem 1 == 0"));
-    assert!(qeval(&mut polar, "1 mod -1 == 0"));
-    assert!(qeval(&mut polar, "1 rem -1 == 0"));
-    assert!(qeval(&mut polar, "0 mod 1 == 0"));
-    assert!(qeval(&mut polar, "0 rem 1 == 0"));
-    assert!(qeval(&mut polar, "0 mod -1 == 0"));
-    assert!(qeval(&mut polar, "0 rem -1 == 0"));
-    check_arithmetic_error(&mut polar, "1 mod 0 = x");
-    check_arithmetic_error(&mut polar, "1 rem 0 = x");
-    let res = qvar(&mut polar, "1 mod 0.0 = x", "x")[0].clone();
+fn test_modulo_and_remainder() -> TestResult {
+    let mut p = Polar::new();
+    assert!(qeval(&mut p, "1 mod 1 == 0"));
+    assert!(qeval(&mut p, "1 rem 1 == 0"));
+    assert!(qeval(&mut p, "1 mod -1 == 0"));
+    assert!(qeval(&mut p, "1 rem -1 == 0"));
+    assert!(qeval(&mut p, "0 mod 1 == 0"));
+    assert!(qeval(&mut p, "0 rem 1 == 0"));
+    assert!(qeval(&mut p, "0 mod -1 == 0"));
+    assert!(qeval(&mut p, "0 rem -1 == 0"));
+    check_arithmetic_error(&mut p, "1 mod 0 = x");
+    check_arithmetic_error(&mut p, "1 rem 0 = x");
+    let res = qvar(&mut p, "1 mod 0.0 = x", "x")[0].clone();
     if let Value::Number(Numeric::Float(x)) = res {
         assert!(x.is_nan());
     } else {
         panic!();
     }
-    let res = qvar(&mut polar, "1 rem 0.0 = x", "x")[0].clone();
+    let res = qvar(&mut p, "1 rem 0.0 = x", "x")[0].clone();
     if let Value::Number(Numeric::Float(x)) = res {
         assert!(x.is_nan());
     } else {
@@ -955,78 +1012,75 @@ fn test_modulo_and_remainder() {
     }
 
     // From http://www.lispworks.com/documentation/lw50/CLHS/Body/f_mod_r.htm.
-    assert!(qeval(&mut polar, "-1 rem 5 == -1"));
-    assert!(qeval(&mut polar, "-1 mod 5 == 4"));
-    assert!(qeval(&mut polar, "13 mod 4 == 1"));
-    assert!(qeval(&mut polar, "13 rem 4 == 1"));
-    assert!(qeval(&mut polar, "-13 mod 4 == 3"));
-    assert!(qeval(&mut polar, "-13 rem 4 == -1"));
-    assert!(qeval(&mut polar, "13 mod -4 == -3"));
-    assert!(qeval(&mut polar, "13 rem -4 == 1"));
-    assert!(qeval(&mut polar, "-13 mod -4 == -1"));
-    assert!(qeval(&mut polar, "-13 rem -4 == -1"));
-    assert!(qeval(&mut polar, "13.4 mod 1 == 0.40000000000000036"));
-    assert!(qeval(&mut polar, "13.4 rem 1 == 0.40000000000000036"));
-    assert!(qeval(&mut polar, "-13.4 mod 1 == 0.5999999999999996"));
-    assert!(qeval(&mut polar, "-13.4 rem 1 == -0.40000000000000036"));
+    assert!(qeval(&mut p, "-1 rem 5 == -1"));
+    assert!(qeval(&mut p, "-1 mod 5 == 4"));
+    assert!(qeval(&mut p, "13 mod 4 == 1"));
+    assert!(qeval(&mut p, "13 rem 4 == 1"));
+    assert!(qeval(&mut p, "-13 mod 4 == 3"));
+    assert!(qeval(&mut p, "-13 rem 4 == -1"));
+    assert!(qeval(&mut p, "13 mod -4 == -3"));
+    assert!(qeval(&mut p, "13 rem -4 == 1"));
+    assert!(qeval(&mut p, "-13 mod -4 == -1"));
+    assert!(qeval(&mut p, "-13 rem -4 == -1"));
+    assert!(qeval(&mut p, "13.4 mod 1 == 0.40000000000000036"));
+    assert!(qeval(&mut p, "13.4 rem 1 == 0.40000000000000036"));
+    assert!(qeval(&mut p, "-13.4 mod 1 == 0.5999999999999996"));
+    assert!(qeval(&mut p, "-13.4 rem 1 == -0.40000000000000036"));
+    Ok(())
 }
 
 #[test]
-fn test_arithmetic() {
-    let mut polar = Polar::new();
-    assert!(qeval(&mut polar, "1 + 1 == 2"));
-    assert!(qeval(&mut polar, "1 + 1 < 3 and 1 + 1 > 1"));
-    assert!(qeval(&mut polar, "2 - 1 == 1"));
-    assert!(qeval(&mut polar, "1 - 2 == -1"));
-    assert!(qeval(&mut polar, "1.23 - 3.21 == -1.98"));
-    assert!(qeval(&mut polar, "2 * 3 == 6"));
-    assert!(qeval(&mut polar, "6 / 2 == 3"));
-    assert!(qeval(&mut polar, "2 / 6 == 0.3333333333333333"));
+fn test_arithmetic() -> TestResult {
+    let mut p = Polar::new();
+    assert!(qeval(&mut p, "1 + 1 == 2"));
+    assert!(qeval(&mut p, "1 + 1 < 3 and 1 + 1 > 1"));
+    assert!(qeval(&mut p, "2 - 1 == 1"));
+    assert!(qeval(&mut p, "1 - 2 == -1"));
+    assert!(qeval(&mut p, "1.23 - 3.21 == -1.98"));
+    assert!(qeval(&mut p, "2 * 3 == 6"));
+    assert!(qeval(&mut p, "6 / 2 == 3"));
+    assert!(qeval(&mut p, "2 / 6 == 0.3333333333333333"));
 
-    polar
-        .load_str(
-            r#"even(0) if cut;
-               even(x) if x > 0 and odd(x - 1);
-               odd(1) if cut;
-               odd(x) if x > 0 and even(x - 1);"#,
-        )
-        .unwrap();
+    p.load_str(
+        r#"even(0) if cut;
+           even(x) if x > 0 and odd(x - 1);
+           odd(1) if cut;
+           odd(x) if x > 0 and even(x - 1);"#,
+    )?;
 
-    assert!(qeval(&mut polar, "even(0)"));
-    assert!(qnull(&mut polar, "even(1)"));
-    assert!(qeval(&mut polar, "even(2)"));
-    assert!(qnull(&mut polar, "even(3)"));
-    assert!(qeval(&mut polar, "even(4)"));
+    assert!(qeval(&mut p, "even(0)"));
+    assert!(qnull(&mut p, "even(1)"));
+    assert!(qeval(&mut p, "even(2)"));
+    assert!(qnull(&mut p, "even(3)"));
+    assert!(qeval(&mut p, "even(4)"));
 
-    assert!(qnull(&mut polar, "odd(0)"));
-    assert!(qeval(&mut polar, "odd(1)"));
-    assert!(qnull(&mut polar, "odd(2)"));
-    assert!(qeval(&mut polar, "odd(3)"));
-    assert!(qnull(&mut polar, "odd(4)"));
+    assert!(qnull(&mut p, "odd(0)"));
+    assert!(qeval(&mut p, "odd(1)"));
+    assert!(qnull(&mut p, "odd(2)"));
+    assert!(qeval(&mut p, "odd(3)"));
+    assert!(qnull(&mut p, "odd(4)"));
 
-    check_arithmetic_error(&mut polar, "9223372036854775807 + 1 > 0");
-    check_arithmetic_error(&mut polar, "-9223372036854775807 - 2 < 0");
+    check_arithmetic_error(&mut p, "9223372036854775807 + 1 > 0");
+    check_arithmetic_error(&mut p, "-9223372036854775807 - 2 < 0");
 
     // x / 0 = ∞
-    assert_eq!(qvar(&mut polar, "x=1/0", "x"), vec![value!(f64::INFINITY)]);
-    assert!(qeval(&mut polar, "1/0 = 2/0"));
-    assert!(qnull(&mut polar, "1/0 < 0"));
-    assert!(qeval(&mut polar, "1/0 > 0"));
-    assert!(qeval(&mut polar, "1/0 > 1e100"));
+    assert_eq!(qvar(&mut p, "x=1/0", "x"), vec![value!(f64::INFINITY)]);
+    assert!(qeval(&mut p, "1/0 = 2/0"));
+    assert!(qnull(&mut p, "1/0 < 0"));
+    assert!(qeval(&mut p, "1/0 > 0"));
+    assert!(qeval(&mut p, "1/0 > 1e100"));
+    Ok(())
 }
 
 #[test]
-fn test_debug() {
-    let source = indoc!(
-        r#"
-        a() if debug("a") and b() and c() and d();
-        b();
-        c() if debug("c");
-        d();"#
-    );
-
-    let polar = Polar::new();
-    polar.load_str(source).unwrap();
+fn test_debug() -> TestResult {
+    let p = Polar::new();
+    p.load_str(indoc!(
+        r#"a() if debug("a") and b() and c() and d();
+           b();
+           c() if debug("c");
+           d();"#
+    ))?;
 
     let mut call_num = 0;
     let debug_handler = |s: &str| {
@@ -1112,20 +1166,17 @@ fn test_debug() {
         rt.to_string()
     };
 
-    let query = polar.new_query("a()", false).unwrap();
-    let _results = query_results!(query, no_results, no_externals, debug_handler);
+    let q = p.new_query("a()", false)?;
+    let _results = query_results!(q, no_results, no_externals, debug_handler);
 
-    let source = indoc!(
-        r#"
-        a() if debug() and b() and c() and d();
-        a() if 5 = 5;
-        b() if 1 = 1 and 2 = 2;
-        c() if 3 = 3 and 4 = 4;
-        d();"#
-    );
-
-    let polar = Polar::new();
-    polar.load_str(source).unwrap();
+    let p = Polar::new();
+    p.load_str(indoc!(
+        r#"a() if debug() and b() and c() and d();
+           a() if 5 = 5;
+           b() if 1 = 1 and 2 = 2;
+           c() if 3 = 3 and 4 = 4;
+           d();"#
+    ))?;
 
     let mut call_num = 0;
     let debug_handler = |s: &str| {
@@ -1173,135 +1224,135 @@ fn test_debug() {
         call_num += 1;
         rt.to_string()
     };
-    let query = polar.new_query("a()", false).unwrap();
-    let _results = query_results!(query, no_results, no_externals, debug_handler);
+    let q = p.new_query("a()", false)?;
+    let _results = query_results!(q, no_results, no_externals, debug_handler);
+    Ok(())
 }
 
 #[test]
 fn test_anonymous_vars() {
-    let mut polar = Polar::new();
-    assert!(qeval(&mut polar, "[1,2,3] = [_,_,_]"));
-    assert!(qnull(&mut polar, "[1,2,3] = [__,__,__]"));
+    let mut p = Polar::new();
+    assert!(qeval(&mut p, "[1,2,3] = [_,_,_]"));
+    assert!(qnull(&mut p, "[1,2,3] = [__,__,__]"));
 }
 
 #[test]
-fn test_singleton_vars() {
-    let polar = Polar::new();
-    polar.register_constant(sym!("X"), term!(true));
-    polar.register_constant(sym!("Y"), term!(true));
-    polar.load_str("f(x:X,y:Y,z:Z) if z = z;").unwrap();
-    let output = polar.next_message().unwrap();
+fn test_singleton_vars() -> TestResult {
+    let p = Polar::new();
+    p.register_constant(sym!("X"), term!(true));
+    p.register_constant(sym!("Y"), term!(true));
+    p.load_str("f(x:X,y:Y,z:Z) if z = z;")?;
+    let output = p.next_message().unwrap();
     assert!(matches!(&output.kind, MessageKind::Warning));
     assert_eq!(
         &output.msg,
         "Singleton variable x is unused or undefined, see <https://docs.osohq.com/using/polar-syntax.html#variables>\n001: f(x:X,y:Y,z:Z) if z = z;\n       ^"
     );
-    let output = polar.next_message().unwrap();
+    let output = p.next_message().unwrap();
     assert!(matches!(&output.kind, MessageKind::Warning));
     assert_eq!(
         &output.msg,
         "Singleton variable y is unused or undefined, see <https://docs.osohq.com/using/polar-syntax.html#variables>\n001: f(x:X,y:Y,z:Z) if z = z;\n           ^"
     );
-    let output = polar.next_message().unwrap();
+    let output = p.next_message().unwrap();
     assert!(matches!(&output.kind, MessageKind::Warning));
     assert_eq!(
         &output.msg,
         "Unknown specializer Z\n001: f(x:X,y:Y,z:Z) if z = z;\n                 ^"
     );
+    Ok(())
 }
 
 #[test]
-fn test_print() {
-    // TODO: If polar_log is on this test will fail.
-    let polar = Polar::new();
-    polar.load_str("f(x,y,z) if print(x, y, z);").unwrap();
+fn test_print() -> TestResult {
+    // TODO: If POLAR_LOG is on this test will fail.
+    let p = Polar::new();
+    p.load_str("f(x,y,z) if print(x, y, z);")?;
     let message_handler = |output: &Message| {
         assert!(matches!(&output.kind, MessageKind::Print));
         assert_eq!(&output.msg, "1, 2, 3");
     };
-    let query = polar.new_query("f(1, 2, 3)", false).unwrap();
-    let _results = query_results!(query, @msgs message_handler);
+    let q = p.new_query("f(1, 2, 3)", false)?;
+    let _results = query_results!(q, @msgs message_handler);
+    Ok(())
 }
 
 #[test]
-fn test_unknown_specializer_suggestions() {
-    let polar = Polar::new();
-    polar.load_str("f(s: string) if s;").unwrap();
-    let msg = polar.next_message().unwrap();
+fn test_unknown_specializer_suggestions() -> TestResult {
+    let p = Polar::new();
+    p.load_str("f(s: string) if s;")?;
+    let msg = p.next_message().unwrap();
     assert!(matches!(&msg.kind, MessageKind::Warning));
     assert_eq!(
         &msg.msg,
         "Unknown specializer string, did you mean String?\n001: f(s: string) if s;\n          ^"
     );
+    Ok(())
 }
 
 #[test]
-fn test_rest_vars() {
-    let mut polar = Polar::new();
-
+fn test_rest_vars() -> TestResult {
+    let mut p = Polar::new();
     assert_eq!(
-        qvar(&mut polar, "[1,2,3] = [*rest]", "rest"),
+        qvar(&mut p, "[1,2,3] = [*rest]", "rest"),
         vec![value!([value!(1), value!(2), value!(3)])]
     );
     assert_eq!(
-        qvar(&mut polar, "[1,2,3] = [1, *rest]", "rest"),
+        qvar(&mut p, "[1,2,3] = [1, *rest]", "rest"),
         vec![value!([value!(2), value!(3)])]
     );
     assert_eq!(
-        qvar(&mut polar, "[1,2,3] = [1,2, *rest]", "rest"),
+        qvar(&mut p, "[1,2,3] = [1,2, *rest]", "rest"),
         vec![value!([value!(3)])]
     );
     assert_eq!(
-        qvar(&mut polar, "([1,2,3] = [1,2,3, *rest])", "rest"),
+        qvar(&mut p, "([1,2,3] = [1,2,3, *rest])", "rest"),
         vec![value!([])]
     );
-    assert!(qnull(&mut polar, "[1,2,3] = [1,2,3,4, *_rest]"));
+    assert!(qnull(&mut p, "[1,2,3] = [1,2,3,4, *_rest]"));
 
-    polar
-        .load_str(
-            r#"member(x, [x, *_rest]);
-               member(x, [_first, *rest]) if member(x, rest);"#,
-        )
-        .unwrap();
-    assert!(qeval(&mut polar, "member(1, [1,2,3])"));
-    assert!(qeval(&mut polar, "member(3, [1,2,3])"));
-    assert!(qeval(&mut polar, "not member(4, [1,2,3])"));
+    p.load_str(
+        r#"member(x, [x, *_rest]);
+           member(x, [_first, *rest]) if member(x, rest);"#,
+    )?;
+    assert!(qeval(&mut p, "member(1, [1,2,3])"));
+    assert!(qeval(&mut p, "member(3, [1,2,3])"));
+    assert!(qeval(&mut p, "not member(4, [1,2,3])"));
     assert_eq!(
-        qvar(&mut polar, "member(x, [1,2,3])", "x"),
+        qvar(&mut p, "member(x, [1,2,3])", "x"),
         vec![value!(1), value!(2), value!(3)]
     );
 
-    polar
-        .load_str(
-            r#"append([], x, x);
-               append([first, *rest], x, [first, *tail]) if append(rest, x, tail);"#,
-        )
-        .unwrap();
-    assert!(qeval(&mut polar, "append([], [], [])"));
-    assert!(qeval(&mut polar, "append([], [1,2,3], [1,2,3])"));
-    assert!(qeval(&mut polar, "append([1], [2,3], [1,2,3])"));
-    assert!(qeval(&mut polar, "append([1,2], [3], [1,2,3])"));
-    assert!(qeval(&mut polar, "append([1,2,3], [], [1,2,3])"));
-    assert!(qeval(&mut polar, "not append([1,2,3], [4], [1,2,3])"));
+    p.load_str(
+        r#"append([], x, x);
+           append([first, *rest], x, [first, *tail]) if append(rest, x, tail);"#,
+    )?;
+    assert!(qeval(&mut p, "append([], [], [])"));
+    assert!(qeval(&mut p, "append([], [1,2,3], [1,2,3])"));
+    assert!(qeval(&mut p, "append([1], [2,3], [1,2,3])"));
+    assert!(qeval(&mut p, "append([1,2], [3], [1,2,3])"));
+    assert!(qeval(&mut p, "append([1,2,3], [], [1,2,3])"));
+    assert!(qeval(&mut p, "not append([1,2,3], [4], [1,2,3])"));
+    Ok(())
 }
 
 #[test]
-fn test_in_op() {
-    let mut polar = Polar::new();
-    polar.load_str("f(x, y) if x in y;").unwrap();
-    assert!(qeval(&mut polar, "f(1, [1,2,3])"));
+fn test_in_op() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str("f(x, y) if x in y;")?;
+    assert!(qeval(&mut p, "f(1, [1,2,3])"));
     assert_eq!(
-        qvar(&mut polar, "f(x, [1,2,3])", "x"),
+        qvar(&mut p, "f(x, [1,2,3])", "x"),
         vec![value!(1), value!(2), value!(3)]
     );
 
     // Failure.
-    assert!(qnull(&mut polar, "4 in [1,2,3]"));
-    assert!(qeval(&mut polar, "4 in [1,2,3] or 1 in [1,2,3]"));
+    assert!(qnull(&mut p, "4 in [1,2,3]"));
+    assert!(qeval(&mut p, "4 in [1,2,3] or 1 in [1,2,3]"));
 
     // Make sure we scan the whole list.
-    let query = polar.new_query("1 in [1, 2, x, 1]", false).unwrap();
-    let results = query_results!(query);
+    let q = p.new_query("1 in [1, 2, x, 1]", false)?;
+    let results = query_results!(q);
     assert_eq!(results.len(), 3);
     assert!(results[0].0.is_empty());
     assert_eq!(
@@ -1311,277 +1362,267 @@ fn test_in_op() {
     assert!(results[2].0.is_empty());
 
     // This returns 3 results, with 1 binding each.
-    let query = polar.new_query("f(1, [x,y,z])", false).unwrap();
-    let results = query_results!(query);
+    let q = p.new_query("f(1, [x,y,z])", false)?;
+    let results = query_results!(q);
     assert_eq!(results.len(), 3);
     assert_eq!(results[0].0[&sym!("x")], value!(1));
     assert_eq!(results[1].0[&sym!("y")], value!(1));
     assert_eq!(results[2].0[&sym!("z")], value!(1));
 
-    assert!(qeval(&mut polar, "f({a:1}, [{a:1}, b, c])"));
+    assert!(qeval(&mut p, "f({a:1}, [{a:1}, b, c])"));
 
-    let mut query = polar.new_query("a in {a:1}", false).unwrap();
-    let e = query.next_event().unwrap_err();
+    let mut q = p.new_query("a in {a:1}", false)?;
+    let e = q.next_event().unwrap_err();
     assert!(matches!(
         e.kind,
         ErrorKind::Runtime(RuntimeError::TypeError { .. })
     ));
 
     // Negation.
-    assert!(qeval(&mut polar, "not (4 in [1,2,3])"));
-    assert!(qnull(&mut polar, "not (1 in [1,2,3])"));
-    assert!(qnull(&mut polar, "not (2 in [1,2,3])"));
-    assert!(qnull(&mut polar, "not (3 in [1,2,3])"));
+    assert!(qeval(&mut p, "not (4 in [1,2,3])"));
+    assert!(qnull(&mut p, "not (1 in [1,2,3])"));
+    assert!(qnull(&mut p, "not (2 in [1,2,3])"));
+    assert!(qnull(&mut p, "not (3 in [1,2,3])"));
 
     // Nothing is in an empty list.
-    assert!(qnull(&mut polar, "x in []"));
-    assert!(qnull(&mut polar, "1 in []"));
-    assert!(qnull(&mut polar, "\"foo\" in []"));
-    assert!(qnull(&mut polar, "[] in []"));
-    assert!(qeval(&mut polar, "not x in []"));
-    assert!(qeval(&mut polar, "not 1 in []"));
-    assert!(qeval(&mut polar, "not \"foo\" in []"));
-    assert!(qeval(&mut polar, "not [] in []"));
+    assert!(qnull(&mut p, "x in []"));
+    assert!(qnull(&mut p, "1 in []"));
+    assert!(qnull(&mut p, "\"foo\" in []"));
+    assert!(qnull(&mut p, "[] in []"));
+    assert!(qeval(&mut p, "not x in []"));
+    assert!(qeval(&mut p, "not 1 in []"));
+    assert!(qeval(&mut p, "not \"foo\" in []"));
+    assert!(qeval(&mut p, "not [] in []"));
+    Ok(())
 }
 
 #[test]
-fn test_matches() {
-    let mut polar = Polar::new();
-    assert!(qnull(&mut polar, "1 matches 2"));
-    assert!(qeval(&mut polar, "1 matches 1"));
+fn test_matches() -> TestResult {
+    let mut p = Polar::new();
+    assert!(qnull(&mut p, "1 matches 2"));
+    assert!(qeval(&mut p, "1 matches 1"));
     // This doesn't fail because `y` is parsed as an unknown specializer
-    // assert!(qnull(&mut polar, "x = 1 and y = 2 and x matches y"));
-    assert!(qeval(&mut polar, "x = {foo: 1} and x matches {foo: 1}"));
-    assert!(qeval(
-        &mut polar,
-        "x = {foo: 1, bar: 2} and x matches {foo: 1}"
-    ));
-    assert!(qnull(
-        &mut polar,
-        "x = {foo: 1} and x matches {foo: 1, bar: 2}"
-    ));
-    assert!(qnull(&mut polar, "x = {foo: 1} and x matches {foo: 2}"));
+    // assert!(qnull(&mut p, "x = 1 and y = 2 and x matches y"));
+    assert!(qeval(&mut p, "x = {foo: 1} and x matches {foo: 1}"));
+    assert!(qeval(&mut p, "x = {foo: 1, bar: 2} and x matches {foo: 1}"));
+    assert!(qnull(&mut p, "x = {foo: 1} and x matches {foo: 1, bar: 2}"));
+    assert!(qnull(&mut p, "x = {foo: 1} and x matches {foo: 2}"));
+    Ok(())
 }
 
 #[test]
-fn test_keyword_bug() {
-    let polar = Polar::new();
-    let result = polar.load_str("g(a) if a.new(b);").unwrap_err();
+fn test_keyword_bug() -> TestResult {
+    let p = Polar::new();
+    let result = p.load_str("g(a) if a.new(b);").unwrap_err();
     assert!(matches!(
         result.kind,
         ErrorKind::Parse(ParseError::ReservedWord { .. })
     ));
 
-    let result = polar.load_str("f(a) if a.in(b);").unwrap_err();
+    let result = p.load_str("f(a) if a.in(b);").unwrap_err();
     assert!(matches!(
         result.kind,
         ErrorKind::Parse(ParseError::ReservedWord { .. })
     ));
 
-    let result = polar.load_str("cut(a) if a;").unwrap_err();
+    let result = p.load_str("cut(a) if a;").unwrap_err();
     assert!(matches!(
         result.kind,
         ErrorKind::Parse(ParseError::ReservedWord { .. })
     ));
 
-    let result = polar.load_str("debug(a) if a;").unwrap_err();
+    let result = p.load_str("debug(a) if a;").unwrap_err();
     assert!(matches!(
         result.kind,
         ErrorKind::Parse(ParseError::ReservedWord { .. })
     ));
+    Ok(())
 }
 
 /// Test that rule heads work correctly when unification or specializers are used.
 #[test]
-fn test_unify_rule_head() {
-    let polar = Polar::new();
+fn test_unify_rule_head() -> TestResult {
+    let p = Polar::new();
     assert!(matches!(
-        polar
+        p
             .load_str("f(Foo{a: 1});")
             .expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
     assert!(matches!(
-        polar
+        p
             .load_str("f(new Foo(a: Foo{a: 1}));")
             .expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
     assert!(matches!(
-        polar
+        p
             .load_str("f(x: new Foo(a: 1));")
             .expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
     assert!(matches!(
-        polar
+        p
             .load_str("f(x: Foo{a: new Foo(a: 1)});")
             .expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
-    polar.register_constant(sym!("Foo"), term!(true));
-    polar.load_str("f(_: Foo{a: 1}, x) if x = 1;").unwrap();
-    polar
-        .load_str("g(_: Foo{a: Foo{a: 1}}, x) if x = 1;")
-        .unwrap();
+    p.register_constant(sym!("Foo"), term!(true));
+    p.load_str(
+        r#"f(_: Foo{a: 1}, x) if x = 1;
+           g(_: Foo{a: Foo{a: 1}}, x) if x = 1;"#,
+    )?;
 
-    let query = polar.new_query("f(new Foo(a: 1), x)", false).unwrap();
-    let (results, _externals) = query_results_with_externals(query);
+    let q = p.new_query("f(new Foo(a: 1), x)", false)?;
+    let (results, _externals) = query_results_with_externals(q);
     assert_eq!(results[0].0[&sym!("x")], value!(1));
 
-    let query = polar
-        .new_query("g(new Foo(a: new Foo(a: 1)), x)", false)
-        .unwrap();
-    let (results, _externals) = query_results_with_externals(query);
+    let q = p.new_query("g(new Foo(a: new Foo(a: 1)), x)", false)?;
+    let (results, _externals) = query_results_with_externals(q);
     assert_eq!(results[0].0[&sym!("x")], value!(1));
+    Ok(())
 }
 
 /// Test that cut commits to all choice points before the cut, not just the last.
 #[test]
-fn test_cut() {
-    let mut polar = Polar::new();
-    polar
-        .load_str(
-            r#"a(x) if x = 1 or x = 2;
-               b(x) if x = 3 or x = 4;
-               bcut(x) if x = 3 or x = 4 and cut;
-               c(a, b) if a(a) and b(b) and cut;
-               c_no_cut(a, b) if a(a) and b(b);
-               c_partial_cut(a, b) if a(a) and bcut(b);
-               c_another_partial_cut(a, b) if a(a) and cut and b(b);"#,
-        )
-        .unwrap();
+fn test_cut() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"a(x) if x = 1 or x = 2;
+           b(x) if x = 3 or x = 4;
+           bcut(x) if x = 3 or x = 4 and cut;
+           c(a, b) if a(a) and b(b) and cut;
+           c_no_cut(a, b) if a(a) and b(b);
+           c_partial_cut(a, b) if a(a) and bcut(b);
+           c_another_partial_cut(a, b) if a(a) and cut and b(b);"#,
+    )?;
 
     // Ensure we return multiple results without a cut.
-    assert!(qvars(&mut polar, "c_no_cut(a, b)", &["a", "b"]).len() > 1);
+    assert!(qvars(&mut p, "c_no_cut(a, b)", &["a", "b"]).len() > 1);
 
     // Ensure that only one result is returned when cut is at the end.
     assert_eq!(
-        qvars(&mut polar, "c(a, b)", &["a", "b"]),
+        qvars(&mut p, "c(a, b)", &["a", "b"]),
         vec![vec![value!(1), value!(3)]]
     );
 
     // Make sure that cut in `bcut` does not affect `c_partial_cut`.
     // If it did, only one result would be returned, [1, 3].
     assert_eq!(
-        qvars(&mut polar, "c_partial_cut(a, b)", &["a", "b"]),
+        qvars(&mut p, "c_partial_cut(a, b)", &["a", "b"]),
         vec![vec![value!(1), value!(3)], vec![value!(2), value!(3)]]
     );
 
     // Make sure cut only affects choice points before it.
     assert_eq!(
-        qvars(&mut polar, "c_another_partial_cut(a, b)", &["a", "b"]),
+        qvars(&mut p, "c_another_partial_cut(a, b)", &["a", "b"]),
         vec![vec![value!(1), value!(3)], vec![value!(1), value!(4)]]
     );
 
-    polar.load_str("f(x) if (x = 1 and cut) or x = 2;").unwrap();
-    assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1)]);
-    assert!(qeval(&mut polar, "f(1)"));
-    assert!(qeval(&mut polar, "f(2)"));
+    p.load_str("f(x) if (x = 1 and cut) or x = 2;")?;
+    assert_eq!(qvar(&mut p, "f(x)", "x"), vec![value!(1)]);
+    assert!(qeval(&mut p, "f(1)"));
+    assert!(qeval(&mut p, "f(2)"));
+    Ok(())
 }
 
 #[test]
-fn test_forall() {
-    let mut polar = Polar::new();
-    polar
-        .load_str("all_ones(l) if forall(item in l, item = 1);")
-        .unwrap();
+fn test_forall() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str("all_ones(l) if forall(item in l, item = 1);")?;
 
-    assert!(qeval(&mut polar, "all_ones([1])"));
-    assert!(qeval(&mut polar, "all_ones([1, 1, 1])"));
-    assert!(qnull(&mut polar, "all_ones([1, 2, 1])"));
+    assert!(qeval(&mut p, "all_ones([1])"));
+    assert!(qeval(&mut p, "all_ones([1, 1, 1])"));
+    assert!(qnull(&mut p, "all_ones([1, 2, 1])"));
 
-    polar
-        .load_str("not_ones(l) if forall(item in l, item != 1);")
-        .unwrap();
-    assert!(qnull(&mut polar, "not_ones([1])"));
-    assert!(qeval(&mut polar, "not_ones([2, 3, 4])"));
+    p.load_str("not_ones(l) if forall(item in l, item != 1);")?;
+    assert!(qnull(&mut p, "not_ones([1])"));
+    assert!(qeval(&mut p, "not_ones([2, 3, 4])"));
 
-    assert!(qnull(&mut polar, "forall(x = 2 or x = 3, x != 2)"));
-    assert!(qnull(&mut polar, "forall(x = 2 or x = 3, x != 3)"));
-    assert!(qeval(&mut polar, "forall(x = 2 or x = 3, x = 2 or x = 3)"));
-    assert!(qeval(&mut polar, "forall(x = 1, x = 1)"));
-    assert!(qeval(&mut polar, "forall(x in [2, 3, 4], x > 1)"));
+    assert!(qnull(&mut p, "forall(x = 2 or x = 3, x != 2)"));
+    assert!(qnull(&mut p, "forall(x = 2 or x = 3, x != 3)"));
+    assert!(qeval(&mut p, "forall(x = 2 or x = 3, x = 2 or x = 3)"));
+    assert!(qeval(&mut p, "forall(x = 1, x = 1)"));
+    assert!(qeval(&mut p, "forall(x in [2, 3, 4], x > 1)"));
 
-    polar.load_str("g(1);").unwrap();
-    polar.load_str("g(2);").unwrap();
-    polar.load_str("g(3);").unwrap();
+    p.load_str(
+        r#"g(1);
+           g(2);
+           g(3);"#,
+    )?;
+    assert!(qeval(&mut p, "forall(g(x), x in [1, 2, 3])"));
 
-    assert!(qeval(&mut polar, "forall(g(x), x in [1, 2, 3])"));
-
-    polar.load_str("allow(_: {x: 1}, y) if y = 1;").unwrap();
-    polar.load_str("allow(_: {y: 1}, y) if y = 2;").unwrap();
-    polar.load_str("allow(_: {z: 1}, y) if y = 3;").unwrap();
-
+    p.load_str(
+        r#"allow(_: {x: 1}, y) if y = 1;
+           allow(_: {y: 1}, y) if y = 2;
+           allow(_: {z: 1}, y) if y = 3;"#,
+    )?;
     assert!(qeval(
-        &mut polar,
+        &mut p,
         "forall(allow({x: 1, y: 1, z: 1}, y), y in [1, 2, 3])"
     ));
+    Ok(())
 }
 
 #[test]
-fn test_emoji_policy() {
-    let mut polar = Polar::new();
-    polar
-        .load_str(
-            r#"
+fn test_emoji_policy() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"
                     👩‍🔧("👩‍🦰");
                     allow(👩, "🛠", "🚙") if 👩‍🔧(👩);
                 "#,
-        )
-        .unwrap();
-    assert!(qeval(&mut polar, r#"allow("👩‍🦰","🛠","🚙")"#));
-    assert!(qnull(&mut polar, r#"allow("🧟","🛠","🚙")"#));
+    )?;
+    assert!(qeval(&mut p, r#"allow("👩‍🦰","🛠","🚙")"#));
+    assert!(qnull(&mut p, r#"allow("🧟","🛠","🚙")"#));
+    Ok(())
 }
 
 #[test]
 /// Check that boolean expressions evaluate without requiring "= true".
-fn test_boolean_expression() {
-    let mut polar = Polar::new();
-
+fn test_boolean_expression() -> TestResult {
+    let mut p = Polar::new();
     // Succeeds because t is true.
-    assert!(qeval(&mut polar, "a = {t: true, f: false} and a.t"));
+    assert!(qeval(&mut p, "a = {t: true, f: false} and a.t"));
     // Fails because `f` is not true.
-    assert!(qnull(&mut polar, "a = {t: true, f: false} and a.f"));
+    assert!(qnull(&mut p, "a = {t: true, f: false} and a.f"));
     // Fails because `f` is not true.
-    assert!(qnull(&mut polar, "a = {t: true, f: false} and a.f and a.t"));
+    assert!(qnull(&mut p, "a = {t: true, f: false} and a.f and a.t"));
     // Succeeds because `t` is true.
-    assert!(qeval(
-        &mut polar,
-        "a = {t: true, f: false} and (a.f or a.t)"
-    ));
+    assert!(qeval(&mut p, "a = {t: true, f: false} and (a.f or a.t)"));
 
-    assert!(qeval(&mut polar, "true"));
-    assert!(qnull(&mut polar, "false"));
-    assert!(qeval(&mut polar, "a = true and a"));
-    assert!(qnull(&mut polar, "a = false and a"));
+    assert!(qeval(&mut p, "true"));
+    assert!(qnull(&mut p, "false"));
+    assert!(qeval(&mut p, "a = true and a"));
+    assert!(qnull(&mut p, "a = false and a"));
+    Ok(())
 }
 
 #[test]
 fn test_float_parsing() {
-    let mut polar = Polar::new();
-    assert_eq!(qvar(&mut polar, "x=1+1", "x"), vec![value!(2)]);
-    assert_eq!(qvar(&mut polar, "x=1+1.5", "x"), vec![value!(2.5)]);
-    assert_eq!(qvar(&mut polar, "x=1.e+5", "x"), vec![value!(1e5)]);
-    assert_eq!(qvar(&mut polar, "x=1e+5", "x"), vec![value!(1e5)]);
-    assert_eq!(qvar(&mut polar, "x=1e5", "x"), vec![value!(1e5)]);
-    assert_eq!(qvar(&mut polar, "x=1e-5", "x"), vec![value!(1e-5)]);
-    assert_eq!(qvar(&mut polar, "x=1.e-5", "x"), vec![value!(1e-5)]);
-    assert_eq!(qvar(&mut polar, "x=1.0e+15", "x"), vec![value!(1e15)]);
-    assert_eq!(qvar(&mut polar, "x=1.0E+15", "x"), vec![value!(1e15)]);
-    assert_eq!(qvar(&mut polar, "x=1.0e-15", "x"), vec![value!(1e-15)]);
+    let mut p = Polar::new();
+    assert_eq!(qvar(&mut p, "x=1+1", "x"), vec![value!(2)]);
+    assert_eq!(qvar(&mut p, "x=1+1.5", "x"), vec![value!(2.5)]);
+    assert_eq!(qvar(&mut p, "x=1.e+5", "x"), vec![value!(1e5)]);
+    assert_eq!(qvar(&mut p, "x=1e+5", "x"), vec![value!(1e5)]);
+    assert_eq!(qvar(&mut p, "x=1e5", "x"), vec![value!(1e5)]);
+    assert_eq!(qvar(&mut p, "x=1e-5", "x"), vec![value!(1e-5)]);
+    assert_eq!(qvar(&mut p, "x=1.e-5", "x"), vec![value!(1e-5)]);
+    assert_eq!(qvar(&mut p, "x=1.0e+15", "x"), vec![value!(1e15)]);
+    assert_eq!(qvar(&mut p, "x=1.0E+15", "x"), vec![value!(1e15)]);
+    assert_eq!(qvar(&mut p, "x=1.0e-15", "x"), vec![value!(1e-15)]);
 }
 
 #[test]
-fn test_assignment() {
-    let mut polar = Polar::new();
-    assert!(qeval(&mut polar, "x := 5 and x == 5"));
-    let mut query = polar.new_query("x := 5 and x := 6", false).unwrap();
-    let e = query.next_event().unwrap_err();
+fn test_assignment() -> TestResult {
+    let mut p = Polar::new();
+    assert!(qeval(&mut p, "x := 5 and x == 5"));
+    let mut q = p.new_query("x := 5 and x := 6", false)?;
+    let e = q.next_event().unwrap_err();
     assert!(matches!(
         e.kind,
         ErrorKind::Runtime(RuntimeError::TypeError {
@@ -1589,247 +1630,225 @@ fn test_assignment() {
             ..
         }) if s == "Can only assign to unbound variables, x is bound to value 5."
     ));
-    assert!(qnull(&mut polar, "x := 5 and x > 6"));
-    assert!(qeval(&mut polar, "x := y and y = 6 and x = 6"));
+    assert!(qnull(&mut p, "x := 5 and x > 6"));
+    assert!(qeval(&mut p, "x := y and y = 6 and x = 6"));
 
     // confirm old syntax -> parse error
-    let e = polar.load_str("f(x) := g(x)").unwrap_err();
+    let e = p.load_str("f(x) := g(x)").unwrap_err();
     assert!(matches!(
         e.kind,
         ErrorKind::Parse(ParseError::UnrecognizedToken { .. })
     ));
+    Ok(())
 }
 
 #[test]
-fn test_rule_index() {
-    let mut polar = Polar::new();
-    polar.load_str(r#"f(1, 1, "x");"#).unwrap();
-    polar.load_str(r#"f(1, 1, "y");"#).unwrap();
-    polar.load_str(r#"f(1, x, "y") if x = 2;"#).unwrap();
-    polar.load_str(r#"f(1, 2, {b: "y"});"#).unwrap();
-    polar.load_str(r#"f(1, 3, {c: "z"});"#).unwrap();
-
+fn test_rule_index() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(1, 1, "x");
+           f(1, 1, "y");
+           f(1, x, "y") if x = 2;
+           f(1, 2, {b: "y"});
+           f(1, 3, {c: "z"});"#,
+    )?;
     // Exercise the index.
-    assert!(qeval(&mut polar, r#"f(1, 1, "x")"#));
-    assert!(qeval(&mut polar, r#"f(1, 1, "y")"#));
+    assert!(qeval(&mut p, r#"f(1, 1, "x")"#));
+    assert!(qeval(&mut p, r#"f(1, 1, "y")"#));
     assert_eq!(
-        qvar(&mut polar, r#"f(1, x, "y")"#, "x"),
+        qvar(&mut p, r#"f(1, x, "y")"#, "x"),
         vec![value!(1), value!(2)]
     );
-    assert!(qnull(&mut polar, r#"f(1, 1, "z")"#));
-    assert!(qnull(&mut polar, r#"f(1, 2, "x")"#));
-    assert!(qeval(&mut polar, r#"f(1, 2, {b: "y"})"#));
-    assert!(qeval(&mut polar, r#"f(1, 3, {c: "z"})"#));
+    assert!(qnull(&mut p, r#"f(1, 1, "z")"#));
+    assert!(qnull(&mut p, r#"f(1, 2, "x")"#));
+    assert!(qeval(&mut p, r#"f(1, 2, {b: "y"})"#));
+    assert!(qeval(&mut p, r#"f(1, 3, {c: "z"})"#));
+    Ok(())
 }
 
 #[test]
-fn test_fib() {
-    let policy = r#"
-        fib(0, 1) if cut;
-        fib(1, 1) if cut;
-        fib(n, a+b) if fib(n-1, a) and fib(n-2, b);
-    "#;
-
-    let mut polar = Polar::new();
-    polar.load_str(policy).unwrap();
-
-    assert_eq!(qvar(&mut polar, r#"fib(0, x)"#, "x"), vec![value!(1)]);
-    assert_eq!(qvar(&mut polar, r#"fib(1, x)"#, "x"), vec![value!(1)]);
-    assert_eq!(qvar(&mut polar, r#"fib(2, x)"#, "x"), vec![value!(2)]);
-    assert_eq!(qvar(&mut polar, r#"fib(3, x)"#, "x"), vec![value!(3)]);
-    assert_eq!(qvar(&mut polar, r#"fib(4, x)"#, "x"), vec![value!(5)]);
-    assert_eq!(qvar(&mut polar, r#"fib(5, x)"#, "x"), vec![value!(8)]);
+fn test_fib() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"fib(0, 1) if cut;
+           fib(1, 1) if cut;
+           fib(n, a+b) if fib(n-1, a) and fib(n-2, b);"#,
+    )?;
+    assert_eq!(qvar(&mut p, r#"fib(0, x)"#, "x"), vec![value!(1)]);
+    assert_eq!(qvar(&mut p, r#"fib(1, x)"#, "x"), vec![value!(1)]);
+    assert_eq!(qvar(&mut p, r#"fib(2, x)"#, "x"), vec![value!(2)]);
+    assert_eq!(qvar(&mut p, r#"fib(3, x)"#, "x"), vec![value!(3)]);
+    assert_eq!(qvar(&mut p, r#"fib(4, x)"#, "x"), vec![value!(5)]);
+    assert_eq!(qvar(&mut p, r#"fib(5, x)"#, "x"), vec![value!(8)]);
+    Ok(())
 }
 
 #[test]
-fn test_duplicated_rule() {
-    let policy = r#"
-        f(1);
-        f(1);
-    "#;
-
-    let mut polar = Polar::new();
-    polar.load_str(policy).unwrap();
-
-    assert_eq!(qvar(&mut polar, "f(x)", "x"), vec![value!(1), value!(1)]);
+fn test_duplicated_rule() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"f(1);
+           f(1);"#,
+    )?;
+    assert_eq!(qvar(&mut p, "f(x)", "x"), vec![value!(1), value!(1)]);
+    Ok(())
 }
 
 #[test]
-fn test_numeric_applicability() {
-    let mut polar = Polar::new();
+fn test_numeric_applicability() -> TestResult {
+    let mut p = Polar::new();
     let eps = f64::EPSILON;
     let nan1 = f64::NAN;
     let nan2 = f64::from_bits(f64::NAN.to_bits() | 1);
     assert!(eps.is_normal() && nan1.is_nan() && nan2.is_nan());
-    polar.register_constant(sym!("eps"), term!(eps));
-    polar.register_constant(sym!("nan1"), term!(nan1));
-    polar.register_constant(sym!("nan2"), term!(nan2));
-
-    let policy = r#"
-        f(0);
-        f(1);
-        f(9007199254740991); # (1 << 53) - 1
-        f(9007199254740992); # (1 << 53)
-        f(9223372036854775807); # i64::MAX
-        f(-9223372036854775807); # i64::MIN + 1
-        f(9223372036854776000.0); # i64::MAX as f64
-        f(nan1); # NaN
-    "#;
-    polar.load_str(policy).unwrap();
-
-    assert!(qeval(&mut polar, "f(0)"));
-    assert!(qeval(&mut polar, "f(0.0)"));
-    assert!(qnull(&mut polar, "f(eps)"));
-    assert!(qeval(&mut polar, "f(1)"));
-    assert!(qeval(&mut polar, "f(1.0)"));
-    assert!(qnull(&mut polar, "f(1.0000000000000002)"));
-    assert!(qnull(&mut polar, "f(9007199254740990)"));
-    assert!(qnull(&mut polar, "f(9007199254740990.0)"));
-    assert!(qeval(&mut polar, "f(9007199254740991)"));
-    assert!(qeval(&mut polar, "f(9007199254740991.0)"));
-    assert!(qeval(&mut polar, "f(9007199254740992)"));
-    assert!(qeval(&mut polar, "f(9007199254740992.0)"));
-    assert!(qeval(&mut polar, "f(9223372036854775807)"));
-    assert!(qeval(&mut polar, "f(-9223372036854775807)"));
-    assert!(qeval(&mut polar, "f(9223372036854776000.0)"));
-    assert!(qnull(&mut polar, "f(nan1)"));
-    assert!(qnull(&mut polar, "f(nan2)"));
+    p.register_constant(sym!("eps"), term!(eps));
+    p.register_constant(sym!("nan1"), term!(nan1));
+    p.register_constant(sym!("nan2"), term!(nan2));
+    p.load_str(
+        r#"f(0);
+           f(1);
+           f(9007199254740991); # (1 << 53) - 1
+           f(9007199254740992); # (1 << 53)
+           f(9223372036854775807); # i64::MAX
+           f(-9223372036854775807); # i64::MIN + 1
+           f(9223372036854776000.0); # i64::MAX as f64
+           f(nan1); # NaN"#,
+    )?;
+    assert!(qeval(&mut p, "f(0)"));
+    assert!(qeval(&mut p, "f(0.0)"));
+    assert!(qnull(&mut p, "f(eps)"));
+    assert!(qeval(&mut p, "f(1)"));
+    assert!(qeval(&mut p, "f(1.0)"));
+    assert!(qnull(&mut p, "f(1.0000000000000002)"));
+    assert!(qnull(&mut p, "f(9007199254740990)"));
+    assert!(qnull(&mut p, "f(9007199254740990.0)"));
+    assert!(qeval(&mut p, "f(9007199254740991)"));
+    assert!(qeval(&mut p, "f(9007199254740991.0)"));
+    assert!(qeval(&mut p, "f(9007199254740992)"));
+    assert!(qeval(&mut p, "f(9007199254740992.0)"));
+    assert!(qeval(&mut p, "f(9223372036854775807)"));
+    assert!(qeval(&mut p, "f(-9223372036854775807)"));
+    assert!(qeval(&mut p, "f(9223372036854776000.0)"));
+    assert!(qnull(&mut p, "f(nan1)"));
+    assert!(qnull(&mut p, "f(nan2)"));
+    Ok(())
 }
 
 #[test]
-fn test_external_unify() {
-    let polar = Polar::new();
-    polar.load_str("selfEq(x) if eq(x, x); eq(x, x);").unwrap();
+fn test_external_unify() -> TestResult {
+    let p = Polar::new();
+    p.load_str(
+        r#"selfEq(x) if eq(x, x);
+           eq(x, x);"#,
+    )?;
 
-    let query = polar.new_query("selfEq(new Foo())", false).unwrap();
-    let (results, _externals) = query_results_with_externals(query);
+    let q = p.new_query("selfEq(new Foo())", false)?;
+    let (results, _externals) = query_results_with_externals(q);
     assert_eq!(results.len(), 1);
 
-    let query = polar.new_query("eq(new Foo(), new Foo())", false).unwrap();
-    let (results, _externals) = query_results_with_externals(query);
+    let q = p.new_query("eq(new Foo(), new Foo())", false)?;
+    let (results, _externals) = query_results_with_externals(q);
     assert!(results.is_empty());
+    Ok(())
 }
 
 #[test]
-fn test_list_results() {
-    let mut polar = Polar::new();
-    let policy = r#"
-    delete([x, *xs], x, ys) if delete(xs, x, ys);
-    delete([x, *xs], z, [x, *ys]) if
-        x != z and delete(xs, z, ys);
-    delete([], _, []);
-    "#;
-    polar.load_str(policy).unwrap();
-    assert!(qeval(&mut polar, "delete([1,2,3,2,1],2,[1,3,1])"));
+fn test_list_results() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"delete([x, *xs], x, ys) if delete(xs, x, ys);
+           delete([x, *xs], z, [x, *ys]) if
+               x != z and delete(xs, z, ys);
+           delete([], _, []);"#,
+    )?;
+    assert!(qeval(&mut p, "delete([1,2,3,2,1],2,[1,3,1])"));
     assert_eq!(
-        qvar(&mut polar, "delete([1,2,3,2,1],2,result)", "result"),
+        qvar(&mut p, "delete([1,2,3,2,1],2,result)", "result"),
         vec![value!([value!(1), value!(3), value!(1)])]
     );
 
     assert_eq!(
-        qvar(&mut polar, "[1,2] = [1, *ys]", "ys"),
+        qvar(&mut p, "[1,2] = [1, *ys]", "ys"),
         vec![value!([value!(2)])]
     );
-
     assert_eq!(
-        qvar(
-            &mut polar,
-            "[1,2,*xs] = [1, *ys] and [1,2,3] = [1,*ys]",
-            "xs"
-        ),
+        qvar(&mut p, "[1,2,*xs] = [1, *ys] and [1,2,3] = [1,*ys]", "xs"),
         vec![value!([value!(3)])]
     );
     assert_eq!(
-        qvar(
-            &mut polar,
-            "[1,2,*xs] = [1, *ys] and [1,2,3] = [1,*ys]",
-            "ys"
-        ),
+        qvar(&mut p, "[1,2,*xs] = [1, *ys] and [1,2,3] = [1,*ys]", "ys"),
         vec![value!([value!(2), value!(3)])]
     );
     assert_eq!(
-        qvar(
-            &mut polar,
-            "[1,2,*xs] = [1, *ys] and [1,2,3] = [1,*ys]",
-            "ys"
-        ),
+        qvar(&mut p, "[1,2,*xs] = [1, *ys] and [1,2,3] = [1,*ys]", "ys"),
         vec![value!([value!(2), value!(3)])]
     );
-    assert!(qeval(&mut polar, "xs = [2] and [1,2] = [1, *xs]"));
-    assert!(qnull(&mut polar, "[1, 2] = [2, *ys]"));
+    assert!(qeval(&mut p, "xs = [2] and [1,2] = [1, *xs]"));
+    assert!(qnull(&mut p, "[1, 2] = [2, *ys]"));
+    Ok(())
 }
 
 #[test]
-fn test_expressions_in_lists() {
-    let mut polar = Polar::new();
-    let policy = r#"
-    scope(actor: Dictionary, "read", "Person", filters) if
-        filters = ["id", "=", actor.id];
-    "#;
-    polar.load_str(policy).unwrap();
+fn test_expressions_in_lists() -> TestResult {
+    let mut p = Polar::new();
+    p.load_str(
+        r#"scope(actor: Dictionary, "read", "Person", filters) if
+               filters = ["id", "=", actor.id];"#,
+    )?;
     assert!(qeval(
-        &mut polar,
+        &mut p,
         r#"scope({id: 1}, "read", "Person", ["id", "=", 1])"#
     ));
     assert!(qnull(
-        &mut polar,
+        &mut p,
         r#"scope({id: 2}, "read", "Person", ["id", "=", 1])"#
     ));
     assert!(qnull(
-        &mut polar,
+        &mut p,
         r#"scope({id: 1}, "read", "Person", ["not_id", "=", 1])"#
     ));
-    assert!(qeval(&mut polar, r#"d = {x: 1} and [d.x, 1+1] = [1, 2]"#));
+    assert!(qeval(&mut p, r#"d = {x: 1} and [d.x, 1+1] = [1, 2]"#));
     assert_eq!(
-        qvar(
-            &mut polar,
-            r#"d = {x: 1} and [d.x, 1+1] = [1, *rest]"#,
-            "rest"
-        ),
+        qvar(&mut p, r#"d = {x: 1} and [d.x, 1+1] = [1, *rest]"#, "rest"),
         vec![value!([value!(2)])]
     );
+    Ok(())
 }
 
 #[test]
-fn test_list_matches() {
-    let mut polar = Polar::new();
+fn test_list_matches() -> TestResult {
+    let mut p = Polar::new();
+    assert!(qeval(&mut p, "[] matches []"));
+    assert!(qnull(&mut p, "[1] matches []"));
+    assert!(qnull(&mut p, "[] matches [1]"));
+    assert!(qnull(&mut p, "[1, 2] matches [1, 2, 3]"));
+    assert!(qnull(&mut p, "[2, 1] matches [1, 2]"));
+    assert!(qeval(&mut p, "[1, 2, 3] matches [1, 2, 3]"));
+    assert!(qnull(&mut p, "[1, 2, 3] matches [1, 2]"));
 
-    assert!(qeval(&mut polar, "[] matches []"));
-    assert!(qnull(&mut polar, "[1] matches []"));
-    assert!(qnull(&mut polar, "[] matches [1]"));
-    assert!(qnull(&mut polar, "[1, 2] matches [1, 2, 3]"));
-    assert!(qnull(&mut polar, "[2, 1] matches [1, 2]"));
-    assert!(qeval(&mut polar, "[1, 2, 3] matches [1, 2, 3]"));
-    assert!(qnull(&mut polar, "[1, 2, 3] matches [1, 2]"));
-
-    assert!(qnull(&mut polar, "[x] matches []"));
-    assert!(qnull(&mut polar, "[] matches [x]"));
-    assert!(qnull(&mut polar, "[1, 2, x] matches [1, 2]"));
-    assert!(qnull(&mut polar, "[1, x] matches [1, 2, 3]"));
-    assert!(qnull(&mut polar, "[2, x] matches [1, 2]"));
+    assert!(qnull(&mut p, "[x] matches []"));
+    assert!(qnull(&mut p, "[] matches [x]"));
+    assert!(qnull(&mut p, "[1, 2, x] matches [1, 2]"));
+    assert!(qnull(&mut p, "[1, x] matches [1, 2, 3]"));
+    assert!(qnull(&mut p, "[2, x] matches [1, 2]"));
     assert_eq!(
-        qvar(&mut polar, "[1, 2, x] matches [1, 2, 3]", "x"),
+        qvar(&mut p, "[1, 2, x] matches [1, 2, 3]", "x"),
         vec![value!(3)]
     );
-    assert!(qnull(&mut polar, "[1, 2, 3] matches [1, x]"));
+    assert!(qnull(&mut p, "[1, 2, 3] matches [1, x]"));
 
-    assert_eq!(qvar(&mut polar, "[] matches [*ys]", "ys"), vec![value!([])]);
-    assert_eq!(qvar(&mut polar, "[*xs] matches []", "xs"), vec![value!([])]);
+    assert_eq!(qvar(&mut p, "[] matches [*ys]", "ys"), vec![value!([])]);
+    assert_eq!(qvar(&mut p, "[*xs] matches []", "xs"), vec![value!([])]);
+    assert_eq!(qvar(&mut p, "[*xs] matches [1]", "xs"), vec![value!([1])]);
+    assert_eq!(qvar(&mut p, "[1] matches [*ys]", "ys"), vec![value!([1])]);
+    assert!(qeval(&mut p, "[*xs] matches [*ys]"));
     assert_eq!(
-        qvar(&mut polar, "[*xs] matches [1]", "xs"),
-        vec![value!([1])]
-    );
-    assert_eq!(
-        qvar(&mut polar, "[1] matches [*ys]", "ys"),
-        vec![value!([1])]
-    );
-    assert!(qeval(&mut polar, "[*xs] matches [*ys]"));
-    assert_eq!(
-        qvar(&mut polar, "[1, 2, 3] matches [1, 2, *rest]", "rest"),
+        qvar(&mut p, "[1, 2, 3] matches [1, 2, *rest]", "rest"),
         vec![value!([3])]
     );
     assert_eq!(
-        qvar(&mut polar, "[1, 2, *xs] matches [1, 2, 3, *ys]", "xs"),
+        qvar(&mut p, "[1, 2, *xs] matches [1, 2, 3, *ys]", "xs"),
         vec![value!([3, Value::RestVariable(Symbol::new("ys"))])]
     );
+    Ok(())
 }

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1612,7 +1612,7 @@ fn test_assignment() -> TestResult {
     qeval(&mut p, "x := y and y = 6 and x = 6");
 
     // confirm old syntax -> parse error
-    let e = p.load_str("f(x) := g(x)").unwrap_err();
+    let e = p.load_str("f(x) := g(x);").unwrap_err();
     assert!(matches!(
         e.kind,
         ErrorKind::Parse(ParseError::UnrecognizedToken { .. })

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1424,30 +1424,22 @@ fn test_keyword_bug() -> TestResult {
 fn test_unify_rule_head() -> TestResult {
     let p = Polar::new();
     assert!(matches!(
-        p
-            .load_str("f(Foo{a: 1});")
-            .expect_err("Must have a parser error"),
+        p.load_str("f(Foo{a: 1});").expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
     assert!(matches!(
-        p
-            .load_str("f(new Foo(a: Foo{a: 1}));")
-            .expect_err("Must have a parser error"),
+        p.load_str("f(new Foo(a: Foo{a: 1}));").expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
     assert!(matches!(
-        p
-            .load_str("f(x: new Foo(a: 1));")
-            .expect_err("Must have a parser error"),
+        p.load_str("f(x: new Foo(a: 1));").expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 
     assert!(matches!(
-        p
-            .load_str("f(x: Foo{a: new Foo(a: 1)});")
-            .expect_err("Must have a parser error"),
+        p.load_str("f(x: Foo{a: new Foo(a: 1)});").expect_err("Must have a parser error"),
         PolarError { kind: ErrorKind::Parse(_), .. }
     ));
 


### PR DESCRIPTION
All of this is purely cosmetic -- no actual tests have been harmed.

- Moved `assert[_eq]!()` calls inside of `q[null,eval,var,etc]()` to avoid repeating it a million times.
- Moved the "logic" of `q[null,eval,var,etc]` into separate `[null,eval,var,etc]` functions. The `q-` variants call the bare ones and then `assert[_eq]!()` as appropriate. This is because there were a few nonstandard uses of the `q-` variants.
- Passed the result len into `qext()` since that's all we ever assert on anyway.
- Used the raw string (`r#""#`) syntax every time we have multiple rules instead of `putting(); them(); all(); on(); one(); line();`.
- Added a `values!()` macro that turns `values![1, 2, 3]` into `vec![value!(1), value!(2), value!(3)]` and `values![[1, 2], [3, 4]]` into `vec![vec![value!(1), value!(2)], vec![value!(3), value!(4)]]`. A ton of the "expected" values in our test assertions are of this form.
- Added `qruntime!()` to assert that running a query raises a certain `RuntimeError` and `qparse!()` to assert that loading a Polar snippet raises a certain `ParseError`.
- Return `Result<(), PolarError>` from tests that `.unwrap()` `PolarResult`s so we can use the `?` operator.