### PR TITLE
Update GitHub Actions triggers

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,5 @@
 name: Rust benchmark
-on:
-  push:
-    branches:
+on: [pull_request_target]
 
 jobs:
   benchmark:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,7 +23,6 @@ jobs:
           name: Rust Benchmark
           tool: "cargo"
           output-file-path: output.txt
-          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
           alert-comment-cc-users: "@osohq/eng"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,8 +1,9 @@
 name: Rust benchmark
-on: [pull_request_target]
+on: [push, pull_request_target]
 
 jobs:
   benchmark:
+    if: github.event_name == 'pull_request_target' || contains(github.event.head_commit.message, '[bench]')
     name: Run Rust benchmark example
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,5 +30,5 @@ jobs:
           alert-threshold: "150%"
           # Only push, save + comment on main
           auto-push: ${{ github.ref == 'refs/heads/main' }}
-          comment-always: ${{ github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[bench]') }}
+          comment-always: ${{ github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[showbench]') }}
           save-data-file: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Development
-on: [push, pull_request_target]
+on: [pull_request_target]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
 name: Development
-on: [pull_request_target]
+on: [push, pull_request_target]
 
 jobs:
   test:
+    if: github.event_name == 'pull_request_target' || contains(github.event.head_commit.message, '[test]')
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout code


### PR DESCRIPTION
Development + Rust benchmark workflows now run on:
- [re-]opening a new PR (including from a fork)
- pushing code to a branch associated with an open PR (including from a fork)
- pushing a commit containing `[test]` and/or `[bench]` to a base repo branch (no forks) not associated with an open PR

Note that if you have an open PR in the base repo and you push a commit to it containing `[test]` and/or `[bench]`, CI will run twice (in parallel) for the two matching events (`synchronize` of a `pull_request_target` and matching `[test]`/`[bench]` in the commit message of a `push` event).

I took 5 minutes to try to figure out if we could avoid that duplication entirely, but we would have to check if at least one open PR contains the commit in question (e.g., something like https://github.com/jwalton/gh-find-current-pr). Since that Action wouldn't do it out of the box, it seems easier to just collectively remember that you don't need to add `[test]` / `[bench]` if you already have an open PR.