### PR TITLE
Minor follow-up to #480 & #484

### DIFF
--- a/polar-core/src/folder.rs
+++ b/polar-core/src/folder.rs
@@ -39,8 +39,9 @@ pub trait Folder: Sized {
     fn fold_instance_id(&mut self, i: u64) -> u64 {
         fold_instance_id(i, self)
     }
-    fn fold_symbol(&mut self, s: Symbol) -> Symbol {
-        fold_symbol(s, self)
+    // Class, key, and rule names.
+    fn fold_name(&mut self, n: Symbol) -> Symbol {
+        fold_name(n, self)
     }
     fn fold_variable(&mut self, v: Symbol) -> Symbol {
         fold_variable(v, self)
@@ -91,7 +92,7 @@ pub trait Folder: Sized {
 
 pub fn fold_rule<T: Folder>(Rule { name, params, body }: Rule, fld: &mut T) -> Rule {
     Rule {
-        name: fld.fold_symbol(name),
+        name: fld.fold_name(name),
         params: params.into_iter().map(|p| fld.fold_param(p)).collect(),
         body: fld.fold_term(body),
     }
@@ -155,7 +156,7 @@ pub fn fold_instance_literal<T: Folder>(
     fld: &mut T,
 ) -> InstanceLiteral {
     InstanceLiteral {
-        tag: fld.fold_symbol(tag),
+        tag: fld.fold_name(tag),
         fields: fld.fold_dictionary(fields),
     }
 }
@@ -164,7 +165,7 @@ pub fn fold_dictionary<T: Folder>(Dictionary { fields }: Dictionary, fld: &mut T
     Dictionary {
         fields: fields
             .into_iter()
-            .map(|(k, v)| (fld.fold_symbol(k), fld.fold_term(v)))
+            .map(|(k, v)| (fld.fold_name(k), fld.fold_term(v)))
             .collect::<BTreeMap<Symbol, Term>>(),
     }
 }
@@ -178,12 +179,12 @@ pub fn fold_pattern<T: Folder>(p: Pattern, fld: &mut T) -> Pattern {
 
 pub fn fold_call<T: Folder>(Call { name, args, kwargs }: Call, fld: &mut T) -> Call {
     Call {
-        name: fld.fold_symbol(name),
+        name: fld.fold_name(name),
         args: fld.fold_list(args),
         kwargs: kwargs.map(|kwargs| {
             kwargs
                 .into_iter()
-                .map(|(k, v)| (fld.fold_symbol(k), fld.fold_term(v)))
+                .map(|(k, v)| (fld.fold_name(k), fld.fold_term(v)))
                 .collect::<BTreeMap<Symbol, Term>>()
         }),
     }
@@ -229,8 +230,8 @@ pub fn fold_constraints<T: Folder>(
     }
 }
 
-pub fn fold_symbol<T: Folder>(s: Symbol, _fld: &mut T) -> Symbol {
-    s
+pub fn fold_name<T: Folder>(n: Symbol, _fld: &mut T) -> Symbol {
+    n
 }
 
 pub fn fold_param<T: Folder>(

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -229,27 +229,25 @@ impl Default for PolarVirtualMachine {
 
 #[allow(clippy::ptr_arg)]
 fn query_contains_partial(goals: &Goals) -> bool {
-    if goals.len() == 1 {
-        if let Goal::Query { term } = &goals[0] {
-            struct PartialVisitor {
-                has_partial: bool,
-            }
+    struct PartialVisitor {
+        has_partial: bool,
+    }
 
-            impl Visitor for PartialVisitor {
-                fn visit_constraints(&mut self, _: &partial::Constraints) {
-                    self.has_partial = true;
-                }
-            }
+    impl Visitor for PartialVisitor {
+        fn visit_constraints(&mut self, _: &partial::Constraints) {
+            self.has_partial = true;
+        }
+    }
 
-            let mut visitor = PartialVisitor { has_partial: false };
+    let mut visitor = PartialVisitor { has_partial: false };
+    goals.iter().any(|goal| {
+        if let Goal::Query { term } = goal {
             walk_term(&mut visitor, &term);
             visitor.has_partial
         } else {
             false
         }
-    } else {
-        false
-    }
+    })
 }
 
 // Methods which aren't goals/instructions.

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -912,7 +912,14 @@ impl PolarVirtualMachine {
             (_, Value::InstanceLiteral(_)) | (_, Value::Dictionary(_)) => {
                 unreachable!("parsed as pattern")
             }
-            (_, Value::Partial(_)) => unreachable!("cannot match against a partial"),
+            (_, Value::Partial(_)) => {
+                return Err(self.set_error_context(
+                    &right,
+                    error::RuntimeError::Unsupported {
+                        msg: "cannot match against a partial".to_string(),
+                    },
+                ));
+            }
 
             (Value::Variable(v), _) | (Value::RestVariable(v), _) => {
                 if let Some(value) = self.value(&v).cloned() {


### PR DESCRIPTION
* Rename `fold_symbol` back to `fold_name`, used for non-variable symbols in name position.
* Scan all goals on VM init for queries.
* Make a currently-unreachable case an error.