### PR TITLE
Update CI triggers

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,7 +13,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          # This prevents the Action from persisting the credentials it uses to
+          # perform the fetch/checkout to the Runner's local Git config. On
+          # `pull_request_target` events, the GITHUB_TOKEN provided to the
+          # Runner has Write permissions to the base repository. We do **not**
+          # want to allow untrusted code from forks to execute arbitrary Git
+          # commands with those elevated permissions.
+          #
+          # More info:
+          # https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
           persist-credentials: false
+          # Explicitly setting the `repository` and `ref` inputs ensures that
+          # `pull_request_target` events trigger CI runs against the code from
+          # the HEAD branch. By default, this Action checks out code from the
+          # BASE branch. On `push` events, the `github.event.pull_request` path
+          # will yield a null value, and passing nulls to these inputs causes
+          # them to fall back to the defaults of `osohq/oso` and
+          # `refs/heads/main`, respectively.
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/cache@v2

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -52,7 +52,9 @@ jobs:
           comment-on-alert: true
           alert-comment-cc-users: "@osohq/eng"
           alert-threshold: "150%"
-          # Only push, save + comment on main
-          auto-push: ${{ github.event_name == 'push' }}
-          comment-always: ${{ github.event_name == 'push' || contains(github.event.head_commit.message, '[bench]') }}
-          save-data-file: ${{ github.event_name == 'push' }}
+          # Only push and save on pushes to main.
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          # Comment on pushes to main AND on any commit that includes `[bench]`
+          # in the message.
+          comment-always: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || contains(github.event.head_commit.message, '[bench]') }}
+          save-data-file: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,13 +1,21 @@
 name: Rust benchmark
-on: [push, pull_request_target]
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    branches:
 
 jobs:
   benchmark:
-    if: github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[bench]')
     name: Run Rust benchmark example
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -29,6 +37,6 @@ jobs:
           alert-comment-cc-users: "@osohq/eng"
           alert-threshold: "150%"
           # Only push, save + comment on main
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          comment-always: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || contains(github.event.head_commit.message, '[showbench]') }}
-          save-data-file: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          auto-push: ${{ github.event_name == 'push' }}
+          comment-always: ${{ github.event_name == 'push' || contains(github.event.head_commit.message, '[bench]') }}
+          save-data-file: ${{ github.event_name == 'push' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,13 +197,13 @@ jobs:
       ## Publish docs
       ## Also easier to do here with above deps installed
       - name: s3 preview publish
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: aws s3 sync --delete docs/_build/html s3://docs-preview.oso.dev
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
       - name: cloudfront invalidate docs preview
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: aws cloudfront create-invalidation --distribution-id E2KU2V8C9KJNU7 --paths "/*"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          # This prevents the Action from persisting the credentials it uses to
+          # perform the fetch/checkout to the Runner's local Git config. On
+          # `pull_request_target` events, the GITHUB_TOKEN provided to the
+          # Runner has Write permissions to the base repository. We do **not**
+          # want to allow untrusted code from forks to execute arbitrary Git
+          # commands with those elevated permissions.
+          #
+          # More info:
+          # https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
           persist-credentials: false
+          # Explicitly setting the `repository` and `ref` inputs ensures that
+          # `pull_request_target` events trigger CI runs against the code from
+          # the HEAD branch. By default, this Action checks out code from the
+          # BASE branch. On `push` events, the `github.event.pull_request` path
+          # will yield a null value, and passing nulls to these inputs causes
+          # them to fall back to the defaults of `osohq/oso` and
+          # `refs/heads/main`, respectively.
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -99,7 +115,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          # This prevents the Action from persisting the credentials it uses to
+          # perform the fetch/checkout to the Runner's local Git config. On
+          # `pull_request_target` events, the GITHUB_TOKEN provided to the
+          # Runner has Write permissions to the base repository. We do **not**
+          # want to allow untrusted code from forks to execute arbitrary Git
+          # commands with those elevated permissions.
+          #
+          # More info:
+          # https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
           persist-credentials: false
+          # Explicitly setting the `repository` and `ref` inputs ensures that
+          # `pull_request_target` events trigger CI runs against the code from
+          # the HEAD branch. By default, this Action checks out code from the
+          # BASE branch. On `push` events, the `github.event.pull_request` path
+          # will yield a null value, and passing nulls to these inputs causes
+          # them to fall back to the defaults of `osohq/oso` and
+          # `refs/heads/main`, respectively.
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,20 @@
 name: Development
-on: [push, pull_request_target]
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    branches:
 
 jobs:
   check:
-    if: github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[test]')
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/cache@v2
         with:
@@ -88,11 +95,13 @@ jobs:
           args: "--dry-run --set-exit-if-changed"
 
   test:
-    if: github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[test]')
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/cache@v2
         with:
@@ -156,13 +165,13 @@ jobs:
       ## Publish docs
       ## Also easier to do here with above deps installed
       - name: s3 preview publish
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' }}
         run: aws s3 sync --delete docs/_build/html s3://docs-preview.oso.dev
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
       - name: cloudfront invalidate docs preview
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' }}
         run: aws cloudfront create-invalidation --distribution-id E2KU2V8C9KJNU7 --paths "/*"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}


### PR DESCRIPTION
- No longer run CI on pushes to non-main branches w/o an open PR. If
  this is a workflow we want to support in the future, we can do it. I
  don't think anyone is clamoring for this at the moment, so it's
  unnecessary complexity for now. If you want CI to run on your branch,
  open a PR (draft or otherwise).

- I don't *think* specifying the `branches:` key for the
  `pull_request_target` event does anything, since you already can't
  make a PR from one fork branch to another fork branch (the base branch
  has to be on the osohq/oso repo). However, [the GitHub Actions
  docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags)
  state that "[i]f you define only ... `branches`, the workflow won't
  run for events affecting the undefined Git ref," which sounds ominous.

- Set `persist-credentials` to false, which prevents the
  actions/checkout Action from persisting the credentials it uses to
  perform the fetch/checkout in the Runner's local Git config. This is
  fine because we don't currently do any further Git stuff in any of the
  affected workflows. The only other Git stuff I can think of across any
  of our workflows is where we checkout the submodules in the Test
  Quickstarts step of the Create Release workflow, but even that doesn't
  require any credentials since they're all public repos that we fetch
  over HTTPS.

- We specify the `repository` and `ref` inputs to the actions/checkout
  Action. We're pulling them both from the
  `github.event.pull_request.head` payload, which astute readers will
  surmise doesn't exist on `push` events. Right you are! On `push`
  events (to `main`, in our case), the actions/checkout Action will see
  the null values passed for `repository` and `ref` and fallback to its
  old standbys of `github.repository` (osohq/oso) and the BASE branch (`main`).

- Now that we don't use `[bench]` to trigger a bench run on a non-main
  branch w/o an open PR, I've changed the commit message trigger that
  tells the rhysd/github-action-benchmark Action to leave a comment w/
  benchmark results on the appropriate commit back to `[bench]` from the
  short-lived `[showbench]`.

- I've also removed the `[test]` commit message trigger for reasons
  already covered. If you want to run CI against a branch, open a PR.

- I removed a few unnecessary checks -- since the only push events we
  run CI for are pushes to main, we don't need to check that the
  `github.ref` is `refs/heads/main`.