### PR TITLE
Generalize sub_this to handle levels of nesting > 2.

### DIFF
--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -857,11 +857,11 @@ mod test {
     #[test]
     fn test_nested_dot_in() -> TestResult {
         let p = Polar::new();
-        p.load_str("f(x, y) if x in y.a.b.c;");
+        p.load_str("f(x, y) if x in y.a.b.c;")?;
 
-        let mut q = p.new_query_from_term(term!(call!("f", [1, partial!("a")])), false)?;
+        let mut q = p.new_query_from_term(term!(call!("f", [1, partial!("a")])), false);
 
-        assert_partial_expression!(next_binding(&mut q)?, "a", "_this");
+        assert_partial_expression!(next_binding(&mut q)?, "a", "1 in _this.a.b.c");
         Ok(())
     }
 
@@ -869,10 +869,18 @@ mod test {
     fn test_nested_dot_lookup() -> TestResult {
         let p = Polar::new();
         p.load_str("f(x, y) if x = y.a.b.c;")?;
+        p.load_str("f(x, y) if x > y.a.b.c and x < y.a.b and y.a.b.c > x;")?;
 
         let mut q = p.new_query_from_term(term!(call!("f", [1, partial!("a")])), false);
 
-        assert_partial_expression!(next_binding(&mut q)?, "a", "_this");
+        assert_partial_expression!(next_binding(&mut q)?, "a", "_this.a.b.c = 1");
+        assert_partial_expression!(
+            next_binding(&mut q)?,
+            "a",
+            "_this.a.b.c < 1 and _this.a.b > 1 and _this.a.b.c > 1"
+        );
         Ok(())
     }
+
+    // TODO test for nested dot with compare.
 }

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -858,9 +858,7 @@ mod test {
     fn test_nested_dot_in() -> TestResult {
         let p = Polar::new();
         p.load_str("f(x, y) if x in y.a.b.c;")?;
-
         let mut q = p.new_query_from_term(term!(call!("f", [1, partial!("a")])), false);
-
         assert_partial_expression!(next_binding(&mut q)?, "a", "1 in _this.a.b.c");
         Ok(())
     }
@@ -868,13 +866,15 @@ mod test {
     #[test]
     fn test_nested_dot_lookup() -> TestResult {
         let p = Polar::new();
-        p.load_str("f(x, y) if x = y.a.b.c;")?;
-        p.load_str("f(x, y) if x > y.a.b.c and x < y.a.b and y.a.b.c > x;")?;
-        p.load_str("f(x, y) if x = y.a;")?;
-        p.load_str("f(x, y) if x = y.a.b;")?;
-        p.load_str("f(x, y) if x = y.a.b.c.d;")?;
-        p.load_str("f(x, y) if x = y.a.b.c.d.e;")?;
-        p.load_str("f(x, y) if x = y.a.b.c.d.e.f;")?;
+        p.load_str(
+            r#"f(x, y) if x = y.a.b.c;
+               f(x, y) if x > y.a.b.c and x < y.a.b and y.a.b.c > x;
+               f(x, y) if x = y.a;
+               f(x, y) if x = y.a.b;
+               f(x, y) if x = y.a.b.c.d;
+               f(x, y) if x = y.a.b.c.d.e;
+               f(x, y) if x = y.a.b.c.d.e.f;"#
+        )?;
 
         let mut q = p.new_query_from_term(term!(call!("f", [1, partial!("a")])), false);
 

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -853,4 +853,26 @@ mod test {
         assert_query_done!(q);
         Ok(())
     }
+
+    #[test]
+    fn test_nested_dot_in() -> TestResult {
+        let p = Polar::new();
+        p.load_str("f(x, y) if x in y.a.b.c;");
+
+        let mut q = p.new_query_from_term(term!(call!("f", [1, partial!("a")])), false)?;
+
+        assert_partial_expression!(next_binding(&mut q)?, "a", "_this");
+        Ok(())
+    }
+
+    #[test]
+    fn test_nested_dot_lookup() -> TestResult {
+        let p = Polar::new();
+        p.load_str("f(x, y) if x = y.a.b.c;")?;
+
+        let mut q = p.new_query_from_term(term!(call!("f", [1, partial!("a")])), false);
+
+        assert_partial_expression!(next_binding(&mut q)?, "a", "_this");
+        Ok(())
+    }
 }

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -891,6 +891,4 @@ mod test {
         assert_partial_expression!(next_binding(&mut q)?, "a", "_this.a.b.c.d.e.f = 1");
         Ok(())
     }
-
-    // TODO test for nested dot with compare.
 }

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -870,6 +870,11 @@ mod test {
         let p = Polar::new();
         p.load_str("f(x, y) if x = y.a.b.c;")?;
         p.load_str("f(x, y) if x > y.a.b.c and x < y.a.b and y.a.b.c > x;")?;
+        p.load_str("f(x, y) if x = y.a;")?;
+        p.load_str("f(x, y) if x = y.a.b;")?;
+        p.load_str("f(x, y) if x = y.a.b.c.d;")?;
+        p.load_str("f(x, y) if x = y.a.b.c.d.e;")?;
+        p.load_str("f(x, y) if x = y.a.b.c.d.e.f;")?;
 
         let mut q = p.new_query_from_term(term!(call!("f", [1, partial!("a")])), false);
 
@@ -879,6 +884,11 @@ mod test {
             "a",
             "_this.a.b.c < 1 and _this.a.b > 1 and _this.a.b.c > 1"
         );
+        assert_partial_expression!(next_binding(&mut q)?, "a", "_this.a = 1");
+        assert_partial_expression!(next_binding(&mut q)?, "a", "_this.a.b = 1");
+        assert_partial_expression!(next_binding(&mut q)?, "a", "_this.a.b.c.d = 1");
+        assert_partial_expression!(next_binding(&mut q)?, "a", "_this.a.b.c.d.e = 1");
+        assert_partial_expression!(next_binding(&mut q)?, "a", "_this.a.b.c.d.e.f = 1");
         Ok(())
     }
 

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -873,7 +873,7 @@ mod test {
                f(x, y) if x = y.a.b;
                f(x, y) if x = y.a.b.c.d;
                f(x, y) if x = y.a.b.c.d.e;
-               f(x, y) if x = y.a.b.c.d.e.f;"#
+               f(x, y) if x = y.a.b.c.d.e.f;"#,
         )?;
 
         let mut q = p.new_query_from_term(term!(call!("f", [1, partial!("a")])), false);

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -138,16 +138,6 @@ impl Simplifier {
 
         match arg.value() {
             Value::Variable(v) if v.is_this_var() => dot_op.clone(),
-            Value::Expression(Operation {
-                operator: Operator::Dot,
-                args,
-            }) => {
-                assert!(args[0].value().as_symbol().unwrap().is_this_var());
-                arg.clone_with_value(Value::Expression(Operation {
-                    operator: Operator::Dot,
-                    args: vec![dot_op.clone(), args[1].clone()],
-                }))
-            }
             Value::Expression(Operation { operator, args }) => {
                 arg.clone_with_value(Value::Expression(Operation {
                     operator: *operator,

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -29,75 +29,13 @@ pub struct Simplifier;
 impl Folder for Simplifier {
     /// Deduplicate constraints.
     fn fold_partial(&mut self, partial: Partial) -> Partial {
-        let mut seen: HashSet<&Operation> = HashSet::new();
-        let ops = partial
-            .constraints()
-            .iter()
-            .filter(|o| seen.insert(o))
-            .cloned()
-            .collect();
-        fold_partial(partial.clone_with_constraints(ops), self)
+        fold_partial(self.deduplicate_constraints(partial), self)
     }
 
     fn fold_operation(&mut self, mut o: Operation) -> Operation {
-        fn maybe_unwrap_operation(o: &Operation) -> Option<Operation> {
-            match o {
-                // Unwrap a single-arg And or Or expression and fold the inner term.
-                Operation {
-                    operator: Operator::And,
-                    args,
-                }
-                | Operation {
-                    operator: Operator::Or,
-                    args,
-                } if args.len() == 1 => {
-                    if let Value::Expression(op) = args[0].value() {
-                        Some(op.clone())
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            }
-        }
-
-        if let Some(op) = maybe_unwrap_operation(&o) {
+        if let Some(op) = self.maybe_unwrap_single_argument_and_or(&o) {
             o = op;
         }
-
-        /// Given `this` and `x`, return `x`.
-        /// Given `this.x` and `this.y`, return `this.x.y`.
-        fn sub_this(arg: &Term, expr: &Term) -> Term {
-            match (arg.value(), expr.value()) {
-                (Value::Variable(v), _) if v.is_this_var() => expr.clone(),
-                (
-                    Value::Expression(Operation {
-                        operator: Operator::Dot,
-                        args,
-                    }),
-                    Value::Expression(Operation {
-                        operator: Operator::Dot,
-                        ..
-                    }),
-                ) => arg.clone_with_value(Value::Expression(Operation {
-                    operator: Operator::Dot,
-                    args: vec![expr.clone(), args[1].clone()],
-                })),
-                _ => arg.clone(),
-            }
-        }
-
-        // Optionally sub `expr` into each of the arguments of the partial's constraints.
-        let mut map_constraints = |constraints: &[Operation], expr: &Term| -> TermList {
-            constraints
-                .iter()
-                .map(|c| Operation {
-                    operator: c.operator,
-                    args: c.args.iter().map(|arg| sub_this(arg, expr)).collect(),
-                })
-                .map(|c| expr.clone_with_value(Value::Expression(fold_operation(c, self))))
-                .collect()
-        };
 
         match o.operator {
             Operator::Neq => {
@@ -108,10 +46,10 @@ impl Folder for Simplifier {
                     args: match (left.value(), right.value()) {
                         // Distribute **inverted** expression over the partial.
                         (Value::Partial(c), Value::Expression(_)) => {
-                            map_constraints(&c.inverted_constraints(0), right)
+                            self.map_constraints(&c.inverted_constraints(0), right)
                         }
                         (Value::Expression(_), Value::Partial(c)) => {
-                            map_constraints(&c.inverted_constraints(0), left)
+                            self.map_constraints(&c.inverted_constraints(0), left)
                         }
                         _ => return fold_operation(o, self),
                     },
@@ -125,10 +63,10 @@ impl Folder for Simplifier {
                     args: match (left.value(), right.value()) {
                         // Distribute expression over the partial.
                         (Value::Partial(c), Value::Expression(_)) => {
-                            map_constraints(c.constraints(), right)
+                            self.map_constraints(c.constraints(), right)
                         }
                         (Value::Expression(_), Value::Partial(c)) => {
-                            map_constraints(c.constraints(), left)
+                            self.map_constraints(c.constraints(), left)
                         }
                         _ => return fold_operation(o, self),
                     },
@@ -146,6 +84,94 @@ impl Folder for PartialToExpression {
             Value::Partial(partial) => fold_term(partial.clone().into_expression(), self),
             _ => fold_term(t, self),
         }
+    }
+}
+
+impl Simplifier {
+    /// Remove duplicate constraints from a partial.
+    fn deduplicate_constraints(&mut self, partial: Partial) -> Partial {
+        let mut seen: HashSet<&Operation> = HashSet::new();
+        let constraints = partial
+            .constraints()
+            .iter()
+            .filter(|o| seen.insert(o))
+            .cloned()
+            .collect();
+        partial.clone_with_constraints(constraints)
+    }
+
+    /// If ``operation`` is an AND or OR operation with 1 argument, return the 1st argument.
+    ///
+    /// Returns: Some(op) if a rewrite occured, or None.
+    fn maybe_unwrap_single_argument_and_or(&self, operation: &Operation) -> Option<Operation> {
+        match operation {
+            // Unwrap a single-arg And or Or expression and fold the inner term.
+            Operation {
+                operator: Operator::And,
+                args,
+            }
+            | Operation {
+                operator: Operator::Or,
+                args,
+            } if args.len() == 1 => {
+                if let Value::Expression(op) = args[0].value() {
+                    Some(op.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// Subsitute the this variable in a constraint with a dot operation.
+    /// Given `this` and `x`, return `x`.
+    /// Given `this.x` and `this.y`, return `this.x.y`.
+    fn sub_this(arg: &Term, dot_op: &Term) -> Term {
+        assert!(matches!(
+            dot_op.value(),
+            Value::Expression(Operation {
+                operator: Operator::Dot,
+                ..
+            })
+        ));
+
+        match arg.value() {
+            Value::Variable(v) if v.is_this_var() => dot_op.clone(),
+            Value::Expression(Operation {
+                operator: Operator::Dot,
+                args,
+            }) => {
+                assert!(args[0].value().as_symbol().unwrap().is_this_var());
+                arg.clone_with_value(Value::Expression(Operation {
+                    operator: Operator::Dot,
+                    args: vec![dot_op.clone(), args[1].clone()],
+                }))
+            }
+            Value::Expression(Operation { operator, args }) => {
+                arg.clone_with_value(Value::Expression(Operation {
+                    operator: *operator,
+                    args: args.iter().map(|arg| Self::sub_this(arg, dot_op)).collect(),
+                }))
+            }
+            _ => arg.clone(),
+        }
+    }
+
+    /// Substitute the _this variable in a list of constraints with a dot operation path.
+    fn map_constraints(&mut self, constraints: &[Operation], dot_op: &Term) -> TermList {
+        constraints
+            .iter()
+            .map(|c| Operation {
+                operator: c.operator,
+                args: c
+                    .args
+                    .iter()
+                    .map(|arg| Self::sub_this(arg, dot_op))
+                    .collect(),
+            })
+            .map(|c| dot_op.clone_with_value(Value::Expression(fold_operation(c, self))))
+            .collect()
     }
 }
 

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -100,9 +100,9 @@ impl Simplifier {
         partial.clone_with_constraints(constraints)
     }
 
-    /// If ``operation`` is an AND or OR operation with 1 argument, return the 1st argument.
+    /// If `operation` is a 1-arg AND or OR operation, return its argument.
     ///
-    /// Returns: Some(op) if a rewrite occured, or None.
+    /// Returns: Some(op) if a rewrite occurred; otherwise None.
     fn maybe_unwrap_single_argument_and_or(&self, operation: &Operation) -> Option<Operation> {
         match operation {
             // Unwrap a single-arg And or Or expression and fold the inner term.
@@ -124,7 +124,7 @@ impl Simplifier {
         }
     }
 
-    /// Subsitute the this variable in a constraint with a dot operation.
+    /// Substitute the this variable in a constraint with a dot operation.
     /// Given `this` and `x`, return `x`.
     /// Given `this.x` and `this.y`, return `this.x.y`.
     fn sub_this(arg: &Term, dot_op: &Term) -> Term {
@@ -148,7 +148,7 @@ impl Simplifier {
         }
     }
 
-    /// Substitute the _this variable in a list of constraints with a dot operation path.
+    /// Substitute the this variable in a list of constraints with a dot operation path.
     fn map_constraints(&mut self, constraints: &[Operation], dot_op: &Term) -> TermList {
         constraints
             .iter()


### PR DESCRIPTION
Expressions like `x in y.a.b.c` were not translating properly.  This PR fixes that by changing `sub_this` to operate recursively over operations.

I also did some re-organization and moved each simplification method onto `Simplifier`.  I started this to make it easier to unit test each in isolation, but didn't end up needing to write those tests to figure out the issue.


PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.