### PR TITLE
Set up 404 page.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinxcontrib.contentui",
     "sphinxcontrib.spelling",
+    "notfound.extension",
 ]
 
 
@@ -127,6 +128,17 @@ copybutton_prompt_is_regexp = True
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "borland"
+
+# For 404 page, all URLs start from root
+notfound_urls_prefix = "/"
+
+notfound_context = {
+    'title': 'Page Not Found',
+    'body': '''
+<h1>Page Not Found</h1>
+<p>Sorry, we couldn't find that page.</p>
+'''
+}
 
 ### Show/hide TODOs
 

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -8,3 +8,5 @@ sphinx-tabs
 sphinxcontrib-spelling
 sphinx-copybutton
 sphinx-material
+# Temporary fix
+git+https://github.com/samscott89/sphinx-notfound-page@master


### PR DESCRIPTION
- Creates a 404 page that we can redirect to (see, for example: docs-preview.oso.dev/asdasd/asdasd)
- Does some sphinx shenanigans so that the resource links have an absolute path

Before:

![image](https://user-images.githubusercontent.com/13355482/99743383-91dabf00-2aa3-11eb-899a-3f4d8adf1732.png)

After:

![image](https://user-images.githubusercontent.com/13355482/99743392-969f7300-2aa3-11eb-9e23-8f68ba8f516f.png)
