### PR TITLE
Update 'Wrong value type' error message

### DIFF
--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -276,7 +276,7 @@ ExpectLogical<T>: Term = {
     <loc:@L> <term:T> =>? {
         match term {
             ValueOrLogical::Value(term) => {
-                Err(ParseError::User { error: error::ParseError::WrongValueType { loc, term, expected: "logical".to_string() } })
+                Err(ParseError::User { error: error::ParseError::WrongValueType { loc, term, expected: "logical expression".to_string() } })
             },
             ValueOrLogical::Logical(t) | ValueOrLogical::Either(t) => Ok(t)
         }


### PR DESCRIPTION
Currently:
```python
query> 1 and 2
ParserError
Wrong value type: 1. Expected a logical at line 1, column 1
```
After:
```python
query> 1 and 2
ParserError
Wrong value type: 1. Expected a logical expression at line 1, column 1
```