### PR TITLE
Update django-oso with User model registration, logging vs print

### DIFF
--- a/languages/python/django-oso/django_oso/apps.py
+++ b/languages/python/django-oso/django_oso/apps.py
@@ -1,9 +1,7 @@
 import functools
-import os.path
 from pathlib import Path
 
 from django.apps import AppConfig, apps
-from django.http import HttpRequest
 from django.utils.autoreload import autoreload_started
 
 from .oso import init_oso

--- a/languages/python/django-oso/django_oso/oso.py
+++ b/languages/python/django-oso/django_oso/oso.py
@@ -40,22 +40,13 @@ def init_oso():
         for model in app.get_models():
             register_class(model, polar_model_name(model))
 
-    # Custom registration for auth (AnonymousUser, User)
+    # Custom registration for auth (AnonymousUser)
     if apps.is_installed("django.contrib.auth"):
         from django.contrib.auth.models import AnonymousUser
 
         # Register under `auth` app_label to match default User model, but also fully-qualified name
         register_class(AnonymousUser, "auth::AnonymousUser")
         register_class(AnonymousUser, "django::contrib::auth::AnonymousUser")
-
-        # Register the user model, possibly customized
-        try:
-            from django.contrib.auth import get_user_model
-
-            User = get_user_model()
-            register_class(User, polar_model_name(User))
-        except ImproperlyConfigured:
-            pass
 
     # Register request
     register_class(HttpRequest)

--- a/languages/python/django-oso/django_oso/oso.py
+++ b/languages/python/django-oso/django_oso/oso.py
@@ -51,11 +51,11 @@ def init_oso():
         # Register the user model, possibly customized
         try:
             from django.contrib.auth import get_user_model
+
             User = get_user_model()
             register_class(User, polar_model_name(User))
         except ImproperlyConfigured:
             pass
-
 
     # Register request
     register_class(HttpRequest)


### PR DESCRIPTION
- Update `init_oso`:
  - Register (dynamically set) user model, default as `auth::User`.
  - Register AnonymousUser as `auth::AnonymousUser` polar class to match User.
- Update policy file initialization to log policy files loaded via logging not `print`.
- Remove unused imports from `apps.py`.