### PR TITLE
Improve high level API used by SQLAlchemy adapter.

### DIFF
--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -7,18 +7,26 @@
 Breaking changes
 ================
 
-.. TODO remove warning and replace with "None" if no breaking
-   changes.
-
 .. warning:: This release contains breaking changes. Be sure
    to follow migration steps before upgrading.
 
-Breaking change 1
------------------
+Simplified ``sqlalchemy-oso`` session creation
+----------------------------------------------
 
-- summary of breaking change
+``sqlalchemy-oso`` now associates the current oso instance, user to authorize,
+and action to authorize with
+:py:class:`sqlalchemy_oso.session.AuthorizedSession`.  This class manages
+authorization instead of the removed
+``sqlalchemy_oso.hooks.make_authorized_query_cls``.
 
-Link to migration guide
+- The ``sqlalchemy.hooks`` module has been renamed to ``sqlalchemy.session``.
+  Update any imports to ``sqlalchemy.session``.
+- The ``sqlalchemy_hooks.make_authorized_query_cls`` function has been removed.
+  Use the session API instead
+  (:py:func:`sqlalchemy_oso.authorized_sessionmaker`).
+- The ``sqlalchemy_oso.authorized_sessionmaker`` function no longer accepts
+  extra positional arguments. Use keyword arguments to pass options to the
+  session.
 
 New features
 ============
@@ -33,6 +41,22 @@ flag. Version 0.6 was chosen for compatibility with `Diesel
 
 Thanks to `John Halbert <https://github.com/johnhalbert>`_ for the
 contribution!
+
+Improved ``sqlalchemy-oso`` support for usage with ``flask_sqlalchemy``
+-----------------------------------------------------------------------
+
+The ``sqlalchemy-oso`` library now has a built-in wrapper class that makes it
+easier to use with the popular ``flask_sqlalchemy`` library.  See
+:py:class:`sqlalchemy_oso.flask.AuthorizedSQLAlchemy` for more information.
+
+``scoped_session`` support for ``sqlalchemy-oso``
+-------------------------------------------------
+
+The new :py:func:`sqlalchemy_oso.session.scoped_session` session proxy can be
+used instead of SQLAlchemy's built-in scoped_session_.  This creates a session
+scoped to the current oso instance, user and action.
+
+.. _scoped_session: https://docs.sqlalchemy.org/en/13/orm/contextual.html#sqlalchemy.orm.scoping.scoped_session
 
 Other bugs & improvements
 =========================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,7 +203,7 @@ html_favicon = "favicon.ico"
 
 # --- doctest options ----
 
-doctest_test_doctest_blocks = ""
+doctest_test_doctest_blocks = "default"
 
 lexers["node"] = lexer.NodeShellLexer()
 lexers["polar"] = lexer.PolarLexer()

--- a/docs/getting-started/list-filtering/django.rst
+++ b/docs/getting-started/list-filtering/django.rst
@@ -6,6 +6,16 @@ The ``django-oso`` library can enforce policies over Django models. This allows
 policies to control access to collections of objects without needing to
 authorize each object individually.
 
+Installation
+============
+
+The oso Django integration is available on `PyPI`_ and can be installed using
+``pip``::
+
+    $ pip install django-oso
+
+.. _PyPI: https://pypi.org/project/django-oso/
+
 Usage
 =====
 

--- a/docs/getting-started/list-filtering/sqlalchemy.rst
+++ b/docs/getting-started/list-filtering/sqlalchemy.rst
@@ -6,6 +6,16 @@ The ``sqlalchemy-oso`` library can enforce policies over SQLAlchemy models.
 This allows policies to control access to collections of objects without
 needing to authorize each object individually.
 
+Installation
+============
+
+The oso SQLAlchemy integration is available on `PyPI`_ and can be installed using
+``pip``::
+
+    $ pip install sqlalchemy-oso
+
+.. _PyPI: https://pypi.org/project/sqlalchemy-oso/
+
 Usage
 =====
 
@@ -44,6 +54,12 @@ are translated into SQLAlchemy expressions and applied to the query before
 retrieving objects from the database.
 
 .. _Session: https://docs.sqlalchemy.org/en/13/orm/session_api.html#sqlalchemy.orm.session.Session
+
+**Using with Flask**
+
+``sqlalchemy-oso`` has built in support for using with the popular
+``flask_sqlalchemy`` library.  See
+:py:class:`sqlalchemy_oso.flask.AuthorizedSQLAlchemy`.
 
 Example
 =======
@@ -279,5 +295,10 @@ action:
 
 - application method calls
 - arithmetic operators
+
+API Reference
+=============
+
+See :doc:`/using/frameworks/sqlalchemy` for API documentation.
 
 .. _Slack: http://join-slack.osohq.com/

--- a/docs/spelling_allowed_words.txt
+++ b/docs/spelling_allowed_words.txt
@@ -63,6 +63,7 @@ precommit
 args
 moduli
 enumerables
+mixin
 
 ## Product names
 sqlite

--- a/docs/using/frameworks/sqlalchemy.rst
+++ b/docs/using/frameworks/sqlalchemy.rst
@@ -24,5 +24,20 @@ for more information.
 API Reference
 =============
 
+sqlalchemy_oso
+--------------
+
 .. automodule:: sqlalchemy_oso
+    :members:
+
+sqlalchemy_oso.session
+----------------------
+
+.. automodule:: sqlalchemy_oso.session
+    :members:
+
+sqlalchemy_oso.flask
+----------------------
+
+.. automodule:: sqlalchemy_oso.flask
     :members:

--- a/docs/using/frameworks/sqlalchemy.rst
+++ b/docs/using/frameworks/sqlalchemy.rst
@@ -24,20 +24,20 @@ for more information.
 API Reference
 =============
 
-sqlalchemy_oso
---------------
+``sqlalchemy_oso``
+------------------
 
 .. automodule:: sqlalchemy_oso
     :members:
 
-sqlalchemy_oso.session
-----------------------
+``sqlalchemy_oso.session``
+--------------------------
 
 .. automodule:: sqlalchemy_oso.session
     :members:
 
-sqlalchemy_oso.flask
-----------------------
+``sqlalchemy_oso.flask``
+------------------------
 
 .. automodule:: sqlalchemy_oso.flask
     :members:

--- a/languages/python/oso/oso/oso.py
+++ b/languages/python/oso/oso/oso.py
@@ -9,8 +9,9 @@ class Oso(Polar):
     """The central object to manage application policy state, e.g.
     the policy data, and verify requests.
 
+    >>> from oso import Oso
     >>> Oso()
-    <oso.Oso object at 0x7fad57305100>
+    <oso.oso.Oso object at 0x...>
 
     """
 

--- a/languages/python/sqlalchemy-oso/requirements-test.txt
+++ b/languages/python/sqlalchemy-oso/requirements-test.txt
@@ -1,1 +1,3 @@
 pytest==5.3.5
+flask
+flask_sqlalchemy

--- a/languages/python/sqlalchemy-oso/setup.py
+++ b/languages/python/sqlalchemy-oso/setup.py
@@ -60,7 +60,9 @@ setup(
     #
     # Similar to `install_requires` above, these must be valid existing
     # projects.
-    extras_require={},
+    extras_require={
+        'flask': ['flask', 'flask_sqlalchemy']
+    },
     # If there are data files included in your packages that need to be
     # installed, specify them here.
     #

--- a/languages/python/sqlalchemy-oso/setup.py
+++ b/languages/python/sqlalchemy-oso/setup.py
@@ -60,9 +60,7 @@ setup(
     #
     # Similar to `install_requires` above, these must be valid existing
     # projects.
-    extras_require={
-        'flask': ['flask', 'flask_sqlalchemy']
-    },
+    extras_require={"flask": ["flask", "flask_sqlalchemy"]},
     # If there are data files included in your packages that need to be
     # installed, specify them here.
     #

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/__init__.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "0.1.0"
 
 from .auth import register_models
-from .hooks import authorized_sessionmaker
+from .session import authorized_sessionmaker
 
 __all__ = ["register_models", "authorized_sessionmaker"]

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/flask.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/flask.py
@@ -3,21 +3,22 @@ try:
     from flask_sqlalchemy import SQLAlchemy, SignallingSession
 except ImportError:
     import warnings
-    warnings.warn("Missing depenedencies for Flask. Install sqlalchemy-oso with the flask extra.")
+
+    warnings.warn(
+        "Missing depenedencies for Flask. Install sqlalchemy-oso with the flask extra."
+    )
     raise
 
 from sqlalchemy_oso.hooks import authorized_sessionmaker, scoped_session
+
 
 class AuthorizedSQLAlchemy(SQLAlchemy):
     """flask_sqlalchemy ``SQLAlchemy`` subclass that uses oso.
 
     Creates sessions with oso authorization applied.
     """
-    def __init__(self,
-                 get_oso,
-                 get_user,
-                 get_action,
-                 **kwargs):
+
+    def __init__(self, get_oso, get_user, get_action, **kwargs):
         self._get_oso = get_oso
         self._get_user = get_user
         self._get_action = get_action
@@ -28,7 +29,8 @@ class AuthorizedSQLAlchemy(SQLAlchemy):
             get_oso=self._get_oso,
             get_user=self._get_user,
             get_action=self._get_action,
-            **options)
+            **options
+        )
 
     def create_scoped_session(self, options=None):
         if options is None:
@@ -52,4 +54,5 @@ class AuthorizedSQLAlchemy(SQLAlchemy):
             get_action=self._get_action,
             class_=SignallingSession,
             db=self,
-            **options)
+            **options
+        )

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/flask.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/flask.py
@@ -43,14 +43,6 @@ class AuthorizedSQLAlchemy(SQLAlchemy):
         self._get_action = get_action
         super().__init__(**kwargs)
 
-    def create_session(self, options):
-        return authorized_sessionmaker(
-            get_oso=self._get_oso,
-            get_user=self._get_user,
-            get_action=self._get_action,
-            **options
-        )
-
     def create_scoped_session(self, options=None):
         if options is None:
             options = {}

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/flask.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/flask.py
@@ -9,7 +9,7 @@ except ImportError:
     )
     raise
 
-from sqlalchemy_oso.hooks import authorized_sessionmaker, scoped_session
+from sqlalchemy_oso.session import authorized_sessionmaker, scoped_session
 
 
 class AuthorizedSQLAlchemy(SQLAlchemy):

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/flask.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/flask.py
@@ -1,0 +1,55 @@
+try:
+    from flask import _app_ctx_stack
+    from flask_sqlalchemy import SQLAlchemy, SignallingSession
+except ImportError:
+    import warnings
+    warnings.warn("Missing depenedencies for Flask. Install sqlalchemy-oso with the flask extra.")
+    raise
+
+from sqlalchemy_oso.hooks import authorized_sessionmaker, scoped_session
+
+class AuthorizedSQLAlchemy(SQLAlchemy):
+    """flask_sqlalchemy ``SQLAlchemy`` subclass that uses oso.
+
+    Creates sessions with oso authorization applied.
+    """
+    def __init__(self,
+                 get_oso,
+                 get_user,
+                 get_action,
+                 **kwargs):
+        self._get_oso = get_oso
+        self._get_user = get_user
+        self._get_action = get_action
+        super().__init__(**kwargs)
+
+    def create_session(self, options):
+        return authorized_sessionmaker(
+            get_oso=self._get_oso,
+            get_user=self._get_user,
+            get_action=self._get_action,
+            **options)
+
+    def create_scoped_session(self, options=None):
+        if options is None:
+            options = {}
+
+        scopefunc = options.pop("scopefunc", _app_ctx_stack.__ident_func__)
+        return scoped_session(
+            get_oso=self._get_oso,
+            get_user=self._get_user,
+            get_action=self._get_action,
+            scopefunc=scopefunc,
+            class_=SignallingSession,
+            db=self,
+            **options
+        )
+
+    def create_session(self, options):
+        return authorized_sessionmaker(
+            get_oso=self._get_oso,
+            get_user=self._get_user,
+            get_action=self._get_action,
+            class_=SignallingSession,
+            db=self,
+            **options)

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/flask.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/flask.py
@@ -1,3 +1,8 @@
+"""Wrappers for using ``sqlalchemy_oso`` with the flask_sqlalchemy_ library.
+
+.. _flask_sqlalchemy: https://flask-sqlalchemy.palletsprojects.com/en/2.x/
+"""
+
 try:
     from flask import _app_ctx_stack
     from flask_sqlalchemy import SQLAlchemy, SignallingSession
@@ -15,7 +20,21 @@ from sqlalchemy_oso.session import authorized_sessionmaker, scoped_session
 class AuthorizedSQLAlchemy(SQLAlchemy):
     """flask_sqlalchemy ``SQLAlchemy`` subclass that uses oso.
 
-    Creates sessions with oso authorization applied.
+    Creates sessions with oso authorization applied. See flask_sqlalchemy_ documentation
+    for more information on using flask_sqlalchemy.
+
+    :param get_oso: Callable that returns the :py:class:`oso.Oso` instance to use for authorization.
+    :param get_user: Callable that returns the user to authorize for the current request.
+    :param get_action: Callable that returns the action to authorize for the current request.
+
+    >>> from sqlalchemy_oso.flask import AuthorizedSQLAlchemy
+    >>> db = AuthorizedSQLAlchemy(
+    ...    get_oso=lambda: flask.current_app.oso,
+    ...    get_user=lambda: flask_login.current_user,
+    ...    get_action=lambda: flask.request.method
+    ... )
+
+    .. _flask_sqlalchemy: https://flask-sqlalchemy.palletsprojects.com/en/2.x/
     """
 
     def __init__(self, get_oso, get_user, get_action, **kwargs):

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/hooks.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/hooks.py
@@ -45,16 +45,9 @@ def enable_hooks(
     return enable_before_compile(target, oso, user, action)
 
 
-def enable_before_compile(
-    target,
-    oso,
-    user,
-    action
-):
+def enable_before_compile(target, oso, user, action):
     """Enable before compile hook."""
-    auth = functools.partial(
-        authorize_query, oso=oso, user=user, action=action
-    )
+    auth = functools.partial(authorize_query, oso=oso, user=user, action=action)
 
     listen(target, "before_compile", auth, retval=True)
 
@@ -111,26 +104,20 @@ def authorized_sessionmaker(get_oso, get_user, get_action, **kwargs):
     # session's identity map.
     class Sess(AuthorizedSession):
         def __init__(self, **options):
-            options.setdefault('oso', get_oso())
-            options.setdefault('user', get_user())
-            options.setdefault('action', get_action())
+            options.setdefault("oso", get_oso())
+            options.setdefault("user", get_user())
+            options.setdefault("action", get_action())
             super().__init__(**options)
+
     session = type("Session", (Sess,), {})
 
     # We call sessionmaker here because sessionmaker adds a configure
     # method to the returned session and we want to replicate that
     # functionality.
-    return sessionmaker(
-        class_=session,
-        **kwargs
-    )
+    return sessionmaker(class_=session, **kwargs)
 
 
-def scoped_session(get_oso,
-                   get_action,
-                   get_user,
-                   scopefunc=None,
-                   **kwargs):
+def scoped_session(get_oso, get_action, get_user, scopefunc=None, **kwargs):
     """Return a scoped session maker that uses the user and action as part of the scope function.
 
     Uses authorized_sessionmaker as the factory.
@@ -147,13 +134,12 @@ def scoped_session(get_oso,
 
     factory = authorized_sessionmaker(get_oso, get_action, get_user, **kwargs)
 
-    return orm.scoped_session(
-        factory,
-        scopefunc=_scopefunc)
+    return orm.scoped_session(factory, scopefunc=_scopefunc)
 
 
 class AuthorizedSessionBase(object):
     """Session that uses oso authorization for queries."""
+
     def __init__(self, oso: Oso, user, action, **options):
         """Create an authorized session using ``oso``.
 
@@ -169,10 +155,13 @@ class AuthorizedSessionBase(object):
         self._oso_user = user
         self._oso_action = action
 
-        query_cls = make_authorized_query_cls(oso, user, action,
-                                              options.pop('query_cls', None))
-        options['query_cls'] = query_cls
+        query_cls = make_authorized_query_cls(
+            oso, user, action, options.pop("query_cls", None)
+        )
+        options["query_cls"] = query_cls
 
         super().__init__(**options)
 
-class AuthorizedSession(AuthorizedSessionBase, Session): pass
+
+class AuthorizedSession(AuthorizedSessionBase, Session):
+    pass

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/hooks.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/hooks.py
@@ -52,9 +52,9 @@ def _authorize_query(query: Query) -> Query:
         # Not an authorized session.
         return None
 
-    oso = session.oso_context['oso']
-    user = session.oso_context['user']
-    action = session.oso_context['action']
+    oso = session.oso_context["oso"]
+    user = session.oso_context["user"]
+    action = session.oso_context["action"]
 
     # TODO (dhatch): This is necessary to allow ``authorize_query`` to work
     # on queries that have already been made.  If a query has a LIMIT or OFFSET
@@ -152,11 +152,8 @@ class AuthorizedSessionBase(object):
 
     @property
     def oso_context(self):
-        return {
-            'oso': self._oso,
-            'user': self._oso_user,
-            'action': self._oso_action
-        }
+        return {"oso": self._oso, "user": self._oso_user, "action": self._oso_action}
+
 
 class AuthorizedSession(AuthorizedSessionBase, Session):
     pass

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
@@ -1,11 +1,7 @@
 """SQLAlchemy session classes and factories for oso."""
-import functools
-from typing import Any, Callable
-
-from sqlalchemy.event import listen, remove
 from sqlalchemy import event
 from sqlalchemy.orm.query import Query
-from sqlalchemy.orm import aliased, sessionmaker, Session
+from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy import orm
 
 from oso import Oso

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
@@ -29,9 +29,9 @@ def _authorize_query(query: Query) -> Query:
         # Not an authorized session.
         return None
 
-    oso = session.oso_context['oso']
-    user = session.oso_context['user']
-    action = session.oso_context['action']
+    oso = session.oso_context["oso"]
+    user = session.oso_context["user"]
+    action = session.oso_context["action"]
 
     # TODO (dhatch): This is necessary to allow ``authorize_query`` to work
     # on queries that have already been made.  If a query has a LIMIT or OFFSET
@@ -134,12 +134,10 @@ class AuthorizedSessionBase(object):
 
     @property
     def oso_context(self):
-        return {
-            'oso': self._oso,
-            'user': self._oso_user,
-            'action': self._oso_action
-        }
+        return {"oso": self._oso, "user": self._oso_user, "action": self._oso_action}
+
 
 class AuthorizedSession(AuthorizedSessionBase, Session):
     """AuthorizedSession that uses oso. Queries on this session only return authorized objects."""
+
     pass

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
@@ -155,4 +155,5 @@ class AuthorizedSession(AuthorizedSessionBase, Session):
     Usually :py:func:`authorized_sessionmaker` is used instead of directly
     instantiating the session.
     """
+
     pass

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
@@ -96,7 +96,7 @@ def scoped_session(get_oso, get_user, get_action, scopefunc=None, **kwargs):
     :param scopefunc: Additional scope function to use for scoping sessions.
                       Output will be combined with the oso, action and user objects.
     :param kwargs: Additional keyword arguments to pass to
-                   authorized_sessionmaker.
+                   :py:func:`authorized_sessionmaker`.
 
     .. _scoped_session: https://docs.sqlalchemy.org/en/13/orm/contextual.html
     """

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
@@ -66,7 +66,6 @@ def authorized_sessionmaker(get_oso, get_user, get_action, class_=None, **kwargs
         class_ = Session
 
     # oso, user and action must remain unchanged for the entire session.
-    # If they change before a query runs, an error is thrown.
     # This is to prevent objects that are unauthorized from ending up in the
     # session's identity map.
     class Sess(AuthorizedSessionBase, class_):

--- a/languages/python/sqlalchemy-oso/tests/conftest.py
+++ b/languages/python/sqlalchemy-oso/tests/conftest.py
@@ -92,8 +92,12 @@ def fixture_data(session, post_fixtures):
 
 
 @pytest.fixture
-def engine():
-    engine = create_engine("sqlite:///:memory:")
+def db_uri():
+    return "sqlite:///:memory:"
+
+@pytest.fixture
+def engine(db_uri):
+    engine = create_engine(db_uri)
     ModelBase.metadata.create_all(engine)
     return engine
 

--- a/languages/python/sqlalchemy-oso/tests/conftest.py
+++ b/languages/python/sqlalchemy-oso/tests/conftest.py
@@ -95,6 +95,7 @@ def fixture_data(session, post_fixtures):
 def db_uri():
     return "sqlite:///:memory:"
 
+
 @pytest.fixture
 def engine(db_uri):
     engine = create_engine(db_uri)

--- a/languages/python/sqlalchemy-oso/tests/test_flask.py
+++ b/languages/python/sqlalchemy-oso/tests/test_flask.py
@@ -1,13 +1,13 @@
 import pytest
 
-flask = pytest.importorskip("flask")
-flask_sqlalchemy = pytest.importorskip("flask_sqlalchemy")
-
 from sqlalchemy.orm import Session
 from sqlalchemy import Column, Integer
 from sqlalchemy_oso.flask import AuthorizedSQLAlchemy
 
-from .models import *
+from .models import Post, ModelBase
+
+flask = pytest.importorskip("flask")
+flask_sqlalchemy = pytest.importorskip("flask_sqlalchemy")
 
 
 @pytest.fixture

--- a/languages/python/sqlalchemy-oso/tests/test_flask.py
+++ b/languages/python/sqlalchemy-oso/tests/test_flask.py
@@ -1,0 +1,55 @@
+import pytest
+
+flask = pytest.importorskip("flask")
+flask_sqlalchemy = pytest.importorskip("flask_sqlalchemy")
+
+from sqlalchemy.orm import Session
+from sqlalchemy_oso.flask import AuthorizedSQLAlchemy
+
+from .models import *
+
+@pytest.fixture
+def db_uri(tmp_path):
+    tempfile = tmp_path / "db.sqlite"
+    return f'sqlite:///{tempfile}'
+
+@pytest.fixture
+def flask_app(db_uri):
+    app = flask.Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = db_uri
+    return app
+
+@pytest.fixture
+def ctx(flask_app):
+    with flask_app.app_context() as ctx:
+        yield ctx
+
+@pytest.fixture
+def sqlalchemy(flask_app, oso):
+    sqlalchemy = AuthorizedSQLAlchemy(
+        get_oso=lambda: oso,
+        get_user=lambda: "user",
+        get_action=lambda: "read")
+    sqlalchemy.init_app(flask_app)
+    return sqlalchemy
+
+def test_authorized_sqlalchemy(ctx, flask_app, oso, sqlalchemy, post_fixtures):
+    oso.load_str('allow("user", "read", post: Post) if post.id = 0;')
+    sqlalchemy.init_app(flask_app)
+    engine = sqlalchemy.get_engine()
+    ModelBase.metadata.create_all(engine)
+
+    sessionmaker = sqlalchemy.create_session({})
+
+    # Create fixtures.
+    fixture_session = sessionmaker()
+    post_fixtures(fixture_session)
+    fixture_session.commit()
+    assert Session(bind=engine).query(Post).count() > 0
+
+    authorized_session = sessionmaker()
+
+    assert authorized_session.query(Post).count() == 1
+
+    with flask_app.app_context():
+        assert sqlalchemy.session.query(Post).count() == 1

--- a/languages/python/sqlalchemy-oso/tests/test_flask.py
+++ b/languages/python/sqlalchemy-oso/tests/test_flask.py
@@ -8,10 +8,12 @@ from sqlalchemy_oso.flask import AuthorizedSQLAlchemy
 
 from .models import *
 
+
 @pytest.fixture
 def db_uri(tmp_path):
     tempfile = tmp_path / "db.sqlite"
-    return f'sqlite:///{tempfile}'
+    return f"sqlite:///{tempfile}"
+
 
 @pytest.fixture
 def flask_app(db_uri):
@@ -19,19 +21,21 @@ def flask_app(db_uri):
     app.config["SQLALCHEMY_DATABASE_URI"] = db_uri
     return app
 
+
 @pytest.fixture
 def ctx(flask_app):
     with flask_app.app_context() as ctx:
         yield ctx
 
+
 @pytest.fixture
 def sqlalchemy(flask_app, oso):
     sqlalchemy = AuthorizedSQLAlchemy(
-        get_oso=lambda: oso,
-        get_user=lambda: "user",
-        get_action=lambda: "read")
+        get_oso=lambda: oso, get_user=lambda: "user", get_action=lambda: "read"
+    )
     sqlalchemy.init_app(flask_app)
     return sqlalchemy
+
 
 def test_authorized_sqlalchemy(ctx, flask_app, oso, sqlalchemy, post_fixtures):
     oso.load_str('allow("user", "read", post: Post) if post.id = 0;')

--- a/languages/python/sqlalchemy-oso/tests/test_sqlalchemy.py
+++ b/languages/python/sqlalchemy-oso/tests/test_sqlalchemy.py
@@ -3,7 +3,7 @@ import pytest
 
 from sqlalchemy.orm import aliased, sessionmaker, Query
 
-from sqlalchemy_oso.hooks import (
+from sqlalchemy_oso.session import (
     authorized_sessionmaker,
     scoped_session,
     AuthorizedSession,

--- a/languages/python/sqlalchemy-oso/tests/test_sqlalchemy.py
+++ b/languages/python/sqlalchemy-oso/tests/test_sqlalchemy.py
@@ -1,7 +1,7 @@
 """Test hooks & SQLAlchemy API integrations."""
 import pytest
 
-from sqlalchemy.orm import aliased, sessionmaker, Query
+from sqlalchemy.orm import aliased, Query
 
 from sqlalchemy_oso.session import (
     authorized_sessionmaker,
@@ -129,16 +129,12 @@ def test_hooks_alias(session, oso, fixture_data):
 
     session.configure(query_cls=LocalQueryClass)
 
-    try:
+    post_alias = aliased(Post)
 
-        post_alias = aliased(Post)
+    query = session.query(post_alias)
 
-        query = session.query(post_alias)
-
-        # Fine with hooks if you don't authorize it.
-        assert query.count() == 1
-    finally:
-        disable()
+    # Fine with hooks if you don't authorize it.
+    assert query.count() == 1
 
 
 def test_authorized_sessionmaker_relationship(engine, oso, fixture_data):

--- a/languages/python/sqlalchemy-oso/tests/test_sqlalchemy.py
+++ b/languages/python/sqlalchemy-oso/tests/test_sqlalchemy.py
@@ -4,9 +4,6 @@ import pytest
 from sqlalchemy.orm import aliased, sessionmaker, Query
 
 from sqlalchemy_oso.hooks import (
-    authorize_query,
-    enable_hooks,
-    make_authorized_query_cls,
     authorized_sessionmaker,
     scoped_session,
     AuthorizedSession,
@@ -23,11 +20,11 @@ def log_queries():
     logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
 
 
-def test_authorize_query_no_access(session, oso, fixture_data):
+def test_authorize_query_no_access(engine, oso, fixture_data):
+    session = AuthorizedSession(oso, "user", "action", bind=engine)
     query = session.query(Post)
 
-    authorized = authorize_query(query, oso, "user", "action")
-    assert authorized.count() == 0
+    assert query.count() == 0
 
 
 @pytest.mark.parametrize(
@@ -37,7 +34,7 @@ def test_authorize_query_no_access(session, oso, fixture_data):
         lambda session: session.query(Post.contents, Post.id),
     ],
 )
-def test_authorize_query_basic(session, oso, fixture_data, query):
+def test_authorize_query_basic(engine, oso, fixture_data, query):
     # TODO: copied from test_authorize_model_basic
     oso.load_str('allow("user", "read", post: Post) if post.access_level = "public";')
     oso.load_str('allow("user", "write", post: Post) if post.access_level = "private";')
@@ -48,32 +45,36 @@ def test_authorize_query_basic(session, oso, fixture_data, query):
         "post.needs_moderation = true;"
     )
 
-    query = query(session)
-    authorized = authorize_query(query, oso, "user", "read")
+    session = AuthorizedSession(oso, "user", "read", bind=engine)
+    authorized = query(session)
 
     assert authorized.count() == 5
     assert authorized.all()[0].contents == "foo public post"
     assert authorized.all()[0].id == 0
 
-    posts = authorize_query(query, oso, "user", "write")
+    session = AuthorizedSession(oso, "user", "write", bind=engine)
+    posts = query(session)
 
     assert posts.count() == 4
     assert posts.all()[0].contents == "foo private post"
     assert posts.all()[1].contents == "foo private post 2"
 
-    posts = authorize_query(query, oso, "admin", "read")
+    session = AuthorizedSession(oso, "admin", "read", bind=engine)
+    posts = query(session)
     assert posts.count() == 9
 
-    posts = authorize_query(query, oso, "moderator", "read")
+    session = AuthorizedSession(oso, "moderator", "read", bind=engine)
+    posts = query(session)
     print_query(posts)
     assert posts.all()[0].contents == "private for moderation"
     assert posts.all()[1].contents == "public for moderation"
 
-    posts = authorize_query(query, oso, "guest", "read")
+    session = AuthorizedSession(oso, "guest", "read", bind=engine)
+    posts = query(session)
     assert posts.count() == 0
 
 
-def test_authorize_query_multiple_types(session, oso, fixture_data):
+def test_authorize_query_multiple_types(engine, oso, fixture_data):
     """Test a query involving multiple models."""
     oso.load_str('allow("user", "read", post: Post) if post.id = 1;')
     oso.load_str('allow("user", "read", user: User) if user.id = 0;')
@@ -81,8 +82,8 @@ def test_authorize_query_multiple_types(session, oso, fixture_data):
     oso.load_str('allow("all_posts", "read", _: Post);')
 
     # Query two models. Only return authorized objects from each (no join).
-    query = session.query(Post, User)
-    authorized = authorize_query(query, oso, "user", "read")
+    session = AuthorizedSession(oso, "user", "read", bind=engine)
+    authorized = session.query(Post, User)
     print_query(authorized)
     assert authorized.count() == 2
     assert authorized[0][0].id == 1
@@ -91,16 +92,14 @@ def test_authorize_query_multiple_types(session, oso, fixture_data):
 
     # Query two models, with a join condition. Only return authorized objects that meet the join
     # condition.
-    query = session.query(Post, User.username).join(User)
-    authorized = authorize_query(query, oso, "user", "read")
+    authorized = session.query(Post, User.username).join(User)
     print_query(authorized)
     assert authorized.count() == 1
     assert authorized[0][0].id == 1
     assert authorized[0][1] == "foo"
 
     # Join, but only return fields from one model.
-    query = session.query(Post).join(User)
-    authorized = authorize_query(query, oso, "user", "read")
+    authorized = session.query(Post).join(User)
 
     # This one is odd... we don't return any fields from the User model,
     # so no authorization is applied for users.
@@ -112,24 +111,12 @@ def test_authorize_query_multiple_types(session, oso, fixture_data):
     # are returned.
     # Could this leak data somehow? Maybe if users are allowed to filter arbitrary
     # values and see a count, but not retrieve the objects?
-    query = session.query(Post).join(User).filter(User.username == "admin_user")
-    authorized = authorize_query(query, oso, "all_posts", "read")
+    session = AuthorizedSession(oso, "all_posts", "read", bind=engine)
+    authorized = session.query(Post).join(User).filter(User.username == "admin_user")
     print_query(authorized)
     assert authorized.count() == 2
 
     # TODO (dhatch): What happens for aggregations?
-
-
-@pytest.mark.xfail(reason="Subqueries are an escape hatch with authorize_query API.")
-def test_authorize_query_subquery(session, oso, fixture_data):
-    oso.load_str('allow("user", "read", post: Post) if post.id = 1;')
-
-    subquery = session.query(Post).subquery()
-    query = session.query(subquery)
-    authorized = authorize_query(query, oso, "user", "read")
-
-    # Subquery blows it up if you don't authorize it!
-    assert authorized.count() == 1
 
 
 # TODO convert not to use hooks, internal interface.
@@ -143,7 +130,6 @@ def test_hooks_alias(session, oso, fixture_data):
     session.configure(query_cls=LocalQueryClass)
 
     try:
-        disable = enable_hooks(LocalQueryClass, oso, "user", "read")
 
         post_alias = aliased(Post)
 
@@ -153,35 +139,6 @@ def test_hooks_alias(session, oso, fixture_data):
         assert query.count() == 1
     finally:
         disable()
-
-
-def test_make_authorize_query_cls_relationship(engine, oso, fixture_data):
-    oso.load_str('allow("user", "read", post: Post) if post.id = 1;')
-    # Post with creator id = 1
-    oso.load_str('allow("user", "read", post: Post) if post.id = 7;')
-    oso.load_str('allow("user", "read", user: User) if user.id = 0;')
-
-    Session = sessionmaker(
-        query_cls=make_authorized_query_cls(oso, "user", "read"),
-        bind=engine,
-        enable_baked_queries=False,
-    )
-
-    session = Session()
-
-    posts = session.query(Post)
-    assert posts.count() == 2
-
-    users = session.query(User)
-    assert users.count() == 1
-
-    post_1 = posts.get(1)
-    # Authorized created by field.
-    assert post_1.created_by == users.get(0)
-
-    post_7 = posts.get(7)
-    # created_by isn't actually none, but we can't see it
-    assert post_7.created_by is None
 
 
 def test_authorized_sessionmaker_relationship(engine, oso, fixture_data):

--- a/languages/python/sqlalchemy-oso/tests/test_sqlalchemy.py
+++ b/languages/python/sqlalchemy-oso/tests/test_sqlalchemy.py
@@ -285,3 +285,14 @@ def test_null_with_partial(engine, oso):
         + "posts.needs_moderation AS posts_needs_moderation \nFROM posts \nWHERE posts.contents IS NULL"
     )
     assert posts.count() == 0
+
+
+def test_regular_session(engine, oso, fixture_data):
+    """Test that a regular session doesn't apply authorization."""
+    from sqlalchemy.orm import Session
+
+    session = Session(bind=engine)
+    posts = session.query(Post)
+
+    # No posts would be returned if authorization was applied.
+    assert posts.count() == 9


### PR DESCRIPTION
- The oso object, user and action to authorize are now attached to sessions.  There is no way for the user, action or oso object to change for an individual session. This means the identity map (internal SQLAlchemy cache) will only contain objects from one authorization context, and will never contain unauthorized objects (a risk of the prior approach). The `AuthorizedSession` class handles this, and the changes to `make_authorized_query_cls` to accept `oso`, `action` and `user` instead of `get_oso`, `get_action`, and `get_user`.
- We have a new `scoped_session` factory that behaves like the SQLAlchemy [scoped session](https://docs.sqlalchemy.org/en/13/orm/contextual.html#unitofwork-contextual).  Test added [here](https://github.com/osohq/oso/pull/569/files#diff-016043b481920e3042a3cb543b568a4687d9b744532117a637893dfcdb8e3888R217) showing how that works. This will be useful for the Flask integration.

PR checklist:

<!-- Delete if no entry is required. -->
- [x] Added changelog entry.
- [x] Update documentation
- [x] Make members private (like `enable_hooks`)
- [x] Test for query property.
- [x] Add optional `flask_sqlalchemy.SQLAlchemy` subclass (this could be a separate PR)