### PR TITLE
Add readline back in.

### DIFF
--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -41,4 +41,4 @@ Other bugs & improvements
   SQLAlchemy adapter. Previously these operations would result in an error.
 - The SQLAlchemy list filtering adapter now supports all comparisons. Previously
   comparisons other than ``==`` or ``=`` would cause an error.
-- Fixed bug where checking if a characters is in a string would fail incorrectly.
+- Fixed bug where checking if a character is in a string would fail incorrectly.

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -6,6 +6,13 @@ from pathlib import Path
 import sys
 from typing import Dict
 
+try:
+    # importing readline on compatible platforms
+    # changes how `input` works for the REPL
+    import readline  # noqa: F401
+except ImportError:
+    pass
+
 from .exceptions import (
     PolarRuntimeError,
     InlineQueryFailedError,


### PR DESCRIPTION
I was overeager in addressing lint warnings. The readline import has side effects and is indeed "used"