### PR TITLE
Use django _meta to resolve related fields.

### DIFF
--- a/languages/python/django-oso/django_oso/partial.py
+++ b/languages/python/django-oso/django_oso/partial.py
@@ -77,7 +77,7 @@ def isa_expr(expr: Expression, model: Model, **kwargs):
     assert expr.operator == "Isa"
     (left, right) = expr.args
     for attr in dot_path(left):
-        model = getattr(model, attr).field.related_model
+        model = model._meta.get_field(attr).related_model
     constraint_type = apps.get_model(django_model_name(right.tag))
     assert not right.fields, "Unexpected fields in matches expression"
     return TRUE_FILTER if issubclass(model, constraint_type) else FALSE_FILTER

--- a/languages/python/django-oso/tests/test_app2/models.py
+++ b/languages/python/django-oso/tests/test_app2/models.py
@@ -7,7 +7,7 @@ class User(models.Model):
     username = models.CharField(max_length=255)
     is_moderator = models.BooleanField(default=False)
     is_banned = models.BooleanField(default=False)
-    posts = models.ManyToManyField("Post")
+    posts = models.ManyToManyField("Post", related_name="users")
 
     class Meta:
         app_label = "test_app2"

--- a/languages/python/django-oso/tests/test_post_relationship.py
+++ b/languages/python/django-oso/tests/test_post_relationship.py
@@ -556,6 +556,36 @@ def test_in_with_constraints_but_no_matching_objects(tag_nested_many_many_fixtur
     assert len(posts) == 0
 
 
+@pytest.mark.django_db
+def test_reverse_many_relationship(tag_nested_many_many_fixtures):
+    """Test an authorization rule over a reverse relationship"""
+    Oso.load_str(
+        """
+        allow(actor, _, post: test_app2::Post) if
+            post.users matches test_app2::User and
+            actor in post.users;
+        """
+    )
+
+    user = User.objects.get(username="user")
+    authorize_filter = authorize_model(None, Post, actor=user, action="read")
+    assert (
+        str(authorize_filter)
+        == "(AND: (NOT (AND: ('pk__in', []))), ('users', <User: User object (1)>))"
+    )
+    posts = Post.objects.filter(authorize_filter)
+    assert (
+        str(posts.query)
+        == 'SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."access_level",'
+        + ' "test_app2_post"."created_by_id", "test_app2_post"."needs_moderation"'
+        + ' FROM "test_app2_post"'
+        + ' INNER JOIN "test_app2_user_posts"'
+        + ' ON ("test_app2_post"."id" = "test_app2_user_posts"."post_id")'
+        + ' WHERE "test_app2_user_posts"."user_id" = 1'
+    )
+    assert len(posts) == 4
+
+
 # todo test_nested_relationship_single_many
 # todo test_nested_relationship_single_single
 # todo test_nested_relationship_single_single_single ... etc


### PR DESCRIPTION
The previous behaviour didn't work when going in the _other_ direction on a m2m with a related name.

E.g.

```
class Post(models.Model):
       tags = models.ManyToManyField(Tag, related_name="posts")

class Tag(models.Model):
   pass
```

Then `getattr(Tag, "posts")` returns the `tags` field on `Post, so `field.related_model` returns back `Tag` instead of `Post`.

Using the `_meta` api seems like the correct way to do this: https://docs.djangoproject.com/en/3.1/ref/models/meta/

I tried to write a test for this, but it kinda relies on writing something like:

```
post in tag.posts and
post matches test_app2::Post
```

which doesn't work right (this is probably a separate bug).
