### PR TITLE
mypy 0.800 compatibility

### DIFF
--- a/languages/python/oso/setup.cfg
+++ b/languages/python/oso/setup.cfg
@@ -3,6 +3,8 @@ xfail_strict=true
 filterwarnings =
     ignore::DeprecationWarning
 
+[mypy]
+
 [mypy-cffi.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Fixes the Python type checks under `mypy` version 0.800, which now ignores `setup.cfg` if it does not have a `[mypy]` section. See https://github.com/python/mypy/issues/9940.
