### PR TITLE
golang windows support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,19 @@ jobs:
         with:
           name: oso_static_library
           path: polar-c-api/polar.h
+      - if: runner.os == 'Windows'
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+          cargo build --target x86_64-pc-windows-gnu --release
+          ls target/x86_64-pc-windows-gnu
+          ls target/x86_64-pc-windows-gnu/release
+      - if: runner.os == 'Windows'
+        run: mv target/x86_64-pc-windows-gnu/release/libpolar.a target/x86_64-pc-windows-gnu/release/libpolar-${{runner.os}}.a
+      - uses: actions/upload-artifact@v2
+        if: runner.os == 'Windows'
+        with:
+          name: oso_static_library
+          path: target/x86_64-pc-windows-gnu/release/libpolar-${{runner.os}}.a
 
   build_go:
     name: Build go.
@@ -137,6 +150,8 @@ jobs:
           cp -r oso_static_library/libpolar-Linux.a languages/go/internal/ffi/native/linux/libpolar.a
           mkdir -p languages/go/native/macos
           cp -r oso_static_library/libpolar-macOS.a languages/go/internal/ffi/native/macos/libpolar.a
+          mkdir -p languages/go/native/windows
+          cp -r oso_static_library/libpolar-Windows.a languages/go/internal/ffi/native/windows/libpolar.a
           rm languages/go/Makefile
       - name: Copy license.
         run: cp LICENSE languages/go/LICENSE
@@ -373,7 +388,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,8 +115,6 @@ jobs:
         run: |
           rustup target add x86_64-pc-windows-gnu
           cargo build --target x86_64-pc-windows-gnu --release
-          ls target/x86_64-pc-windows-gnu
-          ls target/x86_64-pc-windows-gnu/release
       - if: runner.os == 'Windows'
         run: mv target/x86_64-pc-windows-gnu/release/libpolar.a target/x86_64-pc-windows-gnu/release/libpolar-${{runner.os}}.a
       - uses: actions/upload-artifact@v2

--- a/languages/go/internal/ffi/ffi.go
+++ b/languages/go/internal/ffi/ffi.go
@@ -6,6 +6,7 @@ package ffi
 // #include "native/polar.h"
 // #cgo linux,amd64 LDFLAGS: ${SRCDIR}/native/linux/libpolar.a -ldl -lm
 // #cgo darwin,amd64 LDFLAGS: ${SRCDIR}/native/macos/libpolar.a -ldl -lm
+// #cgo windows,amd64 LDFLAGS: ${SRCDIR}/native/windows/libpolar.a -lm -lws2_32 -luserenv
 import "C"
 
 import (
@@ -193,7 +194,7 @@ func (q QueryFfi) CallResult(callID uint64, term *types.Term) error {
 		}
 	}
 
-	result := C.polar_call_result(q.ptr, C.__uint64_t(callID), s)
+	result := C.polar_call_result(q.ptr, C.uint64_t(callID), s)
 	if result == 0 {
 		return getError()
 	}
@@ -207,7 +208,7 @@ func (q QueryFfi) QuestionResult(callID uint64, answer bool) error {
 	} else {
 		intAnswer = 0
 	}
-	result := C.polar_question_result(q.ptr, C.__uint64_t(callID), C.int(intAnswer))
+	result := C.polar_question_result(q.ptr, C.uint64_t(callID), C.int(intAnswer))
 	if result == 0 {
 		return getError()
 	}

--- a/new-docs/content/any/project/changelogs/2021-02-17.md
+++ b/new-docs/content/any/project/changelogs/2021-02-17.md
@@ -1,0 +1,12 @@
+---
+title: Release 2021-02-17
+menuTitle: 2021-02-17
+any: true
+description: Changelog for Release 2021-02-17 (oso 0.0.0) containing new features, bug fixes, and more.
+---
+
+## `oso`
+
+### `go-oso`
+
+The `go-oso` library now supports windows.

--- a/new-docs/content/go/reference/_index.md
+++ b/new-docs/content/go/reference/_index.md
@@ -25,6 +25,9 @@ library documentation.
 **Requirements**
 
 * Go version 1.12 or higher
-* Supported platforms:
+* Supported platforms (x64 only):
   * Linux
   * OS X
+  * Windows
+
+Oso uses cgo to embed our vm and on windows cgo depends on a [[MinGW toolchain]](https://jmeubank.github.io/tdm-gcc/).


### PR DESCRIPTION
cgo on windows is based on a MinGW toolchain, not an msvc one.

This adds a new mingw build of the static library that we can link to with cgo. Also cleans up some types and links the libs we need to link to make this work on all three platforms.

This also means that using oso on windows requires a MinGW toolchain (which I guess you wouldn't need if you didn't use any libraries that use cgo). I used [tdm-gcc](https://jmeubank.github.io/tdm-gcc/).