### PR TITLE
speed up test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -322,7 +322,10 @@ jobs:
       - name: Build python lib
         run: make python-build
       - name: Build js lib
-        run: make -C languages/js build
+        run: |
+          rustup target add wasm32-unknown-unknown
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          make -C languages/js build
       - name: Install yard (for doc build)
         run: gem install yard
       - name: Install spelling check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,12 +184,12 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-    - name: Install Ruby + gems
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-        ruby-version: 2.4
-        working-directory: "languages/ruby"
+      - name: Install Ruby + gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 2.4
+          working-directory: "languages/ruby"
       - name: Test ruby
         run: make ruby-test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,113 +92,112 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install Rust stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
-    - name: Build Polar
-      run: cargo build -p polar-c-api
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Build Polar
+        run: cargo build -p polar-c-api
 
   python_test:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install Rust stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
-    - name: Install Python 3.6
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Install Python 3.6
         uses: actions/setup-python@v1
         with:
           python-version: "3.6"
-    - name: Test python
+      - name: Test python
         run: make python-test
-
 # go-test rust-test python-test ruby-test java-test python-flask-test \
 # python-django-test python-sqlalchemy-test wasm-test js-test
 
-  # test:
-  #   runs-on: ubuntu-latest
-    
-  #     - name: Install Python 3.6
-  #       uses: actions/setup-python@v1
-  #       with:
-  #         python-version: "3.6"
-  #     - name: Install Ruby + gems
-  #       uses: ruby/setup-ruby@v1
-  #       with:
-  #         bundler-cache: true
-  #         ruby-version: 2.4
-  #         working-directory: "languages/ruby"
-  #     - name: Use Node.js 10.14.2
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 10.14.2
-  #     - name: Add WebAssembly target
-  #       run: rustup target add wasm32-unknown-unknown
-  #     - name: Install wasm-pack
-  #       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-  #     - name: Install Java
-  #       uses: actions/setup-java@v1
-  #       with:
-  #         java-version: "11"
+# test:
+#   runs-on: ubuntu-latest
 
-  #     ## Run tests
-  #     - name: Test everything
-  #       run: make test
-  #       env:
-  #         MVN_FLAGS: "-q"
+#     - name: Install Python 3.6
+#       uses: actions/setup-python@v1
+#       with:
+#         python-version: "3.6"
+#     - name: Install Ruby + gems
+#       uses: ruby/setup-ruby@v1
+#       with:
+#         bundler-cache: true
+#         ruby-version: 2.4
+#         working-directory: "languages/ruby"
+#     - name: Use Node.js 10.14.2
+#       uses: actions/setup-node@v1
+#       with:
+#         node-version: 10.14.2
+#     - name: Add WebAssembly target
+#       run: rustup target add wasm32-unknown-unknown
+#     - name: Install wasm-pack
+#       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+#     - name: Install Java
+#       uses: actions/setup-java@v1
+#       with:
+#         java-version: "11"
 
-  #     # Python lint requires python build.
-  #     - name: Lint Python code
-  #       run: make -C languages/python lint
+#     ## Run tests
+#     - name: Test everything
+#       run: make test
+#       env:
+#         MVN_FLAGS: "-q"
 
-  #     ## Test + check docs
-  #     ## (easier to do here once all above deps are installed)
-  #     - name: Install yard (for doc build)
-  #       run: gem install yard
-  #     - name: Install spelling check
-  #       run: sudo apt-get install -y libenchant-dev
-  #     - name: Spelling
-  #       run: SPHINXOPTS="-W" make -C docs spelling
-  #     - name: Doc test
-  #       run: make -C docs test
-  #     - name: Docs build
-  #       run: SPHINXOPTS="-W" make -C docs build
+#     # Python lint requires python build.
+#     - name: Lint Python code
+#       run: make -C languages/python lint
 
-  #     ## Publish docs
-  #     ## Also easier to do here with above deps installed
-  #     - name: s3 preview publish
-  #       if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
-  #       run: aws s3 sync --delete docs/_build/html s3://docs-preview.oso.dev
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
-  #     - name: cloudfront invalidate docs preview
-  #       if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
-  #       run: aws cloudfront create-invalidation --distribution-id E2KU2V8C9KJNU7 --paths "/*"
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
+#     ## Test + check docs
+#     ## (easier to do here once all above deps are installed)
+#     - name: Install yard (for doc build)
+#       run: gem install yard
+#     - name: Install spelling check
+#       run: sudo apt-get install -y libenchant-dev
+#     - name: Spelling
+#       run: SPHINXOPTS="-W" make -C docs spelling
+#     - name: Doc test
+#       run: make -C docs test
+#     - name: Docs build
+#       run: SPHINXOPTS="-W" make -C docs build
+
+#     ## Publish docs
+#     ## Also easier to do here with above deps installed
+#     - name: s3 preview publish
+#       if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
+#       run: aws s3 sync --delete docs/_build/html s3://docs-preview.oso.dev
+#       env:
+#         AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
+#         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
+#     - name: cloudfront invalidate docs preview
+#       if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
+#       run: aws cloudfront create-invalidation --distribution-id E2KU2V8C9KJNU7 --paths "/*"
+#       env:
+#         AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
+#         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -321,6 +321,8 @@ jobs:
           java-version: "11"
       - name: Build python lib
         run: make python-build
+      - name: Build js lib
+        run: make -C languages/js build
       - name: Install yard (for doc build)
         run: gem install yard
       - name: Install spelling check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -321,6 +321,8 @@ jobs:
           java-version: "11"
       - name: Build python lib
         run: make python-build
+      - name: Python test deps
+        run: make -C languages/python/oso test-requirements
       - name: Build js lib
         run: |
           rustup target add wasm32-unknown-unknown

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -319,6 +319,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: "11"
+      - name: Build python lib
+        run: make python-build
       - name: Install yard (for doc build)
         run: gem install yard
       - name: Install spelling check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,8 @@ jobs:
         run: make python-django-test
       - name: Test sqlalchemy
         run: make python-sqlalchemy-test
+      - name: Lint Python code
+        run: make -C languages/python lint
 
   ruby_test:
     runs-on: ubuntu-latest
@@ -272,68 +274,72 @@ jobs:
           components: rustfmt, clippy
       - name: Test go
         run: make go-test
-# python-flask-test python-django-test python-sqlalchemy-test
 
-# test:
-#   runs-on: ubuntu-latest
-
-#     - name: Install Python 3.6
-#       uses: actions/setup-python@v1
-#       with:
-#         python-version: "3.6"
-#     - name: Install Ruby + gems
-#       uses: ruby/setup-ruby@v1
-#       with:
-#         bundler-cache: true
-#         ruby-version: 2.4
-#         working-directory: "languages/ruby"
-#     - name: Use Node.js 10.14.2
-#       uses: actions/setup-node@v1
-#       with:
-#         node-version: 10.14.2
-#     - name: Add WebAssembly target
-#       run: rustup target add wasm32-unknown-unknown
-#     - name: Install wasm-pack
-#       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-#     - name: Install Java
-#       uses: actions/setup-java@v1
-#       with:
-#         java-version: "11"
-
-#     ## Run tests
-#     - name: Test everything
-#       run: make test
-#       env:
-#         MVN_FLAGS: "-q"
-
-#     # Python lint requires python build.
-#     - name: Lint Python code
-#       run: make -C languages/python lint
-
-#     ## Test + check docs
-#     ## (easier to do here once all above deps are installed)
-#     - name: Install yard (for doc build)
-#       run: gem install yard
-#     - name: Install spelling check
-#       run: sudo apt-get install -y libenchant-dev
-#     - name: Spelling
-#       run: SPHINXOPTS="-W" make -C docs spelling
-#     - name: Doc test
-#       run: make -C docs test
-#     - name: Docs build
-#       run: SPHINXOPTS="-W" make -C docs build
-
-#     ## Publish docs
-#     ## Also easier to do here with above deps installed
-#     - name: s3 preview publish
-#       if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
-#       run: aws s3 sync --delete docs/_build/html s3://docs-preview.oso.dev
-#       env:
-#         AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
-#         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
-#     - name: cloudfront invalidate docs preview
-#       if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
-#       run: aws cloudfront create-invalidation --distribution-id E2KU2V8C9KJNU7 --paths "/*"
-#       env:
-#         AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
-#         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
+  docs_test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Install Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.6"
+      - name: Install Ruby + gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 2.4
+          working-directory: "languages/ruby"
+      - name: Use Node.js 10.14.2
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.14.2
+      - name: Install Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+      - name: Install yard (for doc build)
+        run: gem install yard
+      - name: Install spelling check
+        run: sudo apt-get install -y libenchant-dev
+      - name: Spelling
+        run: SPHINXOPTS="-W" make -C docs spelling
+      - name: Doc test
+        run: make -C docs test
+      - name: Docs build
+        run: SPHINXOPTS="-W" make -C docs build
+      ## Publish docs
+      ## Also easier to do here with above deps installed
+      - name: s3 preview publish
+        if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
+        run: aws s3 sync --delete docs/_build/html s3://docs-preview.oso.dev
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
+      - name: cloudfront invalidate docs preview
+        if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
+        run: aws cloudfront create-invalidation --distribution-id E2KU2V8C9KJNU7 --paths "/*"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,29 @@ jobs:
       - name: Build Polar
         run: cargo build -p polar-c-api
 
+  # tests all core polar code and the rust language integration
+  rust_test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Test rust
+        run: make rust-test
+
   python_test:
     runs-on: ubuntu-latest
     needs: [build]
@@ -135,8 +158,124 @@ jobs:
           python-version: "3.6"
       - name: Test python
         run: make python-test
-# go-test rust-test python-test ruby-test java-test python-flask-test \
-# python-django-test python-sqlalchemy-test wasm-test js-test
+      - name: Test flask
+        run: make python-flask-test
+      - name: Test django
+        run: make python-django-test
+      - name: Test sqlalchemy
+        run: make python-sqlalchemy-test
+
+  ruby_test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+    - name: Install Ruby + gems
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: 2.4
+        working-directory: "languages/ruby"
+      - name: Test ruby
+        run: make ruby-test
+
+  java_test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+    - name: Install Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: "11"
+      - name: Test java
+        run: make java-test
+        env:
+          MVN_FLAGS: "-q"
+
+  js_test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Use Node.js 10.14.2
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.14.2
+      - name: Add WebAssembly target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Test js
+        run: make js-test
+
+  go_test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Test go
+        run: make go-test
+  
+
+
+# python-flask-test python-django-test python-sqlalchemy-test
 
 # test:
 #   runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,10 +212,10 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-    - name: Install Java
-      uses: actions/setup-java@v1
-      with:
-        java-version: "11"
+      - name: Install Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11"
       - name: Test java
         run: make java-test
         env:
@@ -272,9 +272,6 @@ jobs:
           components: rustfmt, clippy
       - name: Test go
         run: make go-test
-  
-
-
 # python-flask-test python-django-test python-sqlalchemy-test
 
 # test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,83 +89,116 @@ jobs:
           skipCommit: true
           args: "--dry-run --set-exit-if-changed"
 
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install Rust stable toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+    - name: Build Polar
+      run: cargo build -p polar-c-api
 
-      ## Install everything
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      - name: Install Python 3.6
+  python_test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install Rust stable toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+    - name: Install Python 3.6
         uses: actions/setup-python@v1
         with:
           python-version: "3.6"
-      - name: Install Ruby + gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          ruby-version: 2.4
-          working-directory: "languages/ruby"
-      - name: Use Node.js 10.14.2
-        uses: actions/setup-node@v1
-        with:
-          node-version: 10.14.2
-      - name: Add WebAssembly target
-        run: rustup target add wasm32-unknown-unknown
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Install Java
-        uses: actions/setup-java@v1
-        with:
-          java-version: "11"
+    - name: Test python
+        run: make python-test
 
-      ## Run tests
-      - name: Test everything
-        run: make test
-        env:
-          MVN_FLAGS: "-q"
+# go-test rust-test python-test ruby-test java-test python-flask-test \
+# python-django-test python-sqlalchemy-test wasm-test js-test
 
-      # Python lint requires python build.
-      - name: Lint Python code
-        run: make -C languages/python lint
+  # test:
+  #   runs-on: ubuntu-latest
+    
+  #     - name: Install Python 3.6
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         python-version: "3.6"
+  #     - name: Install Ruby + gems
+  #       uses: ruby/setup-ruby@v1
+  #       with:
+  #         bundler-cache: true
+  #         ruby-version: 2.4
+  #         working-directory: "languages/ruby"
+  #     - name: Use Node.js 10.14.2
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 10.14.2
+  #     - name: Add WebAssembly target
+  #       run: rustup target add wasm32-unknown-unknown
+  #     - name: Install wasm-pack
+  #       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+  #     - name: Install Java
+  #       uses: actions/setup-java@v1
+  #       with:
+  #         java-version: "11"
 
-      ## Test + check docs
-      ## (easier to do here once all above deps are installed)
-      - name: Install yard (for doc build)
-        run: gem install yard
-      - name: Install spelling check
-        run: sudo apt-get install -y libenchant-dev
-      - name: Spelling
-        run: SPHINXOPTS="-W" make -C docs spelling
-      - name: Doc test
-        run: make -C docs test
-      - name: Docs build
-        run: SPHINXOPTS="-W" make -C docs build
+  #     ## Run tests
+  #     - name: Test everything
+  #       run: make test
+  #       env:
+  #         MVN_FLAGS: "-q"
 
-      ## Publish docs
-      ## Also easier to do here with above deps installed
-      - name: s3 preview publish
-        if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
-        run: aws s3 sync --delete docs/_build/html s3://docs-preview.oso.dev
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
-      - name: cloudfront invalidate docs preview
-        if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
-        run: aws cloudfront create-invalidation --distribution-id E2KU2V8C9KJNU7 --paths "/*"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
+  #     # Python lint requires python build.
+  #     - name: Lint Python code
+  #       run: make -C languages/python lint
+
+  #     ## Test + check docs
+  #     ## (easier to do here once all above deps are installed)
+  #     - name: Install yard (for doc build)
+  #       run: gem install yard
+  #     - name: Install spelling check
+  #       run: sudo apt-get install -y libenchant-dev
+  #     - name: Spelling
+  #       run: SPHINXOPTS="-W" make -C docs spelling
+  #     - name: Doc test
+  #       run: make -C docs test
+  #     - name: Docs build
+  #       run: SPHINXOPTS="-W" make -C docs build
+
+  #     ## Publish docs
+  #     ## Also easier to do here with above deps installed
+  #     - name: s3 preview publish
+  #       if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
+  #       run: aws s3 sync --delete docs/_build/html s3://docs-preview.oso.dev
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}
+  #     - name: cloudfront invalidate docs preview
+  #       if: ${{ github.event_name == 'push' && github.repository == 'osohq/oso' && github.ref == 'refs/heads/main' }}
+  #       run: aws cloudfront create-invalidation --distribution-id E2KU2V8C9KJNU7 --paths "/*"
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET }}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 	python-flask-test python-django-test python-sqlalchemy-test ruby-test \
 	java-test docs-test fmt clippy lint wasm-build wasm-test js-test
 
+#! If you add another dependency to this you must also add it to the Test
+#! github action or it won't run in CI. All jobs run in parallel on CI and
+#! `make test` is just a local convienence.
 test: go-test rust-test python-test ruby-test java-test python-flask-test \
 	python-django-test python-sqlalchemy-test wasm-test js-test
 


### PR DESCRIPTION
Runs all the steps of the test job in parallel.
They all depend on an initial build step that builds the rust code so it'll be in the cache. That way, all the individual language tests builds will pull the already compiled lib from the cache. Makes every individual step just as fast as doing them in series but lets us parallelize them.

Once we can pull the old docs build out of here it'll be even faster as that's the longest step.

Workflow run times vary throughout the day but to me this seems to take the test job from ~15 minutes to ~8 minutes and should be ~4 or ~5 minutes when we drop the old docs jobs.