### PR TITLE
rm before mv on windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,9 @@ jobs:
           rustup target add x86_64-pc-windows-gnu
           cargo build --target x86_64-pc-windows-gnu --release
       - name: Rename static lib
-        run: mv target/x86_64-pc-windows-gnu/release/libpolar.a target/x86_64-pc-windows-gnu/release/libpolar-${{runner.os}}.a
+        run: |
+          rm target/x86_64-pc-windows-gnu/release/libpolar-${{runner.os}}.a
+          mv target/x86_64-pc-windows-gnu/release/libpolar.a target/x86_64-pc-windows-gnu/release/libpolar-${{runner.os}}.a
       - uses: actions/upload-artifact@v2
         with:
           name: oso_library


### PR DESCRIPTION
Apparently if you rename a file on windows (powershell) to a file that already exists it errors instead of just overwrites it. This means the release job breaks if the old builds are still cached (due to no new rust changes being merged in).
This fixes that by deleting the old file before renaming.