### PR TITLE
Inverter operates over BindingManager, instead of internal binding stack from VM.

### DIFF
--- a/languages/go/internal/ffi/native/polar.h
+++ b/languages/go/internal/ffi/native/polar.h
@@ -59,6 +59,8 @@ const char *polar_next_query_message(polar_Query *query_ptr);
 
 const char *polar_query_source_info(polar_Query *query_ptr);
 
+int32_t polar_bind(polar_Query *query_ptr, const char *name, const char *value);
+
 uint64_t polar_get_external_id(polar_Polar *polar_ptr);
 
 /**

--- a/polar-c-api/src/lib.rs
+++ b/polar-c-api/src/lib.rs
@@ -377,8 +377,13 @@ pub extern "C" fn polar_bind(
         let value = serde_json::from_str(&value);
         match value {
             Ok(value) => {
-                query.bind(terms::Symbol::new(name.as_ref()), value);
-                POLAR_SUCCESS
+                match query.bind(terms::Symbol::new(name.as_ref()), value) {
+                    Ok(_) => POLAR_SUCCESS,
+                    Err(e) => {
+                        set_error(e);
+                        POLAR_FAILURE
+                    }
+                }
             }
             Err(e) => {
                 set_error(error::RuntimeError::Serialization { msg: e.to_string() }.into());

--- a/polar-c-api/src/lib.rs
+++ b/polar-c-api/src/lib.rs
@@ -376,15 +376,13 @@ pub extern "C" fn polar_bind(
         let value = unsafe { ffi_string!(value) };
         let value = serde_json::from_str(&value);
         match value {
-            Ok(value) => {
-                match query.bind(terms::Symbol::new(name.as_ref()), value) {
-                    Ok(_) => POLAR_SUCCESS,
-                    Err(e) => {
-                        set_error(e);
-                        POLAR_FAILURE
-                    }
+            Ok(value) => match query.bind(terms::Symbol::new(name.as_ref()), value) {
+                Ok(_) => POLAR_SUCCESS,
+                Err(e) => {
+                    set_error(e);
+                    POLAR_FAILURE
                 }
-            }
+            },
             Err(e) => {
                 set_error(error::RuntimeError::Serialization { msg: e.to_string() }.into());
                 POLAR_FAILURE

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -377,106 +377,6 @@ impl BindingManager {
         self.constrain(&op)
     }
 
-    /// Add `term` as a constraint.
-    //pub fn add_constraint(&mut self, term: &Term) -> PolarResult<()> {
-        //self.do_followers(|follower| follower.add_constraint(term))?;
-
-        //let Operation { operator: op, args } = term.value().as_expression().unwrap();
-        //assert!(
-            // !matches!(*op, Operator::And | Operator::Or),
-            // "Expected a bare constraint."
-        //);
-        //assert!(args.len() >= 2);
-
-        //let (left, right) = (&args[0], &args[1]);
-        //match (
-            //extract_variable(left.value()),
-            //extract_variable(right.value()),
-        //) {
-            //(Value::Variable(left_name), Value::Variable(right_name)) => {
-                //match (
-                    //self.variable_state(left_name),
-                    //self.variable_state(right_name),
-                //) {
-                    //(VariableState::Unbound, VariableState::Unbound) => {
-                        //self.constrain(&op!(And, term.clone()))?;
-                    //}
-                    //(VariableState::Cycle(left_cycle), VariableState::Cycle(right_cycle)) => {
-                        //let mut merged_cycles = cycle_constraints(left_cycle);
-                        //merged_cycles.merge_constraints(cycle_constraints(right_cycle));
-                        //self.constrain(&merged_cycles.clone_with_new_constraint(term.clone()))?;
-                    //}
-                    //(VariableState::Partial(partial), VariableState::Unbound)
-                    //| (VariableState::Unbound, VariableState::Partial(partial)) => {
-                        //self.constrain(&partial.clone_with_new_constraint(term.clone()))?;
-                    //}
-                    //(
-                        //VariableState::Partial(mut left_partial),
-                        //VariableState::Partial(right_partial),
-                    //) => {
-                        //left_partial.merge_constraints(right_partial);
-                        //self.constrain(&left_partial.clone_with_new_constraint(term.clone()))?;
-                    //}
-                    //(VariableState::Partial(mut partial), VariableState::Cycle(cycle))
-                    //| (VariableState::Cycle(cycle), VariableState::Partial(mut partial)) => {
-                        //partial.merge_constraints(cycle_constraints(cycle));
-                        //self.constrain(&partial.clone_with_new_constraint(term.clone()))?;
-                    //}
-                    //(VariableState::Cycle(cycle), VariableState::Unbound)
-                    //| (VariableState::Unbound, VariableState::Cycle(cycle)) => {
-                        //let partial = cycle_constraints(cycle);
-                        //self.constrain(&partial.clone_with_new_constraint(term.clone()))?;
-                    //}
-                    //(VariableState::Bound(left_value), _) => {
-                        //panic!(
-                            //"Variable {} unexpectedly bound to {} in constraint {}.",
-                            //left.to_polar(),
-                            //left_value.to_polar(),
-                            //term.to_polar(),
-                        //);
-                    //}
-                    //(_, VariableState::Bound(right_value)) => {
-                        //panic!(
-                            //"Variable {} unexpectedly bound to {} in constraint {}.",
-                            //right.to_polar(),
-                            //right_value.to_polar(),
-                            //term.to_polar(),
-                        //);
-                    //}
-                //}
-            //}
-            //(Value::Variable(name), _) | (_, Value::Variable(name)) => {
-                //match self.variable_state(name) {
-                    //VariableState::Unbound => {
-                        //self.constrain(&op!(And, term.clone()))?;
-                    //}
-                    //VariableState::Cycle(cycle) => {
-                        //let partial = cycle_constraints(cycle);
-                        //self.constrain(&partial.clone_with_new_constraint(term.clone()))?;
-                    //}
-                    //VariableState::Partial(partial) => {
-                        //self.constrain(&partial.clone_with_new_constraint(term.clone()))?;
-                    //}
-                    //VariableState::Bound(value) => {
-                        //panic!(
-                            //"Variable {} unexpectedly bound to {} in constraint {}.",
-                            //name.0,
-                            //value.to_polar(),
-                            //term.to_polar()
-                        //);
-                    //}
-                //}
-            //}
-            //(_, _) => panic!(
-                //"At least one side of a constraint expression must be a variable. This is {} {}",
-                //left.to_polar(),
-                //right.to_polar()
-            //),
-        //}
-
-        //Ok(())
-    //}
-
     // TODO (dhatch) This is still called from the VM, breaks followers.
     pub fn constrain(&mut self, o: &Operation) -> PolarResult<()> {
         assert_eq!(o.operator, Operator::And, "bad constraint {}", o.to_polar());
@@ -575,22 +475,6 @@ impl BindingManager {
     // relevant_bindings
     // variable_bindings
     // bindings
-}
-
-/// Get variable out of a term for ``add_constraint`` to determine where the
-/// constraint is stored.
-///
-/// If the term is a variable, the variable is returned.
-/// If the term is a dot expression, the VAR from VAR.field is returned.
-/// Otherwise, the term is returned.
-fn extract_variable(value: &Value) -> &Value {
-    match value {
-        Value::Variable(_) => value,
-        Value::Expression(expr) if expr.operator == Operator::Dot => {
-            extract_variable(expr.args[0].value())
-        }
-        _ => value,
-    }
 }
 
 #[cfg(test)]

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -181,7 +181,7 @@ impl BindingManager {
 
         assert!(term.value().as_expression().is_ok());
         let mut op = op!(And, term.clone());
-        for var in op.variables().clone().iter().rev() {
+        for var in op.variables().iter().rev() {
             match self._variable_state(&var) {
                 BindingManagerVariableState::Unbound => {},
                 BindingManagerVariableState::Cycle(c) => {
@@ -193,8 +193,8 @@ impl BindingManager {
                     e.merge_constraints(op);
                     op = e;
                 },
-                BindingManagerVariableState::Bound(v) => {
-                    panic!("Unexpected bound variable in constraint.");
+                BindingManagerVariableState::Bound(_) => {
+                    panic!("Unexpected bound variable {} in constraint.", var);
                 }
             }
         }

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -326,14 +326,16 @@ impl BindingManager {
         }
     }
 
+
+    // TODO: These functions are now internal, separate internal variable state from
+    // external variable state.
     /// Check the state of `variable`.
-    pub fn variable_state(&self, variable: &Symbol) -> VariableState {
+    fn variable_state(&self, variable: &Symbol) -> VariableState {
         self.variable_state_at_point(variable, self.bsp())
     }
 
-    // TODO: Get rid of this, only used in inverter.
     /// Check the state of `variable` at `bsp`.
-    pub fn variable_state_at_point(&self, variable: &Symbol, bsp: Bsp) -> VariableState {
+    fn variable_state_at_point(&self, variable: &Symbol, bsp: Bsp) -> VariableState {
         let mut path = vec![variable];
         while let Some(value) = self.value(path.last().unwrap(), bsp) {
             match value.value() {
@@ -377,8 +379,7 @@ impl BindingManager {
         self.constrain(&op)
     }
 
-    // TODO (dhatch) This is still called from the VM, breaks followers.
-    pub fn constrain(&mut self, o: &Operation) -> PolarResult<()> {
+    fn constrain(&mut self, o: &Operation) -> PolarResult<()> {
         assert_eq!(o.operator, Operator::And, "bad constraint {}", o.to_polar());
         for var in o.variables() {
             match self.variable_state(&var) {

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -51,7 +51,7 @@ pub struct BindingManager {
     /// Track the bsp of followers when they were added so they can be
     /// backtracked.
     follower_bsps: HashMap<FollowerId, Bsp>,
-    next_follower_id: usize,
+    next_follower_id: FollowerId,
 }
 
 /// The `BindingManager` maintains associations between variables and values,
@@ -205,7 +205,7 @@ impl BindingManager {
 
     /// Look up a variable in the bindings stack and return
     /// a reference to its value if it's bound.
-    pub fn value(&self, variable: &Symbol, bsp: usize) -> Option<&Term> {
+    pub fn value(&self, variable: &Symbol, bsp: Bsp) -> Option<&Term> {
         self.bindings[..bsp]
             .iter()
             .rev()

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -325,6 +325,7 @@ impl BindingManager {
 
 }
 
+// Private impls.
 impl BindingManager {
     /// Bind two variables together.
     fn bind_variables(&mut self, left: &Symbol, right: &Symbol) {

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -7,7 +7,6 @@ use crate::error::{PolarResult, RuntimeError};
 use crate::folder::{fold_term, Folder};
 use crate::formatting::ToPolarString;
 use crate::terms::{has_rest_var, Operation, Operator, Symbol, Term, Value};
-use crate::vm::cycle_constraints;
 
 #[derive(Clone, Debug)]
 pub struct Binding(pub Symbol, pub Term);
@@ -30,6 +29,16 @@ pub enum VariableState {
     Unbound,
     Bound(Term),
     Partial(Operation),
+}
+
+/// Represent each binding in a cycle as a unification constraint.
+// TODO(gj): put this in an impl block on VariableState?
+fn cycle_constraints(cycle: Vec<Symbol>) -> Operation {
+    let mut constraints = op!(And);
+    for (x, y) in cycle.iter().zip(cycle.iter().skip(1)) {
+        constraints.add_constraint(op!(Unify, term!(x.clone()), term!(y.clone())));
+    }
+    constraints
 }
 
 impl From<BindingManagerVariableState> for VariableState {

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -194,9 +194,7 @@ impl BindingManager {
                     op = e;
                 },
                 BindingManagerVariableState::Bound(v) => {
-                    let ground_op = op.ground(var.clone(), v.clone()).unwrap();
-                    println!("variable {:?} bound to {} in constraint {} grounded to {ground_op}", var, v, op.to_polar(), ground_op=ground_op.to_polar());
-                    op = ground_op;
+                    panic!("Unexpected bound variable in constraint.");
                 }
             }
         }

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -264,7 +264,6 @@ impl BindingManager {
 
     /// Dereference all variables in term, including within nested structures like
     /// lists and dictionaries.
-    /// Do not dereference variables inside expressions.
     pub fn deep_deref(&self, term: &Term) -> Term {
         pub struct Derefer<'a> {
             binding_manager: &'a BindingManager,
@@ -282,10 +281,7 @@ impl BindingManager {
                     Value::List(_) => fold_term(self.binding_manager.deref(&t), self),
                     Value::Variable(_) | Value::RestVariable(_) => {
                         let derefed = self.binding_manager.deref(&t);
-                        match derefed.value() {
-                            Value::Expression(_) => t,
-                            _ => fold_term(derefed, self),
-                        }
+                        fold_term(derefed, self)
                     }
                     _ => fold_term(t, self),
                 }

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -356,7 +356,7 @@ impl BindingManager {
 
         assert!(term.value().as_expression().is_ok());
         let mut op = op!(And, term.clone());
-        for var in op.variables().clone() {
+        for var in op.variables().clone().iter().rev() {
             match self.variable_state(&var) {
                 VariableState::Unbound => {},
                 VariableState::Cycle(c) => {
@@ -781,4 +781,6 @@ mod test {
             panic!("unexpected");
         }
     }
+
+    // TODO (dhatch): Test backtrack with followers.
 }

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -373,7 +373,9 @@ impl BindingManager {
     }
 
     pub fn remove_follower(&mut self, follower_id: &FollowerId) -> Option<BindingManager> {
-        self.followers.remove(follower_id).map(|(follower, _bsp)| follower)
+        self.followers
+            .remove(follower_id)
+            .map(|(follower, _bsp)| follower)
     }
 }
 

--- a/polar-core/src/error.rs
+++ b/polar-core/src/error.rs
@@ -258,6 +258,9 @@ pub enum RuntimeError {
     FileLoading {
         msg: String,
     },
+    IncompatibleBindings {
+        msg: String,
+    }
 }
 
 impl RuntimeError {
@@ -293,6 +296,7 @@ impl fmt::Display for RuntimeError {
                 write!(f, "Application error: {}", msg)
             }
             Self::FileLoading { msg } => write!(f, "Problem loading file: {}", msg),
+            Self::IncompatibleBindings { msg } => write!(f, "Attempted binding was incompatible: {}", msg),
         }
     }
 }

--- a/polar-core/src/error.rs
+++ b/polar-core/src/error.rs
@@ -260,7 +260,7 @@ pub enum RuntimeError {
     },
     IncompatibleBindings {
         msg: String,
-    }
+    },
 }
 
 impl RuntimeError {
@@ -296,7 +296,9 @@ impl fmt::Display for RuntimeError {
                 write!(f, "Application error: {}", msg)
             }
             Self::FileLoading { msg } => write!(f, "Problem loading file: {}", msg),
-            Self::IncompatibleBindings { msg } => write!(f, "Attempted binding was incompatible: {}", msg),
+            Self::IncompatibleBindings { msg } => {
+                write!(f, "Attempted binding was incompatible: {}", msg)
+            }
         }
     }
 }

--- a/polar-core/src/formatting.rs
+++ b/polar-core/src/formatting.rs
@@ -233,9 +233,6 @@ pub mod display {
             }
 
             match self {
-                Goal::Bind { var, value } => {
-                    write!(fmt, "Bind({}, {})", var, value.to_polar())
-                }
                 Goal::Isa { left, right } => {
                     write!(fmt, "Isa({}, {})", left.to_polar(), right.to_polar())
                 }

--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -20,8 +20,8 @@ pub struct Inverter {
     bsp: usize,
     results: Vec<BindingManager>,
     add_constraints: Rc<RefCell<Bindings>>,
+    follower: Option<usize>,
     _debug_id: u64,
-    follower: Option<usize>
 }
 
 static ID: AtomicU64 = AtomicU64::new(0);
@@ -40,8 +40,8 @@ impl Inverter {
             bsp,
             add_constraints,
             results: vec![],
+            follower: None,
             _debug_id: ID.fetch_add(1, Ordering::AcqRel),
-            follower: None
         }
     }
 }

--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -126,6 +126,15 @@ fn invert_partials(bindings: BindingStack, vm: &PolarVirtualMachine, bsp: usize)
             // TODO: This case is for something like
             // w(x) if not (y = 1) and y = x;
             //
+            // f(x) if not g(x);
+            // g(y) if y = 1
+            //
+            // f(1) -> fail
+            // g(y)
+            //  bind _y_5 = 1
+            //
+            //  _y_5 != 1
+            //
             // Ultimately this should add constraints, but for now this query always succeeds with
             // no constraints because a negation is performed over a variable that is not
             // bound.

--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -1,28 +1,24 @@
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
-use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::bindings::{Binding, BindingStack, VariableState, BindingManager};
+use crate::bindings::{VariableState, BindingManager};
 use crate::counter::Counter;
 use crate::error::PolarResult;
 use crate::events::QueryEvent;
-use crate::folder::{fold_value, Folder};
 use crate::formatting::ToPolarString;
 use crate::kb::Bindings;
 use crate::partial::simplify_bindings;
 use crate::runnable::Runnable;
-use crate::terms::{Operation, Operator, Symbol, Term, Value};
-use crate::vm::{cycle_constraints, Goals, PolarVirtualMachine};
+use crate::terms::{Operation, Operator, Term, Value};
+use crate::vm::{Goals, PolarVirtualMachine};
 
 #[derive(Clone)]
 pub struct Inverter {
     vm: PolarVirtualMachine,
-    bindings: Rc<RefCell<BindingStack>>,
     bsp: usize,
-    results: Vec<BindingStack>,
-    results_binding_managers: Vec<BindingManager>,
+    results: Vec<BindingManager>,
     add_constraints: Rc<RefCell<Bindings>>,
     _debug_id: u64,
     follower: Option<usize>
@@ -34,7 +30,6 @@ impl Inverter {
     pub fn new(
         vm: &PolarVirtualMachine,
         goals: Goals,
-        bindings: Rc<RefCell<BindingStack>>,
         add_constraints: Rc<RefCell<Bindings>>,
         bsp: usize,
     ) -> Self {
@@ -42,54 +37,12 @@ impl Inverter {
         vm.inverting = true;
         Self {
             vm,
-            bindings,
             bsp,
             add_constraints,
             results: vec![],
-            results_binding_managers: vec![],
             _debug_id: ID.fetch_add(1, Ordering::AcqRel),
             follower: None
         }
-    }
-}
-
-struct PartialInverter {
-    this_var: Symbol,
-    old_state: VariableState,
-}
-
-impl PartialInverter {
-    pub fn new(this_var: Symbol, old_state: VariableState) -> Self {
-        Self {
-            this_var,
-            old_state,
-        }
-    }
-
-    fn invert_operation(&self, o: &Operation) -> Operation {
-        // Compute csp from old_value vs. p.
-        let csp = match &self.old_state {
-            VariableState::Partial(e) => e.constraints().len(),
-            _ => 0,
-        };
-        o.clone_with_constraints(o.inverted_constraints(csp))
-    }
-}
-
-impl Folder for PartialInverter {
-    /// Invert top-level constraints.
-    fn fold_term(&mut self, t: Term) -> Term {
-        t.clone_with_value(match t.value() {
-            Value::Expression(o) => Value::Expression(self.invert_operation(o)),
-            v => Value::Expression(op!(
-                And,
-                term!(value!(op!(
-                    Neq,
-                    term!(value!(self.this_var.clone())),
-                    term!(fold_value(v.clone(), self))
-                )))
-            )),
-        })
     }
 }
 
@@ -115,77 +68,6 @@ fn results_to_constraints(results: Vec<BindingManager>) -> Bindings {
     }).collect()
 }
 
-
-/// Invert partial values in `bindings` with respect to the old VM bindings.
-fn invert_partials(bindings: BindingStack, vm: &PolarVirtualMachine, bsp: usize) -> BindingStack {
-    let mut new_bindings = vec![];
-    for Binding(var, value) in bindings {
-        // Determine whether to invert partials based on the state of the variable in the VM
-        // before inversion.
-        match vm.variable_state_at_point(&var, bsp) {
-            // TODO: This case is for something like
-            // w(x) if not (y = 1) and y = x;
-            //
-            // f(x) if not g(x);
-            // g(y) if y = 1
-            //
-            // f(1) -> fail
-            // g(y)
-            //  bind _y_5 = 1
-            //
-            //  _y_5 != 1
-            //
-            // Ultimately this should add constraints, but for now this query always succeeds with
-            // no constraints because a negation is performed over a variable that is not
-            // bound.
-            VariableState::Unbound => (),
-            // during the negation to a different value (the negated query would backtrack).
-            VariableState::Bound(x) => assert_eq!(x, value, "inconsistent bindings"),
-            VariableState::Cycle(c) => {
-                let constraints =
-                    PartialInverter::new(var.clone(), VariableState::Cycle(c.clone()))
-                        .fold_term(value);
-
-                // TODO (dhatch): This whole thing could just be an add constraints call.
-                match constraints.value() {
-                    Value::Expression(e) => {
-                        let mut f = cycle_constraints(c);
-                        f.merge_constraints(e.clone());
-                        for var in f.variables() {
-                            new_bindings.push(Binding(var.clone(), f.clone().into_term()));
-                        }
-                    }
-                    _ => unreachable!("Constraint from partial inverter must be expression."),
-                }
-            }
-            // Three states of a partial x
-            //
-            // x > 1 and not (x < 0)
-            //
-            // - before inversion partial (two constraints)
-            // - post-inversion but pre-simplification partial (>2 constraints)
-            // - post-inversion post-simplification partial (>2 constraints)
-            //
-            VariableState::Partial(e) => {
-                let constraints =
-                    PartialInverter::new(var.clone(), VariableState::Partial(e.clone()))
-                        .fold_term(value);
-                // Same thing here.
-                match constraints.value() {
-                    Value::Expression(f) => {
-                        let mut e = e.clone();
-                        e.merge_constraints(f.clone());
-                        for var in e.variables() {
-                            new_bindings.push(Binding(var.clone(), e.clone().into_term()));
-                        }
-                    }
-                    _ => unreachable!("Constraint from partial inverter must be expression."),
-                }
-            }
-        }
-    }
-    new_bindings
-}
 
 fn invert_partials_bm(bindings: BindingManager) -> Bindings {
      let mut new_bindings = Bindings::new();
@@ -253,51 +135,6 @@ fn reduce_constraints_bm(bindings: Vec<Bindings>) -> Bindings {
     reduced
 }
 
-
-// TODO Remove dedupe bindings once inverter operates over BindingManager instead of binding stack.
-/// Only keep latest bindings.
-fn dedupe_bindings(bindings: BindingStack) -> BindingStack {
-    let mut seen = HashSet::new();
-    bindings
-        .into_iter()
-        .rev()
-        .filter(|Binding(v, _)| seen.insert(v.clone()))
-        .collect()
-}
-
-
-/// Reduce + merge constraints.
-fn reduce_constraints(bindings: Vec<BindingStack>) -> (Bindings, Vec<Symbol>) {
-    let mut vars = vec![];
-    let reduced = bindings
-        .into_iter()
-        .fold(Bindings::new(), |mut acc, bindings| {
-            dedupe_bindings(bindings)
-                .into_iter()
-                .for_each(|Binding(var, value)| match acc.entry(var.clone()) {
-                    Entry::Occupied(mut o) => match (o.get().value(), value.value()) {
-                        (Value::Expression(x), Value::Expression(y)) => {
-                            let mut x = x.clone();
-                            x.merge_constraints(y.clone());
-                            o.insert(value.clone_with_value(value!(x)));
-                        }
-                        (existing, new) => panic!(
-                            "Illegal state reached while reducing constraints for {}: {} → {}",
-                            var,
-                            existing.to_polar(),
-                            new.to_polar()
-                        ),
-                    },
-                    Entry::Vacant(v) => {
-                        v.insert(value);
-                        vars.push(var);
-                    }
-                });
-            acc
-        });
-    (reduced, vars)
-}
-
 /// A Runnable that runs a query and inverts the results in three ways:
 ///
 /// 1. If no results are emitted (indicating failure), return true.
@@ -321,7 +158,7 @@ impl Runnable for Inverter {
                         // If there are results, the inversion should usually fail. However,
                         // if those results have constraints we collect them and pass them
                         // out to the parent VM.
-                        let constraints = results_to_constraints(self.results_binding_managers.drain(..).collect::<Vec<_>>());
+                        let constraints = results_to_constraints(self.results.drain(..).collect::<Vec<_>>());
 
                         // Decide which variables come out of negation. This is hacky.
                         // And the unbound one should sometimes come out I think...
@@ -333,73 +170,6 @@ impl Runnable for Inverter {
                         for (constraint, val) in constraints.iter() {
                             println!("{:?} {}", constraint, val.to_polar());
                         }
-
-                        // OLD
-                        let inverted: Vec<BindingStack> = self
-                            .results
-                            .drain(..)
-                            .collect::<Vec<BindingStack>>()
-                            .into_iter()
-                            // Inverts each result
-                            .map(|bindings| invert_partials(bindings, &self.vm, self.bsp))
-                            .collect();
-
-                        // Now have disjunction of results. not OR[result1, result2, ...]
-                        // Reduce constraints converts it into a conjunct of negated results.
-                        // AND[!result1, ...]
-                        let (reduced, ordered_vars) = reduce_constraints(inverted);
-                        let simplified =
-                            simplify_bindings(reduced.clone()).unwrap_or_else(Bindings::new);
-
-                        let simplified_keys = simplified.keys().collect::<HashSet<&Symbol>>();
-                        let reduced_keys = reduced.keys().collect::<HashSet<&Symbol>>();
-                        let ordered_keys = ordered_vars.iter().collect::<HashSet<&Symbol>>();
-
-                        assert_eq!(simplified_keys, reduced_keys);
-                        assert_eq!(reduced_keys, ordered_keys);
-
-                        // Figure out which bindings should go into parent VM's binding
-                        // stack.
-                        let new_bindings = ordered_vars.into_iter().flat_map(|var| {
-                            // We have at least one binding to return, so succeed.
-                            // result = true;
-
-                            let value = simplified[&var].clone();
-                            if let Value::Expression(_) = value.value() {
-                                match self.vm.variable_state_at_point(&var, self.bsp) {
-                                    VariableState::Unbound => vec![Binding(var, value)],
-                                    VariableState::Bound(x) => {
-                                        assert_eq!(x, value, "inconsistent bindings");
-                                        vec![Binding(var, value)]
-                                    }
-                                    VariableState::Cycle(c) => {
-                                        let constraint = cycle_constraints(c.clone())
-                                            .clone_with_new_constraint(value)
-                                            .into_term();
-                                        c.into_iter()
-                                            .map(|v| Binding(v, constraint.clone()))
-                                            .collect()
-                                    }
-                                    VariableState::Partial(e) => {
-                                        let e = e.clone_with_new_constraint(value);
-                                        e.variables()
-                                            .into_iter()
-                                            .map(|var| Binding(var, e.clone().into_term()))
-                                            .collect()
-                                    }
-                                }
-                            } else {
-                                vec![Binding(var, value)]
-                            }
-                        });
-
-                        println!("{} new bindings: ", self._debug_id);
-                        for Binding(var, value) in new_bindings {
-                            println!("{:?} {}", var, value.to_polar());
-                        }
-
-                        // Return new bindings created by inverter to parent VM.
-                        // OLD
                         if !constraints.is_empty() {
                             result = true;
                         }
@@ -411,14 +181,9 @@ impl Runnable for Inverter {
                 QueryEvent::Result { .. } => {
                     // Retrieve new bindings made when running inverted query.
                     // Bindings are retrieved as the raw BindingStack.
-                    let bindings: BindingStack =
-                        self.vm.bindings_for_inverter().drain(self.bsp..).collect();
-                    // Add new part of binding stack from inversion to results.
-                    self.results.push(bindings);
-
                     let binding_follower = self.vm.remove_binding_follower(&self.follower.unwrap()).unwrap();
                     println!("{} removed follower {}", self._debug_id, self.follower.unwrap());
-                    self.results_binding_managers.push(binding_follower);
+                    self.results.push(binding_follower);
                     self.follower = Some(self.vm.add_binding_follower());
                     println!("{} added follower {}", self._debug_id, self.follower.unwrap());
                 }

--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::Entry;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::bindings::{BindingManager, Bsp, VariableState};
+use crate::bindings::{BindingManager, Bsp, FollowerId, VariableState};
 use crate::counter::Counter;
 use crate::error::PolarResult;
 use crate::events::QueryEvent;
@@ -36,7 +36,7 @@ pub struct Inverter {
     add_constraints: Rc<RefCell<Bindings>>,
 
     /// The ID of the current binding manager follower. Initialized in `run`.
-    follower: Option<usize>,
+    follower: Option<FollowerId>,
 
     /// An ID to distinguish logging from each inverter, useful when debugging
     /// queries with multiple nested `not` operations.
@@ -50,7 +50,7 @@ impl Inverter {
         vm: &PolarVirtualMachine,
         goals: Goals,
         add_constraints: Rc<RefCell<Bindings>>,
-        bsp: usize,
+        bsp: Bsp,
     ) -> Self {
         let mut vm = vm.clone_with_goals(goals);
         vm.inverting = true;

--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -98,7 +98,7 @@ fn results_to_constraints(results: Vec<BindingManager>) -> Bindings {
 /// Constraints are inverted by getting each binding as a constraint.
 /// Simplification is performed, to subsitute bindings and remove temporary variables.
 /// Then, each simplified expression is inverted.
-/// A binding of `var` to `val` after simplification is converted into `var != bound.
+/// A binding of `var` to `val` after simplification is converted into `var != val`.
 fn invert_partials(bindings: BindingManager) -> Bindings {
     let mut new_bindings = Bindings::new();
 

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -621,9 +621,10 @@ mod test {
 
         let mut q = p.new_query_from_term(term!(call!("j", [sym!("x"), sym!("y")])), false);
         assert_partial_expressions!(next_binding(&mut q)?,
-            "x" => "y matches Y{} and _this matches X{} and y.x = _this",
-            "x" => "y matches Y{} and _this matches X{} and y.x = _this",
-            "y" => "_this matches Y{} and _this.x matches X{}"
+            // TODO dhatch change in order here
+            "x" => "_this matches X{} and y matches Y{} and y.x = _this",
+            "x" => "_this matches X{} and y matches Y{} and y.x = _this",
+            "y" => "_this.x matches X{} and _this matches Y{}"
         );
         assert_query_done!(q);
 
@@ -1776,17 +1777,17 @@ mod test {
                       g(y) if y = 1;
                       "#,
         )?;
-        let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
-        let bindings = next_binding(&mut q)?;
-        assert_partial_expressions!(
-            &bindings,
-            "x" => "_this != 1"
-        );
-        assert_query_done!(q);
+        //let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
+        //let bindings = next_binding(&mut q)?;
+        //assert_partial_expressions!(
+            //&bindings,
+            //"x" => "_this != 1"
+        //);
+        //assert_query_done!(q);
 
-        let mut q = p.new_query_from_term(term!(call!("f", [2])), false);
-        assert_eq!(next_binding(&mut q)?.len(), 0);
-        assert_query_done!(q);
+        //let mut q = p.new_query_from_term(term!(call!("f", [2])), false);
+        //assert_eq!(next_binding(&mut q)?.len(), 0);
+        //assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("f", [1])), false);
         assert_query_done!(q);

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -217,13 +217,6 @@ impl Operation {
         combined
     }
 
-    pub fn after(&self, csp: usize) -> Operation {
-        assert_eq!(self.operator, Operator::And);
-        let constraints = self.constraints();
-        let (_, new) = constraints.split_at(csp);
-        self.clone_with_constraints(Vec::from(new))
-    }
-
     pub fn constraints(&self) -> Vec<Operation> {
         self.args
             .iter()
@@ -621,7 +614,6 @@ mod test {
 
         let mut q = p.new_query_from_term(term!(call!("j", [sym!("x"), sym!("y")])), false);
         assert_partial_expressions!(next_binding(&mut q)?,
-            // TODO dhatch change in order here
             "x" => "y matches Y{} and _this matches X{} and y.x = _this",
             "x" => "y matches Y{} and _this matches X{} and y.x = _this",
             "y" => "_this matches Y{} and _this.x matches X{}"

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -622,9 +622,9 @@ mod test {
         let mut q = p.new_query_from_term(term!(call!("j", [sym!("x"), sym!("y")])), false);
         assert_partial_expressions!(next_binding(&mut q)?,
             // TODO dhatch change in order here
-            "x" => "_this matches X{} and y matches Y{} and y.x = _this",
-            "x" => "_this matches X{} and y matches Y{} and y.x = _this",
-            "y" => "_this.x matches X{} and _this matches Y{}"
+            "x" => "y matches Y{} and _this matches X{} and y.x = _this",
+            "x" => "y matches Y{} and _this matches X{} and y.x = _this",
+            "y" => "_this matches Y{} and _this.x matches X{}"
         );
         assert_query_done!(q);
 
@@ -1733,12 +1733,12 @@ mod test {
         assert_partial_expression!(
             next_binding(&mut q)?,
             "x",
-            "_this = 1 and not _this matches Foo{}"
+            "1 = _this and not 1 matches Foo{}"
         );
         assert_partial_expression!(
             next_binding(&mut q)?,
             "x",
-            "_this = 1 and not _this matches Bar{}"
+            "1 = _this and not 1 matches Bar{}"
         );
         assert_query_done!(q);
         Ok(())

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -1392,10 +1392,9 @@ mod test {
         assert_partial_expression!(next_binding(&mut q)?, "x", "_this > 1 and _this >= 0");
         assert_query_done!(q);
 
-        // TODO(ap): The below fails because of interaction between the simplifier and inverter.
-        // let mut q = p.new_query_from_term(term!(call!("g", [sym!("x")])), false);
-        // assert_partial_expression!(next_binding(&mut q)?, "x", "_this > 1 and _this != 2");
-        // assert_query_done!(q);
+        let mut q = p.new_query_from_term(term!(call!("g", [sym!("x")])), false);
+        assert_partial_expression!(next_binding(&mut q)?, "x", "_this > 1 and _this != 2");
+        assert_query_done!(q);
 
         Ok(())
     }

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -1778,25 +1778,25 @@ mod test {
                 h(x) if not (not g(x));
                       "#,
         )?;
-        let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
-        let bindings = next_binding(&mut q)?;
-        assert_partial_expressions!(
-            &bindings,
-            "x" => "_this != 1"
-        );
-        assert_query_done!(q);
+        //let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
+        //let bindings = next_binding(&mut q)?;
+        //assert_partial_expressions!(
+            //&bindings,
+            //"x" => "_this != 1"
+        //);
+        //assert_query_done!(q);
 
-        let mut q = p.new_query_from_term(term!(call!("f", [2])), false);
-        assert_eq!(next_binding(&mut q)?.len(), 0);
-        assert_query_done!(q);
+        //let mut q = p.new_query_from_term(term!(call!("f", [2])), false);
+        //assert_eq!(next_binding(&mut q)?.len(), 0);
+        //assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("f", [1])), false);
         assert_query_done!(q);
 
-        let mut q = p.new_query_from_term(term!(call!("h", [sym!("x")])), false);
-        let bindings = next_binding(&mut q)?;
-        assert_eq!(bindings.get(&sym!("x")).unwrap(), &term!(1));
-        assert_query_done!(q);
+        //let mut q = p.new_query_from_term(term!(call!("h", [sym!("x")])), false);
+        //let bindings = next_binding(&mut q)?;
+        //assert_eq!(bindings.get(&sym!("x")).unwrap(), &term!(1));
+        //assert_query_done!(q);
 
         Ok(())
     }

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -217,6 +217,12 @@ impl Operation {
         combined
     }
 
+    pub fn after(&self, csp: usize) -> Operation {
+        assert_eq!(self.operator, Operator::And);
+        let (_, new) = self.constraints().split_at(csp);
+        self.clone_with_constraints(Vec::from(new))
+    }
+
     pub fn constraints(&self) -> Vec<Operation> {
         self.args
             .iter()
@@ -1733,7 +1739,8 @@ mod test {
     fn test_multiple_gt_three_variables() -> TestResult {
         let p = Polar::new();
         p.load_str(r#"f(x, y, z) if x > z and y > z;"#)?;
-        let mut q = p.new_query_from_term(term!(call!("f", [sym!("x"), sym!("y"), sym!("z")])), false);
+        let mut q =
+            p.new_query_from_term(term!(call!("f", [sym!("x"), sym!("y"), sym!("z")])), false);
         assert_partial_expressions!(
             next_binding(&mut q)?,
             "x" => "_this > z and y > z",
@@ -1763,9 +1770,11 @@ mod test {
         // TODO: More complicated version:
         //  f(x) if not g(z) and z = x;
         //  g(y) if y = 1;
-        p.load_str(r#"f(x) if not g(x);
+        p.load_str(
+            r#"f(x) if not g(x);
                       g(y) if y = 1;
-                      "#)?;
+                      "#,
+        )?;
         let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
         let bindings = next_binding(&mut q)?;
         assert_partial_expressions!(
@@ -1783,7 +1792,6 @@ mod test {
 
         Ok(())
     }
-
 
     // TODO(gj): add test where we have a partial prior to an inversion
     // TODO (dhatch): We have few tests involving multiple rules and partials.

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -1819,6 +1819,20 @@ mod test {
         Ok(())
     }
 
+    #[test]
+    fn test_output_variable() -> TestResult {
+        let p = Polar::new();
+        p.load_str(
+            r#"f(a, b) if a = b;"#)?;
+
+        let mut q = p.new_query_from_term(term!(call!("f", [1, sym!("x")])), false);
+        let r = next_binding(&mut q)?;
+        assert_eq!(r.get(&sym!("x")).unwrap(), &term!(1));
+        assert_query_done!(q);
+
+        Ok(())
+    }
+
     // TODO(gj): add test where we have a partial prior to an inversion
     // TODO (dhatch): We have few tests involving multiple rules and partials.
 }

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -1782,21 +1782,28 @@ mod test {
         p.load_str(
             r#"f(x) if not g(x);
                       g(y) if y = 1;
+
+                h(x) if not (not g(x));
                       "#,
         )?;
-        //let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
-        //let bindings = next_binding(&mut q)?;
-        //assert_partial_expressions!(
-            //&bindings,
-            //"x" => "_this != 1"
-        //);
-        //assert_query_done!(q);
+        let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
+        let bindings = next_binding(&mut q)?;
+        assert_partial_expressions!(
+            &bindings,
+            "x" => "_this != 1"
+        );
+        assert_query_done!(q);
 
-        //let mut q = p.new_query_from_term(term!(call!("f", [2])), false);
-        //assert_eq!(next_binding(&mut q)?.len(), 0);
-        //assert_query_done!(q);
+        let mut q = p.new_query_from_term(term!(call!("f", [2])), false);
+        assert_eq!(next_binding(&mut q)?.len(), 0);
+        assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("f", [1])), false);
+        assert_query_done!(q);
+
+        let mut q = p.new_query_from_term(term!(call!("h", [sym!("x")])), false);
+        let bindings = next_binding(&mut q)?;
+        assert_eq!(bindings.get(&sym!("x")).unwrap(), &term!(1));
         assert_query_done!(q);
 
         Ok(())

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -219,7 +219,8 @@ impl Operation {
 
     pub fn after(&self, csp: usize) -> Operation {
         assert_eq!(self.operator, Operator::And);
-        let (_, new) = self.constraints().split_at(csp);
+        let constraints = self.constraints();
+        let (_, new) = constraints.split_at(csp);
         self.clone_with_constraints(Vec::from(new))
     }
 

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -1778,25 +1778,26 @@ mod test {
                 h(x) if not (not g(x));
                       "#,
         )?;
-        //let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
-        //let bindings = next_binding(&mut q)?;
-        //assert_partial_expressions!(
-            //&bindings,
-            //"x" => "_this != 1"
-        //);
-        //assert_query_done!(q);
 
-        //let mut q = p.new_query_from_term(term!(call!("f", [2])), false);
-        //assert_eq!(next_binding(&mut q)?.len(), 0);
-        //assert_query_done!(q);
+        let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
+        let bindings = next_binding(&mut q)?;
+        assert_partial_expressions!(
+            &bindings,
+            "x" => "_this != 1"
+        );
+        assert_query_done!(q);
+
+        let mut q = p.new_query_from_term(term!(call!("f", [2])), false);
+        assert_eq!(next_binding(&mut q)?.len(), 0);
+        assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("f", [1])), false);
         assert_query_done!(q);
 
-        //let mut q = p.new_query_from_term(term!(call!("h", [sym!("x")])), false);
-        //let bindings = next_binding(&mut q)?;
-        //assert_eq!(bindings.get(&sym!("x")).unwrap(), &term!(1));
-        //assert_query_done!(q);
+        let mut q = p.new_query_from_term(term!(call!("h", [sym!("x")])), false);
+        let bindings = next_binding(&mut q)?;
+        assert_eq!(bindings.get(&sym!("x")).unwrap(), &term!(1));
+        assert_query_done!(q);
 
         Ok(())
     }

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -1344,22 +1344,18 @@ mod test {
         );
         assert_query_done!(q);
 
-         let mut q = p.new_query_from_term(term!(call!("u", [sym!("x")])), false);
-         let binding = next_binding(&mut q)?;
-         // This is unbound because any input succeeds.
-         assert_eq!(binding.get(&sym!("x")).unwrap(), &term!(sym!("x")));
-         assert_query_done!(q);
+        let mut q = p.new_query_from_term(term!(call!("u", [sym!("x")])), false);
+        let binding = next_binding(&mut q)?;
+        // This is unbound because any input succeeds.
+        assert_eq!(binding.get(&sym!("x")).unwrap(), &term!(sym!("x")));
+        assert_query_done!(q);
 
         let mut v = p.new_query_from_term(term!(call!("v", [sym!("x")])), false);
         assert_partial_expression!(next_binding(&mut v)?, "x", "_this != 1");
         assert_query_done!(v);
 
         let mut q = p.new_query_from_term(term!(call!("w", [sym!("x")])), false);
-        assert_partial_expression!(
-            next_binding(&mut q)?,
-            "x",
-            "_this != 6"
-        );
+        assert_partial_expression!(next_binding(&mut q)?, "x", "_this != 6");
         assert_query_done!(q);
 
         Ok(())
@@ -1808,9 +1804,7 @@ mod test {
         // TODO: More complicated version:
         //  f(x) if not g(z) and z = x;
         //  g(y) if y = 1;
-        p.load_str(
-            r#"f() if x = 1;"#,
-        )?;
+        p.load_str(r#"f() if x = 1;"#)?;
 
         let mut q = p.new_query_from_term(term!(call!("f", [])), false);
         let r = next_binding(&mut q)?;
@@ -1823,8 +1817,7 @@ mod test {
     #[test]
     fn test_output_variable() -> TestResult {
         let p = Polar::new();
-        p.load_str(
-            r#"f(a, b) if a = b;"#)?;
+        p.load_str(r#"f(a, b) if a = b;"#)?;
 
         let mut q = p.new_query_from_term(term!(call!("f", [1, sym!("x")])), false);
         let r = next_binding(&mut q)?;

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -100,8 +100,8 @@ impl Query {
         self.vm.term_source(&self.term, true)
     }
 
-    pub fn bind(&mut self, name: Symbol, value: Term) {
-        self.vm.bind(&name, value);
+    pub fn bind(&mut self, name: Symbol, value: Term) -> PolarResult<()> {
+        self.vm.bind(&name, value)
     }
 }
 

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -496,7 +496,7 @@ impl PolarVirtualMachine {
             Goal::AddConstraintsBatch { add_constraints } => add_constraints
                 .borrow_mut()
                 .drain()
-                .map(|(_, constraint)| {
+                .try_for_each(|(_, constraint)| -> PolarResult<()> {
                     println!("bindings before add_constraint: ");
                     for val in self.binding_manager.variables() {
                         println!("{:?}", self.variable_state(&val));
@@ -511,8 +511,7 @@ impl PolarVirtualMachine {
                     }
 
                     Ok(())
-                })
-                .collect::<PolarResult<()>>()?,
+                })?,
             Goal::Run { runnable } => return self.run_runnable(runnable.clone_runnable()),
         }
         Ok(QueryEvent::None)

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2058,11 +2058,6 @@ impl PolarVirtualMachine {
                     VariableState::Bound(value) => {
                         self.push_goal(Goal::Unify { left: value, right })?;
                     }
-                    VariableState::Partial(_) => {
-                        if self.bind(var, right).is_err() {
-                            self.push_goal(Goal::Backtrack)?;
-                        }
-                    }
                     _ => {
                         if self.bind(var, right).is_err() {
                             self.push_goal(Goal::Backtrack)?;
@@ -2077,11 +2072,6 @@ impl PolarVirtualMachine {
                 match self.variable_state(var) {
                     VariableState::Bound(value) => {
                         self.push_goal(Goal::Unify { left, right: value })?;
-                    }
-                    VariableState::Partial(_) => {
-                        if self.bind(var, left).is_err() {
-                            self.push_goal(Goal::Backtrack)?;
-                        }
                     }
                     _ => {
                         if self.bind(var, left).is_err() {

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -962,15 +962,6 @@ impl PolarVirtualMachine {
             | (Value::RestVariable(l), Value::RestVariable(r)) => {
                 // Two variables.
                 match (self.variable_state(l), self.variable_state(r)) {
-                    // TODO (dhatch): This special case does not seem right to me.
-                    // Do we need this to preserve some functionality, or can we add
-                    // a constraint?
-                    (VariableState::Unbound, VariableState::Unbound) => {
-                        self.push_goal(Goal::Unify {
-                            left: left.clone(),
-                            right: right.clone(),
-                        })?
-                    }
                     (VariableState::Bound(x), _) => self.push_goal(Goal::Isa {
                         left: x,
                         right: right.clone(),
@@ -994,7 +985,6 @@ impl PolarVirtualMachine {
                 _ => self.isa_expr(left, right)?,
             },
             (_, Value::Variable(r)) | (_, Value::RestVariable(r)) => match self.variable_state(r) {
-                // TODO (dhatch): Is this case tested?
                 VariableState::Unbound => self.push_goal(Goal::Unify {
                     left: left.clone(),
                     right: right.clone(),

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -7,7 +7,7 @@ use std::string::ToString;
 use std::sync::{Arc, RwLock};
 
 use super::visitor::{walk_term, Visitor};
-use crate::bindings::{Binding, BindingManager, BindingStack, Bindings, Bsp, VariableState, FollowerId};
+use crate::bindings::{BindingManager, Bindings, Bsp, VariableState, FollowerId};
 use crate::counter::Counter;
 use crate::debugger::{DebugEvent, Debugger};
 use crate::error::{self, PolarResult};
@@ -502,7 +502,7 @@ impl PolarVirtualMachine {
                         println!("{:?}",
                             self.variable_state(&val));
                     }
-                    self.add_constraint(&constraint);
+                    self.add_constraint(&constraint)?;
                     println!("bindings after add_constraint: ");
                     for val in self.binding_manager.variables() {
                         println!("{val} {:?}",
@@ -2067,7 +2067,7 @@ impl PolarVirtualMachine {
                     VariableState::Bound(value) => {
                         self.push_goal(Goal::Unify { left: value, right })?;
                     }
-                    VariableState::Partial(f) => {
+                    VariableState::Partial(_) => {
                         if self.bind(var, right).is_err() {
                             self.push_goal(Goal::Backtrack)?;
                         }
@@ -2085,7 +2085,7 @@ impl PolarVirtualMachine {
                     VariableState::Bound(value) => {
                         self.push_goal(Goal::Unify { left, right: value })?;
                     }
-                    VariableState::Partial(f) => {
+                    VariableState::Partial(_) => {
                         if self.bind(var, left).is_err() {
                             self.push_goal(Goal::Backtrack)?;
                         }
@@ -2593,7 +2593,7 @@ impl PolarVirtualMachine {
                     self.bind(
                         &answer,
                         Term::new_temporary(Value::Boolean(right_fields.len() < left.fields.len())),
-                    );
+                    )?;
                 }
                 Ok(QueryEvent::None)
             }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -7,7 +7,7 @@ use std::string::ToString;
 use std::sync::{Arc, RwLock};
 
 use super::visitor::{walk_term, Visitor};
-use crate::bindings::{BindingManager, Bindings, Bsp, VariableState, FollowerId};
+use crate::bindings::{BindingManager, Bindings, Bsp, FollowerId, VariableState};
 use crate::counter::Counter;
 use crate::debugger::{DebugEvent, Debugger};
 use crate::error::{self, PolarResult};
@@ -499,14 +499,12 @@ impl PolarVirtualMachine {
                 .map(|(_, constraint)| {
                     println!("bindings before add_constraint: ");
                     for val in self.binding_manager.variables() {
-                        println!("{:?}",
-                            self.variable_state(&val));
+                        println!("{:?}", self.variable_state(&val));
                     }
                     self.add_constraint(&constraint)?;
                     println!("bindings after add_constraint: ");
                     for val in self.binding_manager.variables() {
-                        println!("{val} {:?}",
-                            self.variable_state(&val), val=val);
+                        println!("{val} {:?}", self.variable_state(&val), val = val);
                         if let VariableState::Partial(p) = self.variable_state(&val) {
                             println!("formatted {}", p.to_polar());
                         }
@@ -1490,7 +1488,7 @@ impl PolarVirtualMachine {
                         }
                         // TODO should this one be allowed?
                         //VariableState::Partial(e) => {
-                            //return Err(self.type_error(&left, format!("Can only assign to unbound variables, {} is bound to expression {}.", var.to_polar(), e.to_polar())));
+                        //    return Err(self.type_error(&left, format!("Can only assign to unbound variables, {} is bound to expression {}.", var.to_polar(), e.to_polar())));
                         //}
                         _ => {
                             self.push_goal(Goal::Unify { left, right })?;
@@ -2072,8 +2070,10 @@ impl PolarVirtualMachine {
                             self.push_goal(Goal::Backtrack)?;
                         }
                     }
-                    _ => if self.bind(var, right).is_err() {
-                        self.push_goal(Goal::Backtrack)?;
+                    _ => {
+                        if self.bind(var, right).is_err() {
+                            self.push_goal(Goal::Backtrack)?;
+                        }
                     }
                 }
             }
@@ -2090,8 +2090,10 @@ impl PolarVirtualMachine {
                             self.push_goal(Goal::Backtrack)?;
                         }
                     }
-                    _ => if self.bind(var, left).is_err() {
-                        self.push_goal(Goal::Backtrack)?;
+                    _ => {
+                        if self.bind(var, left).is_err() {
+                            self.push_goal(Goal::Backtrack)?;
+                        }
                     }
                 }
             }
@@ -2509,7 +2511,8 @@ impl PolarVirtualMachine {
                         // This is done here for safety to avoid a bug where `answer` is unbound by
                         // `IsSubspecializer` and the `Unify` Goal just assigns it to `true` instead
                         // of checking that is is equal to `true`.
-                        self.bind(&answer, Term::new_temporary(Value::Boolean(false))).unwrap();
+                        self.bind(&answer, Term::new_temporary(Value::Boolean(false)))
+                            .unwrap();
 
                         return self.append_goals(vec![
                             Goal::IsSubspecializer {
@@ -3446,7 +3449,8 @@ mod tests {
         });
         let query = query!(call!("bar", [sym!("x")]));
         let mut vm = PolarVirtualMachine::new_test(Arc::new(RwLock::new(kb)), false, vec![query]);
-        vm.bind(&sym!("x"), Term::new_from_test(external_instance)).unwrap();
+        vm.bind(&sym!("x"), Term::new_from_test(external_instance))
+            .unwrap();
 
         let mut external_isas = vec![];
 

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -654,11 +654,6 @@ impl PolarVirtualMachine {
         self.binding_manager.bind(var, val);
     }
 
-    /// Bind each variable that occurs in a constraint to the constraint.
-    fn constrain(&mut self, o: &Operation) -> PolarResult<()> {
-        self.binding_manager.constrain(o)
-    }
-
     pub fn add_binding_follower(&mut self) -> FollowerId {
         self.binding_manager.add_follower(BindingManager::new())
     }
@@ -687,13 +682,6 @@ impl PolarVirtualMachine {
             self.bind(var, value.clone());
         }
         self.csp = self.bsp();
-    }
-
-    // TODO(dhatch): Would like to replace this with bindings_after, but for now
-    // new cycles are transferred through this and get destroyed without it.
-    // This is leaky.
-    pub fn bindings_for_inverter(&self) -> BindingStack {
-        self.binding_manager.bindings_debug().clone()
     }
 
     /// Retrieve the current non-constant bindings as a hash map.
@@ -1489,12 +1477,10 @@ impl PolarVirtualMachine {
                 // Query in a sub-VM and invert the results.
                 assert_eq!(args.len(), 1);
                 let term = args.pop().unwrap();
-                let bindings = Rc::new(RefCell::new(BindingStack::new()));
                 let add_constraints = Rc::new(RefCell::new(Bindings::new()));
                 let inverter = Box::new(Inverter::new(
                     self,
                     vec![Goal::Query { term }],
-                    bindings.clone(),
                     add_constraints.clone(),
                     self.bsp(),
                 ));

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -7,7 +7,7 @@ use std::string::ToString;
 use std::sync::{Arc, RwLock};
 
 use super::visitor::{walk_term, Visitor};
-use crate::bindings::{Binding, BindingManager, BindingStack, Bindings, Bsp, VariableState};
+use crate::bindings::{Binding, BindingManager, BindingStack, Bindings, Bsp, VariableState, FollowerId};
 use crate::counter::Counter;
 use crate::debugger::{DebugEvent, Debugger};
 use crate::error::{self, PolarResult};
@@ -628,6 +628,14 @@ impl PolarVirtualMachine {
     /// Bind each variable that occurs in a constraint to the constraint.
     fn constrain(&mut self, o: &Operation) -> PolarResult<()> {
         self.binding_manager.constrain(o)
+    }
+
+    fn add_binding_follower(&mut self) -> FollowerId {
+        self.binding_manager.add_follower(BindingManager::new())
+    }
+
+    fn remove_binding_follower(&mut self, follower_id: FollowerId) -> Option<BindingManager> {
+        self.binding_manager.remove_follower(&follower_id)
     }
 
     /// Add a single constraint operation to the variables referenced in it.

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -172,16 +172,6 @@ impl std::ops::DerefMut for GoalStack {
 
 pub type Queries = TermList;
 
-/// Represent each binding in a cycle as a unification constraint.
-// TODO(gj): put this in an impl block on VariableState?
-pub fn cycle_constraints(cycle: Vec<Symbol>) -> Operation {
-    let mut constraints = op!(And);
-    for (x, y) in cycle.iter().zip(cycle.iter().skip(1)) {
-        constraints.add_constraint(op!(Unify, term!(x.clone()), term!(y.clone())));
-    }
-    constraints
-}
-
 // TODO(ap): don't panic.
 pub fn compare(op: Operator, left: &Term, right: &Term) -> bool {
     // Coerce booleans to integers.

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -493,25 +493,26 @@ impl PolarVirtualMachine {
             }
             Goal::Unify { left, right } => self.unify(&left, &right)?,
             Goal::AddConstraint { term } => self.add_constraint(&term)?,
-            Goal::AddConstraintsBatch { add_constraints } => add_constraints
-                .borrow_mut()
-                .drain()
-                .try_for_each(|(_, constraint)| -> PolarResult<()> {
-                    println!("bindings before add_constraint: ");
-                    for val in self.binding_manager.variables() {
-                        println!("{:?}", self.variable_state(&val));
-                    }
-                    self.add_constraint(&constraint)?;
-                    println!("bindings after add_constraint: ");
-                    for val in self.binding_manager.variables() {
-                        println!("{val} {:?}", self.variable_state(&val), val = val);
-                        if let VariableState::Partial(p) = self.variable_state(&val) {
-                            println!("formatted {}", p.to_polar());
+            Goal::AddConstraintsBatch { add_constraints } => {
+                add_constraints.borrow_mut().drain().try_for_each(
+                    |(_, constraint)| -> PolarResult<()> {
+                        println!("bindings before add_constraint: ");
+                        for val in self.binding_manager.variables() {
+                            println!("{:?}", self.variable_state(&val));
                         }
-                    }
+                        self.add_constraint(&constraint)?;
+                        println!("bindings after add_constraint: ");
+                        for val in self.binding_manager.variables() {
+                            println!("{val} {:?}", self.variable_state(&val), val = val);
+                            if let VariableState::Partial(p) = self.variable_state(&val) {
+                                println!("formatted {}", p.to_polar());
+                            }
+                        }
 
-                    Ok(())
-                })?,
+                        Ok(())
+                    },
+                )?
+            }
             Goal::Run { runnable } => return self.run_runnable(runnable.clone_runnable()),
         }
         Ok(QueryEvent::None)

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -665,7 +665,6 @@ impl PolarVirtualMachine {
     /// Add a single constraint operation to the variables referenced in it.
     /// Precondition: Operation is either binary or ternary (binary + result var),
     /// and at least one of the first two arguments is an unbound variable.
-    #[allow(clippy::many_single_char_names)]
     fn add_constraint(&mut self, term: &Term) -> PolarResult<()> {
         if self.log {
             self.print(&format!("⇒ add_constraint: {}", term.to_polar()));
@@ -847,16 +846,16 @@ impl PolarVirtualMachine {
             .query_start_time
             .expect("Query start time not recorded");
 
-         if now - start_time > self.query_timeout {
-             return Err(error::RuntimeError::QueryTimeout {
-                 msg: format!(
-                     "Query running for {}. Exceeded query timeout of {} seconds",
-                     (now - start_time).as_secs(),
-                     self.query_timeout.as_secs()
-                 ),
-             }
-             .into());
-         }
+        if now - start_time > self.query_timeout {
+            return Err(error::RuntimeError::QueryTimeout {
+                msg: format!(
+                    "Query running for {}. Exceeded query timeout of {} seconds",
+                    (now - start_time).as_secs(),
+                    self.query_timeout.as_secs()
+                ),
+            }
+            .into());
+        }
 
         Ok(())
     }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -681,7 +681,7 @@ impl PolarVirtualMachine {
 
     /// Investigate the current state of a variable and return a variable state variant.
     pub fn variable_state(&self, variable: &Symbol) -> VariableState {
-        self.binding_manager.variable_state(variable)
+        self.binding_manager.variable_state_new(variable)
     }
 
     /// Recursively dereference variables in a term, including subterms, except operations.

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -135,7 +135,7 @@ pub enum Goal {
 #[derive(Clone, Debug)]
 pub struct Choice {
     pub alternatives: Vec<GoalStack>,
-    bsp: usize,            // binding stack pointer
+    bsp: Bsp,              // binding stack pointer
     pub goals: GoalStack,  // goal stack snapshot
     queries: Queries,      // query stack snapshot
     trace: Vec<Rc<Trace>>, // trace snapshot

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2177,7 +2177,6 @@ impl PolarVirtualMachine {
 
     /// Unify two variables. May produce new bindings, `Unify` goals,
     /// or unification constraints.
-    #[allow(clippy::many_single_char_names)]
     fn unify_vars(&mut self, left: &Term, right: &Term) -> PolarResult<()> {
         let l = left.value().as_symbol().expect("variable");
         let r = right.value().as_symbol().expect("variable");

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -1514,9 +1514,9 @@ impl PolarVirtualMachine {
                             return Err(self.type_error(&left, format!("Can only assign to unbound variables, {} is bound to value {}.", var.to_polar(), value.to_polar())));
                         }
                         // TODO should this one be allowed?
-                        VariableState::Partial(e) => {
-                            return Err(self.type_error(&left, format!("Can only assign to unbound variables, {} is bound to expression {}.", var.to_polar(), e.to_polar())));
-                        }
+                        //VariableState::Partial(e) => {
+                            //return Err(self.type_error(&left, format!("Can only assign to unbound variables, {} is bound to expression {}.", var.to_polar(), e.to_polar())));
+                        //}
                         _ => {
                             self.push_goal(Goal::Unify { left, right })?;
                         }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -516,14 +516,14 @@ impl PolarVirtualMachine {
                     println!("bindings before add_constraint: ");
                     for val in self.binding_manager.variables() {
                         println!("{:?}",
-                            self.binding_manager.variable_state(&val));
+                            self.variable_state(&val));
                     }
                     self.add_constraint(&constraint);
                     println!("bindings after add_constraint: ");
                     for val in self.binding_manager.variables() {
                         println!("{val} {:?}",
-                            self.binding_manager.variable_state(&val), val=val);
-                        if let VariableState::Partial(p) = self.binding_manager.variable_state(&val) {
+                            self.variable_state(&val), val=val);
+                        if let VariableState::Partial(p) = self.variable_state(&val) {
                             println!("formatted {}", p.to_polar());
                         }
                     }
@@ -705,7 +705,7 @@ impl PolarVirtualMachine {
 
     /// Investigate the state of a variable at some point and return a variable state variant.
     pub fn variable_state_at_point(&self, variable: &Symbol, bsp: Bsp) -> VariableState {
-        self.binding_manager.variable_state_at_point(variable, bsp)
+        self.binding_manager.variable_state_new_at_point(variable, bsp)
     }
 
     /// Investigate the current state of a variable and return a variable state variant.

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -704,12 +704,12 @@ impl PolarVirtualMachine {
 
     /// Investigate the state of a variable at some point and return a variable state variant.
     pub fn variable_state_at_point(&self, variable: &Symbol, bsp: Bsp) -> VariableState {
-        self.binding_manager.variable_state_new_at_point(variable, bsp)
+        self.binding_manager.variable_state_at_point(variable, bsp)
     }
 
     /// Investigate the current state of a variable and return a variable state variant.
     pub fn variable_state(&self, variable: &Symbol) -> VariableState {
-        self.binding_manager.variable_state_new(variable)
+        self.binding_manager.variable_state(variable)
     }
 
     /// Recursively dereference variables in a term, including subterms, except operations.
@@ -1130,7 +1130,6 @@ impl PolarVirtualMachine {
                     VariableState::Partial(expr) => expr,
                     // This branch is unneeded. A cycle variable has no constraints,
                     // so lhs of matches below will return None.
-                    VariableState::Cycle(c) => cycle_constraints(c),
                     _ => panic!("Invariant violated. left must be a variable"),
                 };
 

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -786,6 +786,7 @@ fn test_non_instance_specializers() -> TestResult {
 }
 
 #[test]
+#[allow(clippy::unnecessary_wraps)]
 fn test_bindings() -> TestResult {
     let mut p = Polar::new();
 
@@ -1934,6 +1935,7 @@ fn test_list_matches() {
 }
 
 #[test]
+#[allow(clippy::unnecessary_wraps)]
 fn error_on_binding_expressions_and_patterns_to_variables() -> TestResult {
     qruntime!(
         "x matches y",

--- a/polar-wasm-api/src/errors.rs
+++ b/polar-wasm-api/src/errors.rs
@@ -36,6 +36,7 @@ fn kind(err: &PolarError) -> String {
         Runtime(Application { .. }) => "RuntimeError::Application",
         Runtime(ArithmeticError { .. }) => "RuntimeError::ArithmeticError",
         Runtime(FileLoading { .. }) => "RuntimeError::FileLoading",
+        Runtime(IncompatibleBindings { .. }) => "RuntimeError::IncompatibleBindings",
         Runtime(QueryTimeout { .. }) => "RuntimeError::QueryTimeout",
         Runtime(Serialization { .. }) => "RuntimeError::Serialization",
         Runtime(StackOverflow { .. }) => "RuntimeError::StackOverflow",


### PR DESCRIPTION
This changes adds a concept of _followers_ to the binding manager. A binding manager may be mutated with:

- `add_constraint`
- `bind`
- `backtrack`

If a binding manager has a follower, the same operations will be forwarded to the follower.  This is used by the inverter to collect the new set of bindings made during the inverted query, and then invert them.  

This replaces the previous implementation of the inverter that used the internal bindings data structure (`BindingStack`) to get this information.

I considered adding an `after` method to the binding manager that does the opposite of `backtrack` and removes operations that occurred before a certain `bsp` instead of this, but the implementation was pretty challenging to get correct, because the data available is not the sequence of operations (`add_constraint`, `bind`, `backtrack`), but the internal bindings (`x => y`).  To implement this correctly, you'd need to analyze the binding stack and figure out in a binding represented an extension of a cycle, a new cycle, or joining cycles. The same would be needed for partials (a new partial or extending an existing partial).

PR checklist:

- [x] Finish some cleanup, including making `VariableState::Cycle` an internal-only state in the binding manager, by having two separate variable state enums.
- [ ] Add tests to binding manager now that interface is complete.
- [x] Have `bind` return an error if the new binding is incompatible with the existing set of constraints on the variable. (Right now grounding happens twice, once in the VM, and again when binding).
- [ ] Remove debugging prints
- [x] Determine if we can remove the ability to rebind variables, which really shouldn't be possible. We use this to provide defaults for some external results right now. Rebinding can lose information with the current implementation (if variables are bound in a cycle, then grounded, rebinding one of them may cause others to change).
- [ ] Added changelog entry.