### PR TITLE
Fix docs requirements 

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -122,7 +122,10 @@ deps-test:
 # in release mode, this means they should be installed
 # from the wheels
 check-deps:
-	python3 -c "import pkg_resources; pkg_resources.require(open('requirements-docs-test.txt'))"
+	pip3 show oso
+	pip3 show django-oso
+	pip3 show flask-oso
+	pip3 show sqlalchemy-oso
 
 submodules:
 	git submodule update --checkout --init --recursive --remote

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -50,10 +50,10 @@ _api_docs: _api_docs/ruby _api_docs/java _api_docs/js/node
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-html doctest spelling: Makefile deps _api_docs submodules
+html doctest spelling: Makefile deps deps_test _api_docs submodules
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-build: Makefile deps _api_docs submodules
+build: Makefile deps check-deps _api_docs submodules
 	@DOCS_RELEASE=1 $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 clean:
@@ -114,6 +114,18 @@ test: doctest
 
 deps:
 	pip3 install -r requirements-docs.txt
+
+deps-test:
+	pip3 install -r requirements-docs-test.txt
+
+# Check that all the dependencies have been installed
+# in release mode, this means they should be installed
+# from the wheels
+check-deps:
+	pip3 show oso
+	pip3 show django-oso
+	pip3 show flask-oso
+	pip3 show sqlalchemy-oso
 
 submodules:
 	git submodule update --checkout --init --recursive --remote

--- a/docs/requirements-docs-test.txt
+++ b/docs/requirements-docs-test.txt
@@ -1,0 +1,5 @@
+# needed for API docs
+-e ../languages/python/oso
+-e ../languages/python/django-oso
+-e ../languages/python/flask-oso
+-e ../languages/python/sqlalchemy-oso[flask]

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -10,9 +10,4 @@ sphinx-copybutton
 sphinx-material
 # Temporary fix
 git+https://github.com/samscott89/sphinx-notfound-page@master
-# needed for API docs
--e ../languages/python/oso
--e ../languages/python/django-oso
--e ../languages/python/flask-oso
--e ../languages/python/sqlalchemy-oso[flask]
 django~=2.2


### PR DESCRIPTION
Previously we ran tests and implicitly assumed deps were installed before

Then we made this better (in some ways) so that we would install these.

But installing these clashes with how we produce the built docs.

So this PR makes the split more explicit.