### PR TITLE
Performance Improvements

### DIFF
--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -78,7 +78,7 @@ impl Inverter {
 fn results_to_constraints(results: Vec<BindingManager>) -> Bindings {
     let inverted = results.into_iter().map(invert_partials).collect();
     let reduced = reduce_constraints(inverted);
-    let simplified = simplify_bindings(reduced).unwrap_or_else(Bindings::new);
+    let simplified = simplify_bindings(reduced, true).unwrap_or_else(Bindings::new);
 
     simplified
         .into_iter()
@@ -106,7 +106,7 @@ fn invert_partials(bindings: BindingManager) -> Bindings {
         new_bindings.insert(var.clone(), term!(constraint));
     }
 
-    let simplified = simplify_bindings(new_bindings).unwrap_or_else(Bindings::new);
+    let simplified = simplify_bindings(new_bindings, true).unwrap_or_else(Bindings::new);
 
     simplified
         .into_iter()

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::bindings::Bindings;
 use crate::folder::{fold_operation, fold_term, Folder};
@@ -94,7 +94,7 @@ pub fn simplify_partial(var: &Symbol, term: Term) -> Term {
 ///
 /// - For partials, simplify the constraint expressions.
 /// - For non-partials, deep deref. TODO(ap/gj): deep deref.
-pub fn simplify_bindings(bindings: Bindings) -> Option<Bindings> {
+pub fn simplify_bindings(bindings: Bindings, all: bool) -> Option<Bindings> {
     let mut unsatisfiable = false;
     let mut simplify = |var: Symbol, term: Term| {
         let simplified = simplify_partial(&var, term);
@@ -102,34 +102,109 @@ pub fn simplify_bindings(bindings: Bindings) -> Option<Bindings> {
             Ok(o) if o == &FALSE => unsatisfiable = true,
             _ => (),
         }
-        simplified
+        let mut symbols = HashSet::new();
+        simplified.variables(&mut symbols);
+        (simplified, symbols)
     };
 
-    let bindings: Bindings = bindings
-        .iter()
-        .map(|(var, value)| match value.value() {
-            Value::Expression(o) => {
-                assert_eq!(o.operator, Operator::And);
-                (var.clone(), simplify(var.clone(), value.clone()))
+    let mut simplified_bindings = HashMap::new();
+    if all {
+        for (var, value) in &bindings {
+            match value.value() {
+                Value::Expression(o) => {
+                    assert_eq!(o.operator, Operator::And);
+                    let (simplified, _) = simplify(var.clone(), value.clone());
+                    simplified_bindings.insert(var.clone(), simplified)
+                }
+                Value::Variable(v) | Value::RestVariable(v)
+                    if v.is_temporary_var()
+                        && bindings.contains_key(v)
+                        && matches!(
+                            bindings[v].value(),
+                            Value::Variable(_) | Value::RestVariable(_)
+                        ) =>
+                {
+                    simplified_bindings.insert(var.clone(), bindings[v].clone())
+                }
+                _ => simplified_bindings.insert(var.clone(), value.clone()),
+            };
+        }
+    } else {
+        let mut referenced_vars: VecDeque<Symbol> = VecDeque::new();
+        for (var, value) in &bindings {
+            if !var.is_temporary_var() {
+                match value.value() {
+                    Value::Expression(o) => {
+                        assert_eq!(o.operator, Operator::And);
+                        let (simplified, mut symbols) = simplify(var.clone(), value.clone());
+                        simplified_bindings.insert(var.clone(), simplified);
+                        referenced_vars.extend(symbols.drain());
+                    }
+                    Value::Variable(v) | Value::RestVariable(v)
+                        if v.is_temporary_var()
+                            && bindings.contains_key(v)
+                            && matches!(
+                                bindings[v].value(),
+                                Value::Variable(_) | Value::RestVariable(_)
+                            ) =>
+                    {
+                        let mut symbols = HashSet::new();
+                        let simplified = bindings[v].clone();
+                        simplified.variables(&mut symbols);
+                        simplified_bindings.insert(var.clone(), simplified);
+                        referenced_vars.extend(symbols.drain());
+                    }
+                    _ => {
+                        let mut symbols = HashSet::new();
+                        let simplified = value.clone();
+                        simplified.variables(&mut symbols);
+                        simplified_bindings.insert(var.clone(), simplified);
+                        referenced_vars.extend(symbols.drain());
+                    }
+                };
             }
-            Value::Variable(v) | Value::RestVariable(v)
-                if v.is_temporary_var()
-                    && bindings.contains_key(v)
-                    && matches!(
-                        bindings[v].value(),
-                        Value::Variable(_) | Value::RestVariable(_)
-                    ) =>
-            {
-                (var.clone(), bindings[v].clone())
+        }
+        while let Some(var) = referenced_vars.pop_front() {
+            if !simplified_bindings.contains_key(&var) {
+                if let Some(value) = bindings.get(&var) {
+                    match value.value() {
+                        Value::Expression(o) => {
+                            assert_eq!(o.operator, Operator::And);
+                            let (simplified, mut symbols) = simplify(var.clone(), value.clone());
+                            simplified_bindings.insert(var.clone(), simplified);
+                            referenced_vars.extend(symbols.drain());
+                        }
+                        Value::Variable(v) | Value::RestVariable(v)
+                            if v.is_temporary_var()
+                                && bindings.contains_key(v)
+                                && matches!(
+                                    bindings[v].value(),
+                                    Value::Variable(_) | Value::RestVariable(_)
+                                ) =>
+                        {
+                            let mut symbols = HashSet::new();
+                            let simplified = bindings[v].clone();
+                            simplified.variables(&mut symbols);
+                            simplified_bindings.insert(var.clone(), simplified);
+                            referenced_vars.extend(symbols.drain());
+                        }
+                        _ => {
+                            let mut symbols = HashSet::new();
+                            let simplified = value.clone();
+                            simplified.variables(&mut symbols);
+                            simplified_bindings.insert(var.clone(), simplified);
+                            referenced_vars.extend(symbols.drain());
+                        }
+                    };
+                }
             }
-            _ => (var.clone(), value.clone()),
-        })
-        .collect();
+        }
+    };
 
     if unsatisfiable {
         None
     } else {
-        Some(bindings)
+        Some(simplified_bindings)
     }
 }
 

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -350,15 +350,16 @@ impl Simplifier {
 
     /// Simplify a partial until quiescence.
     pub fn simplify_partial(&mut self, mut term: Term) -> Term {
-        let mut new;
+        let mut before = term.hash_value();
         loop {
-            new = self.fold_term(term.clone());
-            if new == term {
+            term = self.fold_term(term);
+            let after = term.hash_value();
+            if before == after {
                 break;
             }
-            term = new;
+            before = after;
             self.bindings.clear();
         }
-        new
+        term
     }
 }

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -268,6 +268,101 @@ impl Folder for Simplifier {
             // Non-trivial conjunctions. Choose a unification constraint to
             // make a binding from, maybe throw it away, and fold the rest.
             Operator::And if o.args.len() > 1 => {
+                let mut cycles: Vec<HashSet<Symbol>> = vec![];
+                let mut unifies: Vec<usize> = o
+                    .constraints()
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, constraint)| {
+                        // Collect up unifies to prune out cycles.
+                        match constraint.operator {
+                            Operator::Unify | Operator::Eq => {
+                                let left = &constraint.args[0];
+                                let right = &constraint.args[1];
+                                match (left.value(), right.value()) {
+                                    _ if self.is_dot_this(left) || self.is_dot_this(right) => false,
+                                    // Both sides are variables, but neither is _this. Bind together.
+                                    (Value::Variable(l), Value::Variable(r))
+                                    | (Value::Variable(l), Value::RestVariable(r))
+                                    | (Value::RestVariable(l), Value::Variable(r))
+                                    | (Value::RestVariable(l), Value::RestVariable(r)) => {
+                                        let mut added = false;
+                                        for cycle in &mut cycles {
+                                            if cycle.contains(&l) {
+                                                cycle.insert(r.clone());
+                                                added = true;
+                                                break;
+                                            }
+                                            if cycle.contains(&r) {
+                                                cycle.insert(l.clone());
+                                                added = true;
+                                                break;
+                                            }
+                                        }
+                                        if !added {
+                                            let mut new_cycle = HashSet::new();
+                                            new_cycle.insert(r.clone());
+                                            new_cycle.insert(l.clone());
+                                            cycles.push(new_cycle);
+                                        }
+                                        true
+                                    }
+                                    _ => false,
+                                }
+                            }
+                            _ => false,
+                        }
+                    })
+                    .map(|(i, _)| i)
+                    .collect();
+
+                // Combine cycles.
+                let mut joined_cycles: Vec<HashSet<Symbol>> = vec![];
+                for new_cycle in cycles {
+                    let mut joined = false;
+                    for cycle in &mut joined_cycles {
+                        if !cycle.is_disjoint(&new_cycle) {
+                            cycle.extend(new_cycle.clone().into_iter());
+                            joined = true;
+                            break;
+                        }
+                    }
+                    if !joined {
+                        joined_cycles.push(new_cycle);
+                    }
+                }
+
+                // This is the part where we don't really know what to do.
+                // how do we bind these guys?
+                for cycle in joined_cycles {
+                    // Get any symbol in the cycle. Prefer a non temp one.
+                    let mut set_first = false;
+                    let mut cycle_sym = Symbol("".to_owned());
+                    for symbol in &cycle {
+                        if !set_first {
+                            cycle_sym = symbol.clone();
+                            set_first = true;
+                        }
+                        if !symbol.is_temporary_var() {
+                            cycle_sym = symbol.clone();
+                            break;
+                        }
+                    }
+
+                    let cycle_term = term!(cycle_sym.clone());
+
+                    for symbol in cycle {
+                        if symbol != cycle_sym {
+                            self.bind(symbol, cycle_term.clone());
+                        }
+                    }
+                }
+
+                unifies.reverse();
+                for i in unifies {
+                    o.args.remove(i);
+                }
+
                 if let Some(i) = o.constraints().iter().position(|constraint| {
                     let other_constraints = o.clone_with_constraints(
                         o.constraints()

--- a/polar-core/src/terms.rs
+++ b/polar-core/src/terms.rs
@@ -1,6 +1,7 @@
 use super::sources::SourceInfo;
 pub use super::{error, formatting::ToPolarString};
 use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -341,6 +342,12 @@ impl Term {
         } else {
             None
         }
+    }
+
+    pub fn hash_value(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
     }
 }
 

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2705,7 +2705,7 @@ impl Runnable for PolarVirtualMachine {
 
         let mut bindings = self.bindings(true);
         if !self.inverting {
-            if let Some(bs) = simplify_bindings(bindings) {
+            if let Some(bs) = simplify_bindings(bindings, false) {
                 bindings = bs;
             } else {
                 return Ok(QueryEvent::None);


### PR DESCRIPTION
This pr includes 4 different performance improvements that I did while profiling and digging into the slow parts of this query. 
https://github.com/saolsen/oso-casemgmt-django/blob/steve/perf/casemgmt/management/commands/slow_query.py

1) When simplifying a partial we get a lot of unifications of temp vars. This is because we bind a lot of new temp vars when we call methods and rules and those all get gathered up. 
Expressions end up looking like `a = b and b = c and c = d and d = e and e = f...`
Before in the simplifier we could only clean up one of these every loop which meant we looped a lot of times. I added a way to detect all these cycles in one pass so we can clean up big expressions like that in one iteration instead of n. This approximately halved the amount of times around the simplifier loop we went for the queries I was investigating.

2) When we simplify bindings we simplify ALL the bindings. There will be a binding for every temporary variable in the expressions (which, as we saw from the previous problem, is a lot). We only care about variables that are not temp, and temp variables that are used in expressions bound to non temp variables so instead of simplifying all the bindings I made it simplify bindings in dependency order, starting with the non temp ones and then simplifying any temp ones that are needed after that. This change reduced the total number of expressions simplified (for the query in question) from 80 to 37.

3) In the simplifier main loop we clone the current value, simplify the clone, check if they are equal and if they are we stop simplifying. This clone is expensive so now we just hash the term, simplify it, and compare the new hash to the old one to see if we're done. Not cloning the whole expression every step speeds things up.

4) When derefing vars (a thing that happens a lot!) the vm has to ask the binding manager what state a variable is in. The binding manager returns an enum of the variables state. The creation of that enum, in the partial case, contains a clone of an expression which is a pretty slow operation. In deref however, the vm only cares if the variable is bound or not, so it just throws away that cloned value. In the query I was looking at there were 67,000 clones of expressions that were not used. I added a way for the vm to ask its actual question (is this variable bound to anything?) so we can avoid those clones in all those cases where we don't need them.

These four things together speed up the query in question (for me on my computer) from ~0.24 seconds to ~0.09 seconds. 