### PR TITLE
avoid cloning value being simplified

### DIFF
--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -350,15 +350,16 @@ impl Simplifier {
 
     /// Simplify a partial until quiescence.
     pub fn simplify_partial(&mut self, mut term: Term) -> Term {
-        let mut new;
+        let mut before = term.hash_value();
         loop {
-            new = self.fold_term(term.clone());
-            if new == term {
+            term = self.fold_term(term);
+            let after = term.hash_value();
+            if before == after {
                 break;
             }
-            term = new;
+            before = after;
             self.bindings.clear();
         }
-        new
+        term
     }
 }

--- a/polar-core/src/terms.rs
+++ b/polar-core/src/terms.rs
@@ -1,6 +1,7 @@
 use super::sources::SourceInfo;
 pub use super::{error, formatting::ToPolarString};
 use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -341,6 +342,12 @@ impl Term {
         } else {
             None
         }
+    }
+
+    pub fn hash_value(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
     }
 }
 


### PR DESCRIPTION
In the simplifier main loop we clone the current value, simplify the clone, check if they are equal and if they are we stop simplifying. This clone is expensive so now we just hash the term, simplify it, and compare the new hash to the old one to see if we're done. Not cloning the whole expression every step speeds things up.