### PR TITLE
only check if bound in deref

### DIFF
--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -327,7 +327,7 @@ impl PolarVirtualMachine {
 
         impl<'vm> Visitor for VarVisitor<'vm> {
             fn visit_variable(&mut self, v: &Symbol) {
-                if matches!(self.vm.variable_state(v), VariableState::Partial(_)) {
+                if matches!(self.vm.variable_state(v), VariableState::Partial()) {
                     self.has_partial = true;
                 }
             }
@@ -1084,13 +1084,9 @@ impl PolarVirtualMachine {
                 // involving a particular variable.
                 // TODO(gj): Ensure `op!(And) matches X{}` doesn't die after these changes.
                 let var = left.value().as_symbol()?;
+
                 // Get the existing partial on the LHS variable.
-                let partial = match self.variable_state(var) {
-                    VariableState::Partial(expr) => expr,
-                    // This branch is unneeded. A cycle variable has no constraints,
-                    // so lhs of matches below will return None.
-                    _ => panic!("Invariant violated. left must be a variable"),
-                };
+                let partial = self.binding_manager.get_constraints(var);
 
                 let simplified = simplify_partial(var, partial.into_term());
                 let simplified = simplified.value().as_expression()?;


### PR DESCRIPTION
When derefing vars (a thing that happens a lot!) the vm has to ask the binding manager what state a variable is in. The binding manager returns an enum of the variables state. The creation of that enum, in the partial case, contains a clone of an expression which is a pretty slow operation. In deref however, the vm only cares if the variable is bound or not, so it just throws away that cloned value. In the query I was looking at there were 67,000 clones of expressions that were not used. I added a way for the vm to ask its actual question (is this variable bound to anything?) so we can avoid those clones in all those cases where we don't need them.