### PR TITLE
simplify in dependency order

### DIFF
--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -78,7 +78,7 @@ impl Inverter {
 fn results_to_constraints(results: Vec<BindingManager>) -> Bindings {
     let inverted = results.into_iter().map(invert_partials).collect();
     let reduced = reduce_constraints(inverted);
-    let simplified = simplify_bindings(reduced).unwrap_or_else(Bindings::new);
+    let simplified = simplify_bindings(reduced, true).unwrap_or_else(Bindings::new);
 
     simplified
         .into_iter()
@@ -106,7 +106,7 @@ fn invert_partials(bindings: BindingManager) -> Bindings {
         new_bindings.insert(var.clone(), term!(constraint));
     }
 
-    let simplified = simplify_bindings(new_bindings).unwrap_or_else(Bindings::new);
+    let simplified = simplify_bindings(new_bindings, true).unwrap_or_else(Bindings::new);
 
     simplified
         .into_iter()

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::bindings::Bindings;
 use crate::folder::{fold_operation, fold_term, Folder};
@@ -94,7 +94,7 @@ pub fn simplify_partial(var: &Symbol, term: Term) -> Term {
 ///
 /// - For partials, simplify the constraint expressions.
 /// - For non-partials, deep deref. TODO(ap/gj): deep deref.
-pub fn simplify_bindings(bindings: Bindings) -> Option<Bindings> {
+pub fn simplify_bindings(bindings: Bindings, all: bool) -> Option<Bindings> {
     let mut unsatisfiable = false;
     let mut simplify = |var: Symbol, term: Term| {
         let simplified = simplify_partial(&var, term);
@@ -102,34 +102,109 @@ pub fn simplify_bindings(bindings: Bindings) -> Option<Bindings> {
             Ok(o) if o == &FALSE => unsatisfiable = true,
             _ => (),
         }
-        simplified
+        let mut symbols = HashSet::new();
+        simplified.variables(&mut symbols);
+        (simplified, symbols)
     };
 
-    let bindings: Bindings = bindings
-        .iter()
-        .map(|(var, value)| match value.value() {
-            Value::Expression(o) => {
-                assert_eq!(o.operator, Operator::And);
-                (var.clone(), simplify(var.clone(), value.clone()))
+    let mut simplified_bindings = HashMap::new();
+    if all {
+        for (var, value) in &bindings {
+            match value.value() {
+                Value::Expression(o) => {
+                    assert_eq!(o.operator, Operator::And);
+                    let (simplified, _) = simplify(var.clone(), value.clone());
+                    simplified_bindings.insert(var.clone(), simplified)
+                }
+                Value::Variable(v) | Value::RestVariable(v)
+                    if v.is_temporary_var()
+                        && bindings.contains_key(v)
+                        && matches!(
+                            bindings[v].value(),
+                            Value::Variable(_) | Value::RestVariable(_)
+                        ) =>
+                {
+                    simplified_bindings.insert(var.clone(), bindings[v].clone())
+                }
+                _ => simplified_bindings.insert(var.clone(), value.clone()),
+            };
+        }
+    } else {
+        let mut referenced_vars: VecDeque<Symbol> = VecDeque::new();
+        for (var, value) in &bindings {
+            if !var.is_temporary_var() {
+                match value.value() {
+                    Value::Expression(o) => {
+                        assert_eq!(o.operator, Operator::And);
+                        let (simplified, mut symbols) = simplify(var.clone(), value.clone());
+                        simplified_bindings.insert(var.clone(), simplified);
+                        referenced_vars.extend(symbols.drain());
+                    }
+                    Value::Variable(v) | Value::RestVariable(v)
+                        if v.is_temporary_var()
+                            && bindings.contains_key(v)
+                            && matches!(
+                                bindings[v].value(),
+                                Value::Variable(_) | Value::RestVariable(_)
+                            ) =>
+                    {
+                        let mut symbols = HashSet::new();
+                        let simplified = bindings[v].clone();
+                        simplified.variables(&mut symbols);
+                        simplified_bindings.insert(var.clone(), simplified);
+                        referenced_vars.extend(symbols.drain());
+                    }
+                    _ => {
+                        let mut symbols = HashSet::new();
+                        let simplified = value.clone();
+                        simplified.variables(&mut symbols);
+                        simplified_bindings.insert(var.clone(), simplified);
+                        referenced_vars.extend(symbols.drain());
+                    }
+                };
             }
-            Value::Variable(v) | Value::RestVariable(v)
-                if v.is_temporary_var()
-                    && bindings.contains_key(v)
-                    && matches!(
-                        bindings[v].value(),
-                        Value::Variable(_) | Value::RestVariable(_)
-                    ) =>
-            {
-                (var.clone(), bindings[v].clone())
+        }
+        while let Some(var) = referenced_vars.pop_front() {
+            if !simplified_bindings.contains_key(&var) {
+                if let Some(value) = bindings.get(&var) {
+                    match value.value() {
+                        Value::Expression(o) => {
+                            assert_eq!(o.operator, Operator::And);
+                            let (simplified, mut symbols) = simplify(var.clone(), value.clone());
+                            simplified_bindings.insert(var.clone(), simplified);
+                            referenced_vars.extend(symbols.drain());
+                        }
+                        Value::Variable(v) | Value::RestVariable(v)
+                            if v.is_temporary_var()
+                                && bindings.contains_key(v)
+                                && matches!(
+                                    bindings[v].value(),
+                                    Value::Variable(_) | Value::RestVariable(_)
+                                ) =>
+                        {
+                            let mut symbols = HashSet::new();
+                            let simplified = bindings[v].clone();
+                            simplified.variables(&mut symbols);
+                            simplified_bindings.insert(var.clone(), simplified);
+                            referenced_vars.extend(symbols.drain());
+                        }
+                        _ => {
+                            let mut symbols = HashSet::new();
+                            let simplified = value.clone();
+                            simplified.variables(&mut symbols);
+                            simplified_bindings.insert(var.clone(), simplified);
+                            referenced_vars.extend(symbols.drain());
+                        }
+                    };
+                }
             }
-            _ => (var.clone(), value.clone()),
-        })
-        .collect();
+        }
+    };
 
     if unsatisfiable {
         None
     } else {
-        Some(bindings)
+        Some(simplified_bindings)
     }
 }
 

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -96,38 +96,36 @@ pub fn simplify_partial(var: &Symbol, term: Term) -> Term {
 /// - For non-partials, deep deref. TODO(ap/gj): deep deref.
 pub fn simplify_bindings(bindings: Bindings, all: bool) -> Option<Bindings> {
     let mut unsatisfiable = false;
-    let mut simplify_var = |bindings: &Bindings, var: &Symbol, value: &Term| {
-        match value.value() {
-            Value::Expression(o) => {
-                assert_eq!(o.operator, Operator::And);
-                let simplified = simplify_partial(var, value.clone());
-                match simplified.value().as_expression() {
-                    Ok(o) if o == &FALSE => unsatisfiable = true,
-                    _ => (),
-                }
-                let mut symbols = HashSet::new();
-                simplified.variables(&mut symbols);
-                (simplified, symbols)
+    let mut simplify_var = |bindings: &Bindings, var: &Symbol, value: &Term| match value.value() {
+        Value::Expression(o) => {
+            assert_eq!(o.operator, Operator::And);
+            let simplified = simplify_partial(var, value.clone());
+            match simplified.value().as_expression() {
+                Ok(o) if o == &FALSE => unsatisfiable = true,
+                _ => (),
             }
-            Value::Variable(v) | Value::RestVariable(v)
+            let mut symbols = HashSet::new();
+            simplified.variables(&mut symbols);
+            (simplified, symbols)
+        }
+        Value::Variable(v) | Value::RestVariable(v)
             if v.is_temporary_var()
                 && bindings.contains_key(v)
                 && matches!(
-                                    bindings[v].value(),
-                                    Value::Variable(_) | Value::RestVariable(_)
-                                ) =>
-                {
-                    let mut symbols = HashSet::new();
-                    let simplified = bindings[v].clone();
-                    simplified.variables(&mut symbols);
-                    (simplified, symbols)
-                }
-            _ => {
-                let mut symbols = HashSet::new();
-                let simplified = value.clone();
-                simplified.variables(&mut symbols);
-                (simplified, symbols)
-            }
+                    bindings[v].value(),
+                    Value::Variable(_) | Value::RestVariable(_)
+                ) =>
+        {
+            let mut symbols = HashSet::new();
+            let simplified = bindings[v].clone();
+            simplified.variables(&mut symbols);
+            (simplified, symbols)
+        }
+        _ => {
+            let mut symbols = HashSet::new();
+            let simplified = value.clone();
+            simplified.variables(&mut symbols);
+            (simplified, symbols)
         }
     };
 

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2705,7 +2705,7 @@ impl Runnable for PolarVirtualMachine {
 
         let mut bindings = self.bindings(true);
         if !self.inverting {
-            if let Some(bs) = simplify_bindings(bindings) {
+            if let Some(bs) = simplify_bindings(bindings, false) {
                 bindings = bs;
             } else {
                 return Ok(QueryEvent::None);


### PR DESCRIPTION
When we simplify bindings we simplify ALL the bindings. There will be a binding for every temporary variable in the expressions. We only care about variables that are not temp, and temp variables that are used in expressions bound to non temp variables so instead of simplifying all the bindings I made it simplify bindings in dependency order, starting with the non temp ones and then simplifying any temp ones that are needed after that. This change reduced the total number of expressions simplified (for the query I was looking at) from 80 to 37.