### PR TITLE
don't use the folder for simplifier

### DIFF
--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -335,7 +335,7 @@ impl Simplifier {
                     *o = operation.clone();
                     self.simplify_operation(o);
                 }
-                _ => unreachable!(),
+                _ => (),
             },
 
             // Non-trivial conjunctions. Choose a unification constraint to
@@ -420,6 +420,7 @@ impl Simplifier {
                 Value::Expression(operation) => {
                     self.simplify_operation(operation);
                 }
+                // If it's not in the matches above, it's not in here
                 _ => unreachable!(),
             }
         }

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -5,7 +5,6 @@ use crate::folder::{fold_operation, fold_term, Folder};
 use crate::terms::{Operation, Operator, Symbol, Term, Value};
 
 use super::partial::{invert_operation, FALSE, TRUE};
-use crate::formatting::to_polar::ToPolarString;
 
 
 struct VariableSubber {
@@ -85,9 +84,7 @@ pub fn simplify_partial(var: &Symbol, term: Term) -> Term {
     let mut simplifier = Simplifier::new(var.clone());
     let mut simplified = term.clone();
     simplifier.simplify_partial(&mut simplified);
-    //eprintln!("after simplier: {}", simplified);
     let simplified = simplify_trivial_constraint(var.clone(), simplified);
-    //eprintln!("after trivial_constrant: {}", simplified);
     if matches!(simplified.value(), Value::Expression(e) if e.operator != Operator::And) {
         op!(And, simplified).into_term()
     } else {

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -330,13 +330,12 @@ impl Simplifier {
             Operator::And | Operator::Or if o.args.is_empty() => (),
 
             // Replace one-argument conjunctions & disjunctions with their argument.
-            Operator::And | Operator::Or if o.args.len() == 1 => match o.args[0].value() {
-                Value::Expression(operation) => {
+            Operator::And | Operator::Or if o.args.len() == 1 => {
+                if let Value::Expression(operation) = o.args[0].value() {
                     *o = operation.clone();
                     self.simplify_operation(o);
                 }
-                _ => (),
-            },
+            }
 
             // Non-trivial conjunctions. Choose a unification constraint to
             // make a binding from, maybe throw it away, and fold the rest.

--- a/polar-core/src/partial/simplify.rs
+++ b/polar-core/src/partial/simplify.rs
@@ -436,41 +436,18 @@ impl Simplifier {
 
             // Non-trivial conjunctions. Choose a unification constraint to
             // make a binding from, maybe throw it away, and fold the rest.
-            // Operator::And if o.args.len() > 1 => {
-            //     if let Some(i) = o.args.iter().position(|c| {
-            //         let op = c.value().as_expression().unwrap();
-            //         let variables = o.args.iter()
-            //             .map(|d| d.value().as_expression().unwrap())
-            //             .filter(|inner_op| *inner_op != op)
-            //             .map(|t| t.variables())
-            //             .fold(vec![], |mut vars, mut op_vars| {
-            //                 vars.append(&mut op_vars);
-            //                 vars
-            //             });
-            //         self.maybe_bind_constraint(op, variables)
-            //     }) {
-            //         o.args.remove(i);
-            //     }
-            //     // fold operation
-            //     for arg in &mut o.args {
-            //         self.simplify_term(arg);
-            //     }
-            // }
-
             Operator::And if o.args.len() > 1 => {
-                if let Some(i) = o.constraints().iter().position(|constraint| {
-                    let other_constraints = o.clone_with_constraints(
-                        o.constraints()
-                            .into_iter()
-                            .filter(|r| r != constraint)
-                            .collect(),
-                    );
-                    let variables = other_constraints.variables();
-                    let yes = self.maybe_bind_constraint(constraint, variables);
-                    // if yes {
-                    //     eprintln!("bind away {}", constraint.to_polar());
-                    // }
-                    yes
+                if let Some(i) = o.args.iter().position(|c| {
+                    let op = c.value().as_expression().unwrap();
+                    let variables = o.args.iter()
+                        .map(|d| d.value().as_expression().unwrap())
+                        .filter(|inner_op| *inner_op != op)
+                        .map(|t| t.variables())
+                        .fold(vec![], |mut vars, mut op_vars| {
+                            vars.append(&mut op_vars);
+                            vars
+                        });
+                    self.maybe_bind_constraint(op, variables)
                 }) {
                     o.args.remove(i);
                 }

--- a/polar-core/src/terms.rs
+++ b/polar-core/src/terms.rs
@@ -1,6 +1,7 @@
 use super::sources::SourceInfo;
 pub use super::{error, formatting::ToPolarString};
 use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -310,6 +311,14 @@ impl Term {
         &self.value
     }
 
+    /// Get a mutable reference to the underlying data.
+    /// This will be a real mut pointer if there is only one
+    /// term with an Arc to the value, otherwise it will be
+    /// a clone.
+    pub fn mut_value(&mut self) -> &mut Value {
+        Arc::make_mut(&mut self.value)
+    }
+
     pub fn is_ground(&self) -> bool {
         self.value().is_ground()
     }
@@ -333,6 +342,12 @@ impl Term {
         }
 
         walk_term(&mut VariableVisitor::new(vars), self);
+    }
+
+    pub fn hash_value(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
     }
 
     pub fn get_source_id(&self) -> Option<u64> {


### PR DESCRIPTION
The folder was doing too many clones and slowing things down a lot.
Rewrote the simplifier to just directly walk the term, mutating things as it simplifies.
(this pattern is probably useful elsewhere so we could think about later pulling it out as a `mut_visitor`)

This made it about twice as fast as the version with the folder, didn't break any tests in the process :)