### PR TITLE
Avoid double-escaping Polar code blocks in the docs

### DIFF
--- a/new-docs/themes/oso-webpack/index.js
+++ b/new-docs/themes/oso-webpack/index.js
@@ -163,7 +163,7 @@ import('monaco-editor-core').then(monaco => {
     for (let i = 0; i < polarCode.length; i++) {
       let el = polarCode[i];
       monaco.editor
-        .colorize(el.innerHTML, 'polar', { theme: 'polarTheme' })
+        .colorize(el.innerText, 'polar', { theme: 'polarTheme' })
         .then(colored => {
           el.innerHTML = colored;
           el.parentNode.classList.add('polar-code-in-here');


### PR DESCRIPTION
Use `innerText` when highlighting Polar code blocks to avoid double-escaping special characters.

This fixes an issue where the Polar code blocks in the docs were being
escaped twice - once by Hugo, and another time by Monaco. By using
`innerText` instead of `innerHTML`, the code blocks are unescaped, so Monaco
can format and re-escape it.

**Before**

![Screenshot_2021-02-24 Polar Syntax](https://user-images.githubusercontent.com/139487/109083898-c5496d00-76d4-11eb-8258-e81614316f1a.png)

**After**

![Screenshot_2021-02-24 Polar Syntax(1)](https://user-images.githubusercontent.com/139487/109083906-caa6b780-76d4-11eb-8bc0-abe7d74e8bcd.png)

I think this is the right place to apply this, but I definitely was tracing my way through the build process.