### PR TITLE
Additional tests for list filtering parity.

### DIFF
--- a/languages/python/django-oso/tests/test_app2/models.py
+++ b/languages/python/django-oso/tests/test_app2/models.py
@@ -25,10 +25,11 @@ class Tag(AuthorizedModel):
 
 class Post(AuthorizedModel):
     contents = models.CharField(max_length=255)
+    title = models.CharField(max_length=255)
     access_level = models.CharField(
         choices=[(c, c) for c in ["public", "private"]], max_length=7, default="private"
     )
-    created_by = models.ForeignKey(User, on_delete=models.CASCADE)
+    created_by = models.ForeignKey(User, on_delete=models.CASCADE, null=True)
     needs_moderation = models.BooleanField(default=False)
     tags = models.ManyToManyField(Tag)
 

--- a/languages/python/django-oso/tests/test_partial_parity.py
+++ b/languages/python/django-oso/tests/test_partial_parity.py
@@ -1,0 +1,34 @@
+"""Partial parity tests based on
+
+https://www.notion.so/osohq/Supported-Query-Types-and-Features-435d7a998dc14db3a125c6e5ba5fe6ba.
+"""
+import pytest
+
+from django_oso.models import authorize_model
+from django_oso.oso import Oso, reset_oso
+from test_app2.models import Post, Tag, User
+
+
+@pytest.fixture(autouse=True)
+def reset():
+    reset_oso()
+
+@pytest.mark.django_db
+def test_field_comparison():
+    post0 = Post(id=0, contents="private post", title="not private post")
+    post1 = Post(id=1, contents="private post", title="private post")
+    post2 = Post(id=2, contents="post", title="post")
+
+    post0.save()
+    post1.save()
+    post2.save()
+
+    Oso.load_str("""
+        allow(_, _, post: test_app2::Post) if
+            post.title = post.contents;
+    """)
+
+    posts = Post.objects.authorize(None, actor="u", action="r").all()
+    assert len(posts) == 2
+    assert post1 in posts
+    assert post2 in posts

--- a/languages/python/django-oso/tests/test_partial_parity.py
+++ b/languages/python/django-oso/tests/test_partial_parity.py
@@ -13,6 +13,7 @@ from test_app2.models import Post, Tag, User
 def reset():
     reset_oso()
 
+
 @pytest.mark.xfail(reason="Not supported yet.")
 @pytest.mark.django_db
 def test_field_comparison():
@@ -24,10 +25,12 @@ def test_field_comparison():
     post1.save()
     post2.save()
 
-    Oso.load_str("""
+    Oso.load_str(
+        """
         allow(_, _, post: test_app2::Post) if
             post.title = post.contents;
-    """)
+    """
+    )
 
     posts = Post.objects.authorize(None, actor="u", action="r").all()
     assert len(posts) == 2
@@ -45,10 +48,12 @@ def test_scalar_in_list():
     post1.save()
     post2.save()
 
-    Oso.load_str("""
+    Oso.load_str(
+        """
         allow(_, _, post: test_app2::Post) if
             post.contents in ["post", "allowed posts"];
-    """)
+    """
+    )
 
     posts = Post.objects.authorize(None, actor="u", action="r").all()
     assert len(posts) == 2
@@ -72,10 +77,12 @@ def test_ground_object_in_collection():
     post2.tags.set([tag])
 
     Oso.register_constant(tag, "allowed_tag")
-    Oso.load_str("""
+    Oso.load_str(
+        """
         allow(_, _, post: test_app2::Post) if
             allowed_tag in post.tags;
-    """)
+    """
+    )
 
     posts = Post.objects.authorize(None, actor="u", action="r").all()
     assert len(posts) == 2
@@ -108,10 +115,12 @@ def test_all_objects_collection_condition(oso, engine):
     post3.tags.set([public_tag])
     post4.tags.set([private_tag])
 
-    oso.load_str("""
+    oso.load_str(
+        """
         allow(_, _, post: test_app2::Post) if
             forall(tag in post.tags, tag.is_public = true);
-    """)
+    """
+    )
 
     posts = Post.objects.authorize(None, actor="u", action="r").all()
     assert len(posts) == 2
@@ -144,10 +153,12 @@ def test_no_objects_collection_condition():
     post3.tags.set([public_tag])
     post4.tags.set([private_tag])
 
-    Oso.load_str("""
+    Oso.load_str(
+        """
         allow(_, _, post: test_app2::Post) if
             not (tag in post.tags and tag.is_public = true);
-    """)
+    """
+    )
 
     posts = Post.objects.authorize(None, actor="u", action="r").all()
     assert len(posts) == 2

--- a/languages/python/django-oso/tests/test_partial_parity.py
+++ b/languages/python/django-oso/tests/test_partial_parity.py
@@ -4,9 +4,8 @@ https://www.notion.so/osohq/Supported-Query-Types-and-Features-435d7a998dc14db3a
 """
 import pytest
 
-from django_oso.models import authorize_model
 from django_oso.oso import Oso, reset_oso
-from test_app2.models import Post, Tag, User
+from test_app2.models import Post, Tag
 
 
 @pytest.fixture(autouse=True)

--- a/languages/python/django-oso/tests/test_partial_parity.py
+++ b/languages/python/django-oso/tests/test_partial_parity.py
@@ -13,6 +13,7 @@ from test_app2.models import Post, Tag, User
 def reset():
     reset_oso()
 
+@pytest.mark.xfail(reason="Not supported yet.")
 @pytest.mark.django_db
 def test_field_comparison():
     post0 = Post(id=0, contents="private post", title="not private post")
@@ -32,3 +33,123 @@ def test_field_comparison():
     assert len(posts) == 2
     assert post1 in posts
     assert post2 in posts
+
+
+@pytest.mark.django_db
+def test_scalar_in_list():
+    post0 = Post(id=0, contents="private post", title="not private post")
+    post1 = Post(id=1, contents="allowed posts", title="private post")
+    post2 = Post(id=2, contents="post", title="post")
+
+    post0.save()
+    post1.save()
+    post2.save()
+
+    Oso.load_str("""
+        allow(_, _, post: test_app2::Post) if
+            post.contents in ["post", "allowed posts"];
+    """)
+
+    posts = Post.objects.authorize(None, actor="u", action="r").all()
+    assert len(posts) == 2
+    assert post1 in posts
+    assert post2 in posts
+
+
+@pytest.mark.django_db
+def test_ground_object_in_collection():
+    tag = Tag(name="tag")
+    post0 = Post(id=0, contents="tag post")
+    post1 = Post(id=1, contents="no tag post")
+    post2 = Post(id=2, contents="tag 2 post")
+
+    tag.save()
+    post0.save()
+    post1.save()
+    post2.save()
+
+    post0.tags.set([tag])
+    post2.tags.set([tag])
+
+    Oso.register_constant(tag, "allowed_tag")
+    Oso.load_str("""
+        allow(_, _, post: test_app2::Post) if
+            allowed_tag in post.tags;
+    """)
+
+    posts = Post.objects.authorize(None, actor="u", action="r").all()
+    assert len(posts) == 2
+    assert post0 in posts
+    assert post2 in posts
+
+
+@pytest.mark.xfail(reason="Negate in not supported yet.")
+@pytest.mark.django_db
+def test_all_objects_collection_condition(oso, engine):
+    public_tag = Tag(name="public", is_public=True)
+    private_tag = Tag(name="private", is_public=False)
+
+    post0 = Post(id=0, contents="public tag", tags=[public_tag])
+    post1 = Post(id=1, contents="no tags", tags=[])
+    post2 = Post(id=2, contents="both tags", tags=[public_tag, private_tag])
+    post3 = Post(id=3, contents="public tag 2", tags=[public_tag])
+    post4 = Post(id=4, contents="private tag", tags=[private_tag])
+
+    public_tag.save()
+    private_tag.save()
+    post0.save()
+    post1.save()
+    post2.save()
+    post3.save()
+    post4.save()
+
+    post0.tags.set([public_tag])
+    post2.tags.set([public_tag, private_tag])
+    post3.tags.set([public_tag])
+    post4.tags.set([private_tag])
+
+    oso.load_str("""
+        allow(_, _, post: test_app2::Post) if
+            forall(tag in post.tags, tag.is_public = true);
+    """)
+
+    posts = Post.objects.authorize(None, actor="u", action="r").all()
+    assert len(posts) == 2
+    assert post0 in posts
+    assert post3 in posts
+
+
+@pytest.mark.xfail(reason="Negate in not supported yet.")
+@pytest.mark.django_db
+def test_no_objects_collection_condition():
+    public_tag = Tag(name="public", is_public=True)
+    private_tag = Tag(name="private", is_public=False)
+
+    post0 = Post(id=0, contents="public tag", tags=[public_tag])
+    post1 = Post(id=1, contents="no tags", tags=[])
+    post2 = Post(id=2, contents="both tags", tags=[public_tag, private_tag])
+    post3 = Post(id=3, contents="public tag 2", tags=[public_tag])
+    post4 = Post(id=4, contents="private tag", tags=[private_tag])
+
+    public_tag.save()
+    private_tag.save()
+    post0.save()
+    post1.save()
+    post2.save()
+    post3.save()
+    post4.save()
+
+    post0.tags.set([public_tag])
+    post2.tags.set([public_tag, private_tag])
+    post3.tags.set([public_tag])
+    post4.tags.set([private_tag])
+
+    Oso.load_str("""
+        allow(_, _, post: test_app2::Post) if
+            not (tag in post.tags and tag.is_public = true);
+    """)
+
+    posts = Post.objects.authorize(None, actor="u", action="r").all()
+    assert len(posts) == 2
+    assert post0 in posts
+    assert post3 in posts

--- a/languages/python/django-oso/tests/test_post_relationship.py
+++ b/languages/python/django-oso/tests/test_post_relationship.py
@@ -416,7 +416,7 @@ def tag_nested_many_many_fixtures():
         "random_post": random_post,
         "not_tagged_post": not_tagged_post,
         "all_tagged_post": all_tagged_post,
-        "other_tagged_post": other_tagged_post
+        "other_tagged_post": other_tagged_post,
     }
     for post in posts.values():
         post.save()
@@ -427,8 +427,15 @@ def tag_nested_many_many_fixtures():
     other_tagged_post.tags.set([other])
     all_tagged_post.tags.set([eng, user_posts, random])
 
-    user.posts.set([user_eng_post, user_user_post, not_tagged_post, all_tagged_post,
-                    other_tagged_post])
+    user.posts.set(
+        [
+            user_eng_post,
+            user_user_post,
+            not_tagged_post,
+            all_tagged_post,
+            other_tagged_post,
+        ]
+    )
     other_user.posts.set([random_post])
 
     return posts

--- a/languages/python/django-oso/tests/test_post_relationship.py
+++ b/languages/python/django-oso/tests/test_post_relationship.py
@@ -518,7 +518,8 @@ def test_many_many_with_other_condition(tag_nested_many_many_fixtures):
     user = User.objects.get(username="user")
     posts = Post.objects.authorize(None, actor=user, action="read")
     expected = f"""
-       SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title", "test_app2_post"."access_level",
+       SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title",
+              "test_app2_post"."access_level",
               "test_app2_post"."created_by_id", "test_app2_post"."needs_moderation"
        FROM "test_app2_post"
        WHERE "test_app2_post"."id" IN
@@ -555,7 +556,8 @@ def test_empty_constraints_in(tag_nested_many_many_fixtures):
     posts = Post.objects.filter(authorize_filter).distinct()
     expected = f"""
         SELECT DISTINCT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title",
-                        "test_app2_post"."access_level", "test_app2_post"."created_by_id", "test_app2_post"."needs_moderation"
+                        "test_app2_post"."access_level", "test_app2_post"."created_by_id",
+                        "test_app2_post"."needs_moderation"
         FROM "test_app2_post"
         WHERE "test_app2_post"."id" IN
             (SELECT V0."id"

--- a/languages/python/django-oso/tests/test_post_relationship.py
+++ b/languages/python/django-oso/tests/test_post_relationship.py
@@ -501,7 +501,7 @@ def test_many_many_with_other_condition(tag_nested_many_many_fixtures):
     user = User.objects.get(username="user")
     posts = Post.objects.authorize(None, actor=user, action="read")
     expected = f"""
-       SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."access_level",
+       SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title", "test_app2_post"."access_level",
               "test_app2_post"."created_by_id", "test_app2_post"."needs_moderation"
        FROM "test_app2_post"
        WHERE "test_app2_post"."id" IN
@@ -537,7 +537,7 @@ def test_empty_constraints_in(tag_nested_many_many_fixtures):
     authorize_filter = authorize_model(None, Post, actor=user, action="read")
     posts = Post.objects.filter(authorize_filter).distinct()
     expected = f"""
-        SELECT DISTINCT "test_app2_post"."id", "test_app2_post"."contents",
+        SELECT DISTINCT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title",
                         "test_app2_post"."access_level", "test_app2_post"."created_by_id", "test_app2_post"."needs_moderation"
         FROM "test_app2_post"
         WHERE "test_app2_post"."id" IN
@@ -565,7 +565,7 @@ def test_in_with_constraints_but_no_matching_objects(tag_nested_many_many_fixtur
     user = User.objects.get(username="user")
     posts = Post.objects.authorize(None, actor=user, action="read")
     expected = f"""
-        SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."access_level",
+        SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title", "test_app2_post"."access_level",
                "test_app2_post"."created_by_id", "test_app2_post"."needs_moderation"
         FROM "test_app2_post"
         WHERE "test_app2_post"."id" IN (SELECT W0."id"
@@ -602,7 +602,7 @@ def test_reverse_many_relationship(tag_nested_many_many_fixtures):
     )
     posts = Post.objects.filter(authorize_filter)
     expected = """
-        SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."access_level",
+        SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title", "test_app2_post"."access_level",
                "test_app2_post"."created_by_id", "test_app2_post"."needs_moderation"
         FROM "test_app2_post"
         INNER JOIN "test_app2_user_posts" ON ("test_app2_post"."id" = "test_app2_user_posts"."post_id")
@@ -628,7 +628,7 @@ def test_deeply_nested_in(tag_nested_many_many_fixtures):
     authorize_filter = authorize_model(None, Post, actor=user, action="read")
     posts = Post.objects.filter(authorize_filter).distinct()
     expected = """
-        SELECT DISTINCT "test_app2_post"."id", "test_app2_post"."contents",
+        SELECT DISTINCT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title",
                         "test_app2_post"."access_level", "test_app2_post"."created_by_id",
                         "test_app2_post"."needs_moderation"
         FROM "test_app2_post"
@@ -679,7 +679,7 @@ def test_unify_ins(tag_nested_many_many_fixtures):
     authorize_filter = authorize_model(None, Post, actor=user, action="read")
     posts = Post.objects.filter(authorize_filter)
     expected = """
-        SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."access_level",
+        SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title", "test_app2_post"."access_level",
                "test_app2_post"."created_by_id", "test_app2_post"."needs_moderation"
         FROM "test_app2_post"
         LEFT OUTER JOIN "test_app2_user_posts" ON ("test_app2_post"."id" = "test_app2_user_posts"."post_id")
@@ -750,7 +750,7 @@ def test_in_intersection(tag_nested_many_many_fixtures):
     authorize_filter = authorize_model(None, Post, actor=user, action="read")
     posts = Post.objects.filter(authorize_filter)
     expected = f"""
-        SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."access_level",
+        SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title", "test_app2_post"."access_level",
                "test_app2_post"."created_by_id", "test_app2_post"."needs_moderation"
         FROM "test_app2_post"
         WHERE "test_app2_post"."id"
@@ -792,7 +792,7 @@ def test_redundant_in_on_same_field(tag_nested_many_many_fixtures):
     posts = Post.objects.filter(authorize_filter)
     expected = f"""
 
-        SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."access_level",
+        SELECT "test_app2_post"."id", "test_app2_post"."contents", "test_app2_post"."title", "test_app2_post"."access_level",
                "test_app2_post"."created_by_id", "test_app2_post"."needs_moderation"
         FROM "test_app2_post"
         WHERE "test_app2_post"."id" IN (SELECT V0."id"

--- a/languages/python/django-oso/tests/test_post_relationship.py
+++ b/languages/python/django-oso/tests/test_post_relationship.py
@@ -371,6 +371,8 @@ def tag_nested_many_many_fixtures():
     other_user = User(username="other_user")
     other_user.save()
 
+    other = Tag(name="other tag")
+    other.save()
     eng = Tag(name="eng")
     eng.save()
     eng.users.set([user])
@@ -402,6 +404,11 @@ def tag_nested_many_many_fixtures():
         access_level="public",
         created_by=user,
     )
+    other_tagged_post = Post(
+        contents="other tagged post",
+        access_level="public",
+        created_by=user,
+    )
 
     posts = {
         "user_eng_post": user_eng_post,
@@ -409,6 +416,7 @@ def tag_nested_many_many_fixtures():
         "random_post": random_post,
         "not_tagged_post": not_tagged_post,
         "all_tagged_post": all_tagged_post,
+        "other_tagged_post": other_tagged_post
     }
     for post in posts.values():
         post.save()
@@ -416,9 +424,11 @@ def tag_nested_many_many_fixtures():
     user_eng_post.tags.set([eng])
     user_user_post.tags.set([user_posts])
     random_post.tags.set([random])
+    other_tagged_post.tags.set([other])
     all_tagged_post.tags.set([eng, user_posts, random])
 
-    user.posts.set([user_eng_post, user_user_post, not_tagged_post, all_tagged_post])
+    user.posts.set([user_eng_post, user_user_post, not_tagged_post, all_tagged_post,
+                    other_tagged_post])
     other_user.posts.set([random_post])
 
     return posts
@@ -549,7 +559,7 @@ def test_empty_constraints_in(tag_nested_many_many_fixtures):
                           WHERE U0."id" = {parenthesize('V1."tag_id"')}){is_true()})
     """
     assert str(posts.query) == " ".join(expected.split())
-    assert len(posts) == 4
+    assert len(posts) == 5
     assert tag_nested_many_many_fixtures["not_tagged_post"] not in posts
 
 
@@ -609,7 +619,7 @@ def test_reverse_many_relationship(tag_nested_many_many_fixtures):
         WHERE "test_app2_user_posts"."user_id" = 1
     """
     assert str(posts.query) == " ".join(expected.split())
-    assert len(posts) == 4
+    assert len(posts) == 5
 
 
 @pytest.mark.xfail(reason="Cannot compare items across subqueries.")

--- a/languages/python/sqlalchemy-oso/tests/models.py
+++ b/languages/python/sqlalchemy-oso/tests/models.py
@@ -67,6 +67,7 @@ class Post(ModelBase):
 
     id = Column(Integer, primary_key=True)
     contents = Column(String)
+    title = Column(String)
     access_level = Column(Enum("public", "private"), nullable=False, default="private")
 
     created_by_id = Column(Integer, ForeignKey("users.id"))

--- a/languages/python/sqlalchemy-oso/tests/models.py
+++ b/languages/python/sqlalchemy-oso/tests/models.py
@@ -66,7 +66,7 @@ post_users = Table(
     "post_users",
     ModelBase.metadata,
     Column("post_id", Integer, ForeignKey("posts.id")),
-    Column("user_id", Integer, ForeignKey("users.id"))
+    Column("user_id", Integer, ForeignKey("users.id")),
 )
 
 

--- a/languages/python/sqlalchemy-oso/tests/models.py
+++ b/languages/python/sqlalchemy-oso/tests/models.py
@@ -62,6 +62,14 @@ user_tags = Table(
 )
 
 
+post_users = Table(
+    "post_users",
+    ModelBase.metadata,
+    Column("post_id", Integer, ForeignKey("posts.id")),
+    Column("user_id", Integer, ForeignKey("users.id"))
+)
+
+
 class Post(ModelBase):
     __tablename__ = "posts"
 
@@ -72,6 +80,8 @@ class Post(ModelBase):
 
     created_by_id = Column(Integer, ForeignKey("users.id"))
     created_by = relationship("User", backref="posts")
+
+    users = relationship("User", secondary=post_users)
 
     needs_moderation = Column(Boolean, nullable=False, default=False)
 

--- a/languages/python/sqlalchemy-oso/tests/test_partial_parity.py
+++ b/languages/python/sqlalchemy-oso/tests/test_partial_parity.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from sqlalchemy_oso.session import AuthorizedSession
+
+from .models import User, Post
+
+
+def test_field_comparison(oso, engine):
+    post0 = Post(id=0, contents="private post", title="not private post")
+    post1 = Post(id=1, contents="private post", title="private post")
+    post2 = Post(id=2, contents="post", title="post")
+
+    session = Session(bind=engine)
+    session.add_all([post0, post1, post2])
+    session.commit()
+
+    oso.load_str("""
+        allow(_, _, post: Post) if
+            post.title = post.contents;
+    """)
+
+    authz_session = AuthorizedSession(oso=oso, user="u", action="a")
+    posts = authz_session.query(Post).all()
+    post_ids = [p.id for p in posts]
+
+    assert len(posts) == 2
+    assert 1 in post_ids
+    assert 2 in post_ids

--- a/languages/python/sqlalchemy-oso/tests/test_partial_parity.py
+++ b/languages/python/sqlalchemy-oso/tests/test_partial_parity.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 
 from sqlalchemy_oso.session import AuthorizedSession
 
-from .models import User, Post, Tag
+from .models import Post, Tag
 
 
 @pytest.mark.xfail(reason="Not supported yet.")

--- a/languages/python/sqlalchemy-oso/tests/test_partial_parity.py
+++ b/languages/python/sqlalchemy-oso/tests/test_partial_parity.py
@@ -1,10 +1,13 @@
+import pytest
+
 from sqlalchemy.orm import Session
 
 from sqlalchemy_oso.session import AuthorizedSession
 
-from .models import User, Post
+from .models import User, Post, Tag
 
 
+@pytest.mark.xfail(reason="Not supported yet.")
 def test_field_comparison(oso, engine):
     post0 = Post(id=0, contents="private post", title="not private post")
     post1 = Post(id=1, contents="private post", title="private post")
@@ -19,10 +22,116 @@ def test_field_comparison(oso, engine):
             post.title = post.contents;
     """)
 
-    authz_session = AuthorizedSession(oso=oso, user="u", action="a")
+    authz_session = AuthorizedSession(oso=oso, user="u", action="a", bind=engine)
     posts = authz_session.query(Post).all()
     post_ids = [p.id for p in posts]
 
     assert len(posts) == 2
     assert 1 in post_ids
     assert 2 in post_ids
+
+
+def test_scalar_in_list(oso, engine):
+    post0 = Post(id=0, contents="private post", title="not private post")
+    post1 = Post(id=1, contents="allowed posts", title="private post")
+    post2 = Post(id=2, contents="post", title="post")
+
+    session = Session(bind=engine)
+    session.add_all([post0, post1, post2])
+    session.commit()
+
+    oso.load_str("""
+        allow(_, _, post: Post) if
+            post.contents in ["post", "allowed posts"];
+    """)
+
+    authz_session = AuthorizedSession(oso=oso, user="u", action="a", bind=engine)
+    posts = authz_session.query(Post).all()
+    post_ids = [p.id for p in posts]
+
+    assert len(posts) == 2
+    assert 1 in post_ids
+    assert 2 in post_ids
+
+
+def test_ground_object_in_collection(oso, engine):
+    tag = Tag(name="tag")
+    post0 = Post(id=0, contents="tag post", tags=[tag])
+    post1 = Post(id=1, contents="no tag post", tags=[])
+    post2 = Post(id=2, contents="tag 2 post", tags=[tag])
+
+    session = Session(bind=engine)
+    session.add_all([tag, post0, post1, post2])
+    session.commit()
+
+    oso.register_constant(tag, "allowed_tag")
+    oso.load_str("""
+        allow(_, _, post: Post) if
+            allowed_tag in post.tags;
+    """)
+
+    authz_session = AuthorizedSession(oso=oso, user="u", action="a", bind=engine)
+    posts = authz_session.query(Post).all()
+    post_ids = [p.id for p in posts]
+
+    assert len(posts) == 2
+    assert 0 in post_ids
+    assert 2 in post_ids
+
+
+@pytest.mark.xfail(reason="Negate in not supported yet.")
+def test_all_objects_collection_condition(oso, engine):
+    public_tag = Tag(name="public", is_public=True)
+    private_tag = Tag(name="private", is_public=False)
+
+    post0 = Post(id=0, contents="public tag", tags=[public_tag])
+    post1 = Post(id=1, contents="no tags", tags=[])
+    post2 = Post(id=2, contents="both tags", tags=[public_tag, private_tag])
+    post3 = Post(id=3, contents="public tag 2", tags=[public_tag])
+    post4 = Post(id=4, contents="private tag", tags=[private_tag])
+
+    session = Session(bind=engine)
+    session.add_all([public_tag, private_tag, post0, post1, post2, post3, post4])
+    session.commit()
+
+    oso.load_str("""
+        allow(_, _, post: Post) if
+            forall(tag in post.tags, tag.is_public = true);
+    """)
+
+    authz_session = AuthorizedSession(oso=oso, user="u", action="a", bind=engine)
+    posts = authz_session.query(Post).all()
+    post_ids = [p.id for p in posts]
+
+    assert len(posts) == 2
+    assert 0 in post_ids
+    assert 3 in post_ids
+
+
+@pytest.mark.xfail(reason="Negate in not supported yet.")
+def test_no_objects_collection_condition(oso, engine):
+    public_tag = Tag(name="public", is_public=True)
+    private_tag = Tag(name="private", is_public=False)
+
+    post0 = Post(id=0, contents="public tag", tags=[public_tag])
+    post1 = Post(id=1, contents="no tags", tags=[])
+    post2 = Post(id=2, contents="both tags", tags=[public_tag, private_tag])
+    post3 = Post(id=3, contents="public tag 2", tags=[public_tag])
+    post4 = Post(id=4, contents="private tag", tags=[private_tag])
+
+    session = Session(bind=engine)
+    session.add_all([public_tag, private_tag, post0, post1, post2, post3, post4])
+    session.commit()
+
+    oso.load_str("""
+        allow(_, _, post: Post) if
+            not (tag in post.tags and tag.is_public = true);
+    """)
+
+    authz_session = AuthorizedSession(oso=oso, user="u", action="a", bind=engine)
+    posts = authz_session.query(Post).all()
+    post_ids = [p.id for p in posts]
+
+    assert len(posts) == 2
+    assert 1 in post_ids
+    assert 4 in post_ids

--- a/languages/python/sqlalchemy-oso/tests/test_partial_parity.py
+++ b/languages/python/sqlalchemy-oso/tests/test_partial_parity.py
@@ -17,10 +17,12 @@ def test_field_comparison(oso, engine):
     session.add_all([post0, post1, post2])
     session.commit()
 
-    oso.load_str("""
+    oso.load_str(
+        """
         allow(_, _, post: Post) if
             post.title = post.contents;
-    """)
+    """
+    )
 
     authz_session = AuthorizedSession(oso=oso, user="u", action="a", bind=engine)
     posts = authz_session.query(Post).all()
@@ -40,10 +42,12 @@ def test_scalar_in_list(oso, engine):
     session.add_all([post0, post1, post2])
     session.commit()
 
-    oso.load_str("""
+    oso.load_str(
+        """
         allow(_, _, post: Post) if
             post.contents in ["post", "allowed posts"];
-    """)
+    """
+    )
 
     authz_session = AuthorizedSession(oso=oso, user="u", action="a", bind=engine)
     posts = authz_session.query(Post).all()
@@ -65,10 +69,12 @@ def test_ground_object_in_collection(oso, engine):
     session.commit()
 
     oso.register_constant(tag, "allowed_tag")
-    oso.load_str("""
+    oso.load_str(
+        """
         allow(_, _, post: Post) if
             allowed_tag in post.tags;
-    """)
+    """
+    )
 
     authz_session = AuthorizedSession(oso=oso, user="u", action="a", bind=engine)
     posts = authz_session.query(Post).all()
@@ -94,10 +100,12 @@ def test_all_objects_collection_condition(oso, engine):
     session.add_all([public_tag, private_tag, post0, post1, post2, post3, post4])
     session.commit()
 
-    oso.load_str("""
+    oso.load_str(
+        """
         allow(_, _, post: Post) if
             forall(tag in post.tags, tag.is_public = true);
-    """)
+    """
+    )
 
     authz_session = AuthorizedSession(oso=oso, user="u", action="a", bind=engine)
     posts = authz_session.query(Post).all()
@@ -123,10 +131,12 @@ def test_no_objects_collection_condition(oso, engine):
     session.add_all([public_tag, private_tag, post0, post1, post2, post3, post4])
     session.commit()
 
-    oso.load_str("""
+    oso.load_str(
+        """
         allow(_, _, post: Post) if
             not (tag in post.tags and tag.is_public = true);
-    """)
+    """
+    )
 
     authz_session = AuthorizedSession(oso=oso, user="u", action="a", bind=engine)
     posts = authz_session.query(Post).all()

--- a/languages/python/sqlalchemy-oso/tests/test_post_relationship.py
+++ b/languages/python/sqlalchemy-oso/tests/test_post_relationship.py
@@ -612,7 +612,8 @@ def test_empty_constraints_in(session, oso, tag_nested_many_many_test_fixture):
         authorize_model(oso, user, "read", session, Post)
     )
     assert str(posts) == (
-        "SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.title AS posts_title, posts.access_level AS posts_access_level,"
+        "SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.title AS"
+        + " posts_title, posts.access_level AS posts_access_level,"
         + " posts.created_by_id AS posts_created_by_id, posts.needs_moderation AS posts_needs_moderation"
         + " \nFROM posts"
         + " \nWHERE (EXISTS (SELECT 1"
@@ -639,7 +640,8 @@ def test_in_with_constraints_but_no_matching_objects(
         authorize_model(oso, user, "read", session, Post)
     )
     assert str(posts) == (
-        "SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.title AS posts_title, posts.access_level AS posts_access_level,"
+        "SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.title AS posts_title,"
+        + " posts.access_level AS posts_access_level,"
         + " posts.created_by_id AS posts_created_by_id, posts.needs_moderation AS posts_needs_moderation"
         + " \nFROM posts"
         + " \nWHERE (EXISTS (SELECT 1"

--- a/languages/python/sqlalchemy-oso/tests/test_post_relationship.py
+++ b/languages/python/sqlalchemy-oso/tests/test_post_relationship.py
@@ -594,7 +594,7 @@ def test_empty_constraints_in(session, oso, tag_nested_many_many_test_fixture):
         authorize_model(oso, user, "read", session, Post)
     )
     assert str(posts) == (
-        "SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.access_level AS posts_access_level,"
+        "SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.title AS posts_title, posts.access_level AS posts_access_level,"
         + " posts.created_by_id AS posts_created_by_id, posts.needs_moderation AS posts_needs_moderation"
         + " \nFROM posts"
         + " \nWHERE (EXISTS (SELECT 1"
@@ -621,7 +621,7 @@ def test_in_with_constraints_but_no_matching_objects(
         authorize_model(oso, user, "read", session, Post)
     )
     assert str(posts) == (
-        "SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.access_level AS posts_access_level,"
+        "SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.title AS posts_title, posts.access_level AS posts_access_level,"
         + " posts.created_by_id AS posts_created_by_id, posts.needs_moderation AS posts_needs_moderation"
         + " \nFROM posts"
         + " \nWHERE (EXISTS (SELECT 1"
@@ -686,7 +686,7 @@ def test_deeply_nested_in(session, oso, tag_nested_many_many_test_fixture):
     )
 
     query_str = """
-        SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.access_level AS
+        SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.title AS posts_title, posts.access_level AS
         posts_access_level, posts.created_by_id AS posts_created_by_id, posts.needs_moderation AS
         posts_needs_moderation
         FROM posts

--- a/languages/python/sqlalchemy-oso/tests/test_post_relationship.py
+++ b/languages/python/sqlalchemy-oso/tests/test_post_relationship.py
@@ -346,7 +346,7 @@ def tag_nested_many_many_test_fixture(session):
         contents="other tagged post",
         access_level="public",
         created_by=user,
-        tags=[other]
+        tags=[other],
     )
 
     # HACK!
@@ -357,8 +357,13 @@ def tag_nested_many_many_test_fixture(session):
 
         objects[name] = local
 
-    user.posts += [user_eng_post, user_user_post, not_tagged_post, all_tagged_post,
-                   other_tagged_post]
+    user.posts += [
+        user_eng_post,
+        user_user_post,
+        not_tagged_post,
+        all_tagged_post,
+        other_tagged_post,
+    ]
     other_user.posts += [random_post]
 
     session.commit()
@@ -583,7 +588,8 @@ def test_partial_in_collection(session, oso, tag_nested_many_many_test_fixture):
     assert tag_nested_many_many_test_fixture["random_post"] not in posts
     assert tag_nested_many_many_test_fixture["not_tagged_post"] in posts
     assert tag_nested_many_many_test_fixture["all_tagged_post"] in posts
-    assert len(posts) == 4
+    assert tag_nested_many_many_test_fixture["other_tagged_post"] in posts
+    assert len(posts) == 5
 
     user = tag_nested_many_many_test_fixture["other_user"]
     posts = (
@@ -727,12 +733,14 @@ def test_deeply_nested_in(session, oso, tag_nested_many_many_test_fixture):
 
 @pytest.mark.xfail(reason="Intersection doesn't work in sqlalchemy")
 def test_in_intersection(session, oso, tag_nested_many_many_test_fixture):
-    oso.load_str("""
+    oso.load_str(
+        """
         allow(_, _, post: Post) if
             u in post.users and
             t in post.tags and
             u in t.users;
-    """)
+    """
+    )
 
     posts = session.query(Post).filter(
         authorize_model(oso, "user", "read", session, Post)

--- a/languages/python/sqlalchemy-oso/tests/test_post_relationship.py
+++ b/languages/python/sqlalchemy-oso/tests/test_post_relationship.py
@@ -725,6 +725,7 @@ def test_deeply_nested_in(session, oso, tag_nested_many_many_test_fixture):
     assert posts.count() == 1
 
 
+@pytest.mark.xfail(reason="Intersection doesn't work in sqlalchemy")
 def test_in_intersection(session, oso, tag_nested_many_many_test_fixture):
     oso.load_str("""
         allow(_, _, post: Post) if

--- a/languages/python/sqlalchemy-oso/tests/test_sqlalchemy.py
+++ b/languages/python/sqlalchemy-oso/tests/test_sqlalchemy.py
@@ -274,7 +274,7 @@ def test_null_with_partial(engine, oso):
     posts = Session().query(Post)
 
     assert str(posts) == (
-        "SELECT posts.id AS posts_id, posts.contents AS posts_contents, "
+        "SELECT posts.id AS posts_id, posts.contents AS posts_contents, posts.title AS posts_title, "
         + "posts.access_level AS posts_access_level, posts.created_by_id AS posts_created_by_id, "
         + "posts.needs_moderation AS posts_needs_moderation \nFROM posts \nWHERE posts.contents IS NULL"
     )


### PR DESCRIPTION
This includes tests linked to
https://www.notion.so/osohq/Supported-Query-Types-and-Features-435d7a998dc14db3a125c6e5ba5fe6ba.

I've implemented tests up to the "Partial collection intersects with other
ground list" in the Relationship table. Some tests fail, and are marked
as expected failing. These can serve as test cases when implementing new
operations.