### PR TITLE
Use language-specific isAllowed function name in quickstart guide.

### DIFF
--- a/new-docs/content/any/getting-started/quickstart/index.md
+++ b/new-docs/content/any/getting-started/quickstart/index.md
@@ -92,7 +92,7 @@ resource is an instance of the `Expense` class.
 
 Okay, so what just happened?
 
-When we ask Oso for a policy decision via `Oso.is_allowed()`, the Oso engine
+When we ask Oso for a policy decision via `Oso.{{% exampleGet "isAllowed" %}}()`, the Oso engine
 searches through its knowledge base to determine whether the provided
 **actor**, **action**, and **resource** satisfy any **allow** rules. In the
 above case, we passed in `"alice@example.com"` as the **actor**, `"GET"` as the

--- a/new-docs/content/go/getting-started/quickstart/data/data.md
+++ b/new-docs/content/go/getting-started/quickstart/data/data.md
@@ -22,4 +22,5 @@ expenses1: |
 expenses2: |
   allow(actor: String, "GET", expense: Expense) if
       expense.SubmittedBy = actor;
+isAllowed: IsAllowed
 ---

--- a/new-docs/content/java/getting-started/quickstart/data/data.md
+++ b/new-docs/content/java/getting-started/quickstart/data/data.md
@@ -16,4 +16,5 @@ endswithURL: >
    [the `String.endsWith` method](https://docs.oracle.com/javase/10/docs/api/java/lang/String.html#endsWith(java.lang.String))
 expensesPath1: examples/quickstart/expenses-01-java.polar
 expensesPath2: examples/quickstart/expenses-02-java.polar
+isAllowed: isAllowed
 ---

--- a/new-docs/content/node/getting-started/quickstart/data/data.md
+++ b/new-docs/content/node/getting-started/quickstart/data/data.md
@@ -18,4 +18,5 @@ endswithURL: >
    [the `String.prototype.endsWith` method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith)
 expensesPath1: examples/quickstart/expenses-01-nodejs.polar
 expensesPath2: examples/quickstart/expenses-02-nodejs.polar
+isAllowed: isAllowed
 ---

--- a/new-docs/content/python/getting-started/quickstart/data/data.md
+++ b/new-docs/content/python/getting-started/quickstart/data/data.md
@@ -18,4 +18,5 @@ endswithURL: >
    [the `str.endswith` method](https://docs.python.org/3/library/stdtypes.html#str.endswith)
 expensesPath1: examples/quickstart/expenses-01-python.polar
 expensesPath2: examples/quickstart/expenses-02-python.polar
+isAllowed: is_allowed
 ---

--- a/new-docs/content/ruby/getting-started/quickstart/data/data.md
+++ b/new-docs/content/ruby/getting-started/quickstart/data/data.md
@@ -20,4 +20,5 @@ endswithURL: >
    [the `String#end_with?` method](https://ruby-doc.org/core/String.html#method-i-end_with-3F)
 expensesPath1: examples/quickstart/expenses-01-ruby.polar
 expensesPath2: examples/quickstart/expenses-02-ruby.polar
+isAllowed: allowed?
 ---

--- a/new-docs/content/rust/getting-started/quickstart/data/data.md
+++ b/new-docs/content/rust/getting-started/quickstart/data/data.md
@@ -16,4 +16,5 @@ endswithURL: >
    [the `String::ends_with` method](https://doc.rust-lang.org/std/string/struct.String.html#method.ends_with)
 expensesPath1: examples/quickstart/expenses-01-rust.polar
 expensesPath2: examples/quickstart/expenses-02-rust.polar
+isAllowed: is_allowed
 ---


### PR DESCRIPTION
While getting familiar with the company and product I ran through the Ruby tutorial and was momentarily confused when the quick start section of the docs referred to a call to `is_allowed()` which didn't appear in the sample code. Since the policy page appeared to handle this correctly for the different languages, I copied what was there and added it the to the quick start page. I manually checked the pages in my local env and they all appeared to be working as intended.

Signed-off-by: Pete Higgins <pete@peterhiggins.org>