### PR TITLE
Fix Rust example 'iter()' function

### DIFF
--- a/languages/rust/oso/examples/lib_guide.rs
+++ b/languages/rust/oso/examples/lib_guide.rs
@@ -168,7 +168,7 @@ fn iters() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    oso.load_str(r#"allow(actor, action, resource) if actor.get_group() = "payroll";"#)?;
+    oso.load_str(r#"allow(actor, action, resource) if "payroll" in actor.get_group();"#)?;
 
     let user = User {
         groups: vec!["HR".to_string(), "payroll".to_string()],


### PR DESCRIPTION
The `iter()` function in the Rust language example `lib_guide.rs` was failing (see below). This was caused by incorrect syntax for an iterator in the clause as outlined in the documentation: https://docs.osohq.com/rust/reference/polar/classes.html#iterators

Updating the clause to use the correct syntax seems to fix the issue (thanks @samscott89!)

```
➜  rust git:(main) ✗ RUST_BACKTRACE=1 cargo run --example lib_guide
    Finished dev [unoptimized + debuginfo] target(s) in 0.19s
     Running `/Users/joshrotenberg/GitHub/oso/target/debug/examples/lib_guide`
thread 'main' panicked at 'assertion failed: oso.is_allowed(user, \"foo\", \"bar\")?', languages/rust/oso/examples/lib_guide.rs:176:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/cb75ad5db02783e8b0222fee363c5f63f7e2cf5b/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at /rustc/cb75ad5db02783e8b0222fee363c5f63f7e2cf5b/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/cb75ad5db02783e8b0222fee363c5f63f7e2cf5b/library/core/src/panicking.rs:50:5
   3: lib_guide::iters
             at ./oso/examples/lib_guide.rs:176:5
   4: lib_guide::main
             at ./oso/examples/lib_guide.rs:185:5
   5: core::ops::function::FnOnce::call_once
             at /Users/joshrotenberg/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```


PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
