### PR TITLE
[Rust] Start work on test_oso.rs

### DIFF
--- a/languages/rust/oso/examples/lib_guide.rs
+++ b/languages/rust/oso/examples/lib_guide.rs
@@ -168,7 +168,7 @@ fn iters() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    oso.load_str(r#"allow(actor, action, resource) if actor.get_group() = "payroll";"#)?;
+    oso.load_str(r#"allow(actor, action, resource) if "payroll" in actor.get_group();"#)?;
 
     let user = User {
         groups: vec!["HR".to_string(), "payroll".to_string()],

--- a/languages/rust/oso/tests/test_oso.polar
+++ b/languages/rust/oso/tests/test_oso.polar
@@ -18,5 +18,10 @@ allow(actor: Actor, "create", resource: Company) if
 allow(actor: Actor, "frob", resource: Company) if
     resource in actor.companies();
 
-allow(actor: Actor, "list", Company) if
-    actor.name = "auditor";
+# XXX: test_oso::test_allow_models fails with this, but ...
+#allow(actor: Actor, "list", Company) if
+#   actor.name = "auditor";
+
+# XXX: ... works with this. why?
+allow(actor: Actor, "list", resource: Company) if
+   actor.name = "auditor";

--- a/languages/rust/oso/tests/test_oso.polar
+++ b/languages/rust/oso/tests/test_oso.polar
@@ -18,10 +18,5 @@ allow(actor: Actor, "create", resource: Company) if
 allow(actor: Actor, "frob", resource: Company) if
     resource in actor.companies();
 
-# XXX: test_oso::test_allow_models fails with this, but ...
-#allow(actor: Actor, "list", Company) if
-#   actor.name = "auditor";
-
-# XXX: ... works with this. why?
 allow(actor: Actor, "list", resource: Company) if
    actor.name = "auditor";

--- a/languages/rust/oso/tests/test_oso.polar
+++ b/languages/rust/oso/tests/test_oso.polar
@@ -1,0 +1,22 @@
+allow(actor, action, resource) if
+    allowRole(role, action, resource) and
+    actorInRole(actor, role, resource);
+
+allow(_: {sub: sub}, action, resource) if
+    allow(new Actor(name: sub), action, resource);
+
+allow("guest", action, resource) if
+    allow(new Actor(name: "guest"), action, resource);
+
+allow(_: {username: name}, action, resource) if
+    allow(new Actor(name: name), action, resource);
+
+allow(_actor: Actor, "get", _resource: Widget);
+allow(actor: Actor, "create", resource: Company) if
+    resource.role(actor) = "admin";
+
+allow(actor: Actor, "frob", resource: Company) if
+    resource in actor.companies();
+
+allow(actor: Actor, "list", Company) if
+    actor.name = "auditor";

--- a/languages/rust/oso/tests/test_oso.polar
+++ b/languages/rust/oso/tests/test_oso.polar
@@ -18,5 +18,5 @@ allow(actor: Actor, "create", resource: Company) if
 allow(actor: Actor, "frob", resource: Company) if
     resource in actor.companies();
 
-allow(actor: Actor, "list", resource: Company) if
+allow(actor: Actor, "list", Company) if
    actor.name = "auditor";

--- a/languages/rust/oso/tests/test_oso.rs
+++ b/languages/rust/oso/tests/test_oso.rs
@@ -51,9 +51,9 @@ impl Company {
 
     pub fn role(&self, actor: Actor) -> String {
         if actor.name == "president" {
-            return "admin".to_string();
+            "admin".to_string()
         } else {
-            return "guest".to_string();
+            "guest".to_string()
         }
     }
 }

--- a/languages/rust/oso/tests/test_oso.rs
+++ b/languages/rust/oso/tests/test_oso.rs
@@ -96,28 +96,28 @@ fn test_is_allowed() -> oso::Result<()> {
 
 #[test]
 fn test_query_rule() -> oso::Result<()> {
-    let oso = test_oso();
+    let _oso = test_oso();
 
     Ok(())
 }
 
 #[test]
 fn test_fail() -> oso::Result<()> {
-    let oso = test_oso();
+    let _oso = test_oso();
 
     Ok(())
 }
 
 #[test]
 fn test_instance_from_external_call() -> oso::Result<()> {
-    let oso = test_oso();
+    let _oso = test_oso();
 
     Ok(())
 }
 
 #[test]
 fn test_allow_model() -> oso::Result<()> {
-    let oso = test_oso();
+    let _oso = test_oso();
 
     Ok(())
 }

--- a/languages/rust/oso/tests/test_oso.rs
+++ b/languages/rust/oso/tests/test_oso.rs
@@ -81,6 +81,7 @@ fn test_oso() -> OsoTest {
 
     let path = test_file_path();
     test.oso.load_file(path).unwrap();
+
     test
 }
 
@@ -91,11 +92,13 @@ fn test_is_allowed() -> oso::Result<()> {
     let actor = Actor::new(String::from("guest"));
     let resource = Widget::new(1);
     let action = "get";
+
     assert!(oso.oso.is_allowed(actor, action, resource)?);
 
     let actor = Actor::new(String::from("president"));
     let resource = Company::new(1);
     let action = "create";
+
     assert!(oso.oso.is_allowed(actor, action, resource)?);
 
     Ok(())
@@ -109,6 +112,7 @@ fn test_query_rule() -> oso::Result<()> {
     let resource = Widget::new(1);
     let action = "get";
     let mut query = oso.oso.query_rule("allow", (actor, action, resource))?;
+
     assert!(query.next().is_some());
 
     Ok(())
@@ -121,6 +125,7 @@ fn test_fail() -> oso::Result<()> {
     let actor = Actor::new(String::from("guest"));
     let resource = Widget::new(1);
     let action = "not_allowed";
+
     assert!(!oso.oso.is_allowed(actor, action, resource)?);
 
     Ok(())
@@ -132,6 +137,7 @@ fn test_instance_from_external_call() -> oso::Result<()> {
 
     let actor = Actor::new(String::from("guest"));
     let resource = Company::new(1);
+
     assert!(oso.oso.is_allowed(actor, "frob", resource)?);
 
     Ok(())
@@ -143,10 +149,12 @@ fn test_allow_model() -> oso::Result<()> {
 
     let actor = Actor::new(String::from("auditor"));
     let resource = Company::new(1);
+
     assert!(oso.oso.is_allowed(actor, "list", resource)?);
 
     let actor = Actor::new(String::from("auditor"));
     let resource = Widget::new(1);
+
     assert!(!oso.oso.is_allowed(actor, "list", resource)?);
 
     Ok(())

--- a/languages/rust/oso/tests/test_oso.rs
+++ b/languages/rust/oso/tests/test_oso.rs
@@ -1,0 +1,123 @@
+use oso::PolarClass;
+use std::path::{Path, PathBuf};
+
+mod common;
+
+use common::OsoTest;
+
+fn test_file_path() -> PathBuf {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    path.join(Path::new("tests/test_oso.polar"))
+}
+
+#[derive(PolarClass, Debug, Clone, PartialEq)]
+struct Actor {
+    #[polar(attribute)]
+    name: String,
+}
+
+impl Actor {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+
+    pub fn companies(&self) -> Vec<Company> {
+        vec![Company { id: 1 }]
+    }
+}
+
+#[derive(PolarClass, Debug, Clone, PartialEq)]
+struct Widget {
+    #[polar(attribute)]
+    id: i64,
+}
+
+impl Widget {
+    pub fn new(id: i64) -> Self {
+        Self { id }
+    }
+}
+
+#[derive(PolarClass, Debug, Clone, PartialEq)]
+struct Company {
+    #[polar(attribute)]
+    id: i64,
+}
+
+impl Company {
+    pub fn new(id: i64) -> Self {
+        Self { id }
+    }
+
+    pub fn role(&self, actor: Actor) -> String {
+        if actor.name == "president" {
+            return "admin".to_string();
+        } else {
+            return "guest".to_string();
+        }
+    }
+}
+
+fn test_oso() -> OsoTest {
+    let mut test = OsoTest::new();
+    test.oso.register_class(Actor::get_polar_class()).unwrap();
+    test.oso.register_class(Widget::get_polar_class()).unwrap();
+    test.oso
+        .register_class(
+            Company::get_polar_class_builder()
+                .set_constructor(Company::new)
+                .add_method("role", Company::role)
+                .build(),
+        )
+        .unwrap();
+
+    test
+}
+
+#[test]
+fn test_is_allowed() -> oso::Result<()> {
+    let oso = test_oso();
+
+    let actor = Actor::new(String::from("guest"));
+    let resource = Widget::new(1);
+    let action = "get";
+
+    let path = test_file_path();
+    oso.oso.load_file(path)?;
+    assert!(oso.oso.is_allowed(actor, action, resource)?);
+
+    let actor = Actor::new(String::from("president"));
+    let resource = Company::new(1);
+    let action = "create";
+    assert!(oso.oso.is_allowed(actor, action, resource.clone())?);
+
+    Ok(())
+}
+
+#[test]
+fn test_query_rule() -> oso::Result<()> {
+    let oso = test_oso();
+
+    Ok(())
+}
+
+#[test]
+fn test_fail() -> oso::Result<()> {
+    let oso = test_oso();
+
+    Ok(())
+}
+
+#[test]
+fn test_instance_from_external_call() -> oso::Result<()> {
+    let oso = test_oso();
+
+    Ok(())
+}
+
+#[test]
+fn test_allow_model() -> oso::Result<()> {
+    let oso = test_oso();
+
+    Ok(())
+}

--- a/languages/rust/oso/tests/test_oso.rs
+++ b/languages/rust/oso/tests/test_oso.rs
@@ -89,7 +89,7 @@ fn test_is_allowed() -> oso::Result<()> {
     let actor = Actor::new(String::from("president"));
     let resource = Company::new(1);
     let action = "create";
-    assert!(oso.oso.is_allowed(actor, action, resource.clone())?);
+    assert!(oso.oso.is_allowed(actor, action, resource)?);
 
     Ok(())
 }


### PR DESCRIPTION
Start and stub out `test_oso.rs`. Following along with `test_oso.py` in terms of structure and tests though I imagine there will be some divergence as I dig further. Also, seems like there is an opportunity to incorporate a lot of what is currently in `lib_guide.rs` since that isn't run with tests but tests a lot of functionality. Merge the two?
