### PR TITLE
Fix typo in internals page.

### DIFF
--- a/new-docs/content/any/project/internals.md
+++ b/new-docs/content/any/project/internals.md
@@ -97,7 +97,7 @@ These adapters allow Oso to effectively translate policy logic into SQL `WHERE`
 clauses:
 
 ```sql
-WHERE access_level = "public" AND creator.id = 1
+WHERE access_level = "public" OR creator.id = 1
 ```
 
 In effect, authorization is being enforced by the policy engine and the ORM


### PR DESCRIPTION
The policy is an OR but the SQL translation said AND.

https://www.notion.so/osohq/Documentation-typo-on-list-filtering-index-page-db190b1b181a4c5b9dd895029e03a6e6