### PR TITLE
Add context indicating which inline query failed

### DIFF
--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -41,6 +41,7 @@ Link to relevant documentation section
 Other bugs & improvements
 =========================
 
+- improved error messages for failing inline queries
 - bulleted list
 - improvements
 - of smaller

--- a/docs/changelogs/vNEXT.rst
+++ b/docs/changelogs/vNEXT.rst
@@ -41,7 +41,7 @@ Link to relevant documentation section
 Other bugs & improvements
 =========================
 
-- improved error messages for failing inline queries
+- Error messages for failing inline queries now contain location information indicating which inline query failed.
 - bulleted list
 - improvements
 - of smaller

--- a/languages/rust/oso/src/errors.rs
+++ b/languages/rust/oso/src/errors.rs
@@ -39,6 +39,9 @@ pub enum OsoError {
     #[error("{operation} are unimplemented in the oso Rust library")]
     UnimplementedOperation { operation: String },
 
+    #[error("Inline query failed {location}")]
+    InlineQueryFailedError { location: String },
+
     #[error(transparent)]
     InvalidCallError(#[from] InvalidCallError),
 

--- a/languages/rust/oso/src/oso.rs
+++ b/languages/rust/oso/src/oso.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use crate::host::Host;
 use crate::query::Query;
+use crate::OsoError;
 use crate::{ToPolar, ToPolarList};
 
 /// Oso is the main struct you interact with. It is an instance of the Oso authorization library
@@ -69,10 +70,11 @@ impl Oso {
 
     fn check_inline_queries(&self) -> crate::Result<()> {
         while let Some(q) = self.inner.next_inline_query(false) {
+            let location = q.source_info();
             let query = Query::new(q, self.host.clone());
             match query.collect::<crate::Result<Vec<_>>>() {
                 Ok(v) if !v.is_empty() => continue,
-                Ok(_) => return lazy_error!("inline query result was false"),
+                Ok(_) => return Err(OsoError::InlineQueryFailedError { location }),
                 Err(e) => return lazy_error!("error in inline query: {}", e),
             }
         }

--- a/languages/rust/oso/tests/test_errors.rs
+++ b/languages/rust/oso/tests/test_errors.rs
@@ -89,9 +89,9 @@ fn test_unify_external_not_supported() -> oso::Result<()> {
     Ok(())
 }
 
-/// Test that failing directive sends a sane error message
+/// Test that failing inline query sends a sane error message
 #[test]
-fn test_failing_directive() {
+fn test_failing_inline_query() {
     common::setup();
 
     let oso = Oso::new();

--- a/languages/rust/oso/tests/test_errors.rs
+++ b/languages/rust/oso/tests/test_errors.rs
@@ -5,7 +5,7 @@ use common::OsoTest;
 use oso::errors::polar::{
     ErrorKind as PolarErrorKind, PolarError, RuntimeError as PolarRuntimeError,
 };
-use oso::{OsoError, PolarClass, PolarValue};
+use oso::{Oso, OsoError, PolarClass, PolarValue};
 
 // TODO in all tests, check type of error & message
 
@@ -87,6 +87,26 @@ fn test_unify_external_not_supported() -> oso::Result<()> {
     //);
 
     Ok(())
+}
+
+/// Test that failing directive sends a sane error message
+#[test]
+fn test_failing_directive() {
+    common::setup();
+
+    let oso = Oso::new();
+
+    let result = oso.load_str("?= 1 == 1;\n?= 1 == 0;");
+    match result {
+        Ok(_) => panic!("failed to detect failure of inline query"),
+        Err(e @ OsoError::InlineQueryFailedError { .. }) => {
+            assert_eq!(
+                format!("{}", e),
+                "Inline query failed 1 == 0 at line 2, column 3"
+            )
+        }
+        Err(_) => panic!("returned unexpected error"),
+    }
 }
 
 /// Test that lookup of attribute that doesn't exist raises error.


### PR DESCRIPTION
This PR fixes #695  by returning a new OsoError variant . The user now sees a line number and copy of the source line rather than the unhelpful 'inline query is false'.

PR checklist:

<!-- Delete if no entry is required. -->
- [ X] Added changelog entry.
