### PR TITLE
[Rust] Fail unification instead of returning an error when type casts fail

### DIFF
--- a/languages/rust/oso/src/host/class.rs
+++ b/languages/rust/oso/src/host/class.rs
@@ -185,10 +185,10 @@ where
         self.class.equality_check = Arc::new(move |host, a, b| {
             tracing::trace!("equality check");
 
-            let a = a.downcast(Some(host)).map_err(|e| e.user())?;
-            let b = b.downcast(Some(host)).map_err(|e| e.user())?;
-
-            Ok((f)(a, b))
+            match (a.downcast(Some(host)), b.downcast(Some(host))) {
+                (Ok(a), Ok(b)) => Ok((f)(a, b)),
+                _ => Ok(false),
+            }
         });
 
         self

--- a/languages/rust/oso/src/host/class.rs
+++ b/languages/rust/oso/src/host/class.rs
@@ -110,6 +110,8 @@ impl Class {
     }
 
     fn equals(&self, host: &Host, lhs: &Instance, rhs: &Instance) -> crate::Result<bool> {
+        // equality checking is currently only supported for exactly matching types
+        // TODO: support multiple dispatch for equality
         if lhs.type_id() != rhs.type_id() {
             Ok(false)
         } else {

--- a/languages/rust/oso/tests/test_errors.rs
+++ b/languages/rust/oso/tests/test_errors.rs
@@ -39,37 +39,42 @@ fn test_unify_external_not_supported() -> oso::Result<()> {
         error
     );
 
+    // TODO Any meaningful support of PartialEq implementations with a different
+    // Rhs would require the ability to configure multiple equality_checks for
+    // a given class, which is not currently supported.
+    // See https://github.com/osohq/oso/pull/796 for more context.
+
     // Type that does support unification with a type that doesn't.
-    #[derive(PolarClass, PartialEq)]
-    struct EqFoo(i64);
+    // #[derive(PolarClass, PartialEq)]
+    // struct EqFoo(i64);
 
-    impl PartialEq<Foo> for EqFoo {
-        fn eq(&self, other: &Foo) -> bool {
-            self.0 == other.0
-        }
-    }
+    // impl PartialEq<Foo> for EqFoo {
+    //     fn eq(&self, other: &Foo) -> bool {
+    //         self.0 == other.0
+    //     }
+    // }
 
-    let eq_foo_class = EqFoo::get_polar_class_builder()
-        .with_equality_check()
-        .build();
+    // let eq_foo_class = EqFoo::get_polar_class_builder()
+    //     .with_equality_check()
+    //     .build();
 
-    oso.oso.register_class(eq_foo_class)?;
+    // oso.oso.register_class(eq_foo_class)?;
 
-    let mut query = oso.oso.query_rule("unify", (EqFoo(1), Foo(1)))?;
-    let error = query.next().unwrap().unwrap_err();
+    // let mut query = oso.oso.query_rule("unify", (EqFoo(1), Foo(1)))?;
+    // let error = query.next().unwrap().unwrap_err();
 
     // TODO definitely need stack traces, these would be hard to diagnose
     // otherwise.
-    assert!(
-        matches!(
-            &error,
-            OsoError::TypeError(oso::errors::TypeError {
-                expected,
-                got
-            }) if expected == "EqFoo" && got.as_deref() == Some("Foo")),
-        "{} doesn't match expected error",
-        error
-    );
+    // assert!(
+    //     matches!(
+    //         &error,
+    //         OsoError::TypeError(oso::errors::TypeError {
+    //             expected,
+    //             got
+    //         }) if expected == "EqFoo" && got.as_deref() == Some("Foo")),
+    //     "{} doesn't match expected error",
+    //     error
+    // );
 
     // TODO (dhatch): Right now, this doesn't work because unify only occurs on
     // built-in types.  See https://www.notion.so/osohq/Unify-of-external-instance-with-internal-type-should-use-ExternalUnify-175bac1414324b25b902c1b1f51fafe9

--- a/languages/rust/oso/tests/test_polar_rust.rs
+++ b/languages/rust/oso/tests/test_polar_rust.rs
@@ -111,6 +111,44 @@ fn test_load_function() {
 }
 
 #[test]
+fn test_type_mismatch_fails_unification() {
+    common::setup();
+
+    #[derive(Eq, PartialEq, PolarClass, Clone)]
+    struct Foo {}
+    #[derive(Eq, PartialEq, PolarClass, Clone)]
+    struct Bar {}
+
+    impl Foo {}
+    impl Bar {}
+
+    let mut test = OsoTest::new();
+    test.oso
+        .register_class(
+            Foo::get_polar_class_builder()
+                .set_constructor(|| Foo {})
+                .with_equality_check()
+                .build(),
+        )
+        .unwrap();
+
+    test.oso
+        .register_class(
+            Bar::get_polar_class_builder()
+                .set_constructor(|| Bar {})
+                .with_equality_check()
+                .build(),
+        )
+        .unwrap();
+
+    test.qnull("new Foo() = new Bar()");
+    test.qnull("new Foo() = nil");
+    let rs = test.query("not new Foo() = nil");
+    assert_eq!(rs.len(), 1, "expected one result");
+    assert!(rs[0].is_empty(), "expected empty result");
+}
+
+#[test]
 fn test_external() {
     common::setup();
 

--- a/languages/rust/oso/tests/test_polar_rust.rs
+++ b/languages/rust/oso/tests/test_polar_rust.rs
@@ -114,19 +114,15 @@ fn test_load_function() {
 fn test_type_mismatch_fails_unification() {
     common::setup();
 
-    #[derive(Eq, PartialEq, PolarClass, Clone)]
+    #[derive(Eq, PartialEq, PolarClass, Clone, Default)]
     struct Foo {}
-    #[derive(Eq, PartialEq, PolarClass, Clone)]
+    #[derive(Eq, PartialEq, PolarClass, Clone, Default)]
     struct Bar {}
-
-    impl Foo {}
-    impl Bar {}
 
     let mut test = OsoTest::new();
     test.oso
         .register_class(
-            Foo::get_polar_class_builder()
-                .set_constructor(|| Foo {})
+            ClassBuilder::<Foo>::with_default()
                 .with_equality_check()
                 .build(),
         )
@@ -134,8 +130,7 @@ fn test_type_mismatch_fails_unification() {
 
     test.oso
         .register_class(
-            Bar::get_polar_class_builder()
-                .set_constructor(|| Bar {})
+            ClassBuilder::<Bar>::with_default()
                 .with_equality_check()
                 .build(),
         )


### PR DESCRIPTION
Fixes #788

I'm not sure this is the desired behavior. I couldn't find any tests for equivalent behavior in the Java or Go bindings.

However, once I was able to create a reproducible test case, the source of the behavior described in the original bug report was clear. It should be relatively easy to tweak depending on the ideal results.