### PR TITLE
support web worker builds of oso

### DIFF
--- a/languages/js/src/helpers.ts
+++ b/languages/js/src/helpers.ts
@@ -306,12 +306,10 @@ let RESET = '';
 let FG_BLUE = '';
 let FG_RED = '';
 if (
-  typeof WorkerGlobalScope !== 'function' &&
-  typeof window !== 'object' &&
-  typeof process.stdout.getColorDepth === 'function' &&
-  process.stdout.getColorDepth() >= 4 &&
-  typeof process.stderr.getColorDepth === 'function' &&
-  process.stderr.getColorDepth() >= 4
+  typeof process?.stdout?.getColorDepth === 'function' &&
+  process?.stdout?.getColorDepth() >= 4 &&
+  typeof process?.stderr?.getColorDepth === 'function' &&
+  process?.stderr?.getColorDepth() >= 4
 ) {
   RESET = '\x1b[0m';
   FG_BLUE = '\x1b[34m';

--- a/languages/js/src/helpers.ts
+++ b/languages/js/src/helpers.ts
@@ -306,6 +306,7 @@ let RESET = '';
 let FG_BLUE = '';
 let FG_RED = '';
 if (
+  typeof WorkerGlobalScope !== 'function' &&
   typeof window !== 'object' &&
   typeof process.stdout.getColorDepth === 'function' &&
   process.stdout.getColorDepth() >= 4 &&

--- a/languages/js/src/helpers.ts
+++ b/languages/js/src/helpers.ts
@@ -307,9 +307,9 @@ let FG_BLUE = '';
 let FG_RED = '';
 if (
   typeof process?.stdout?.getColorDepth === 'function' &&
-  process?.stdout?.getColorDepth() >= 4 &&
+  process.stdout.getColorDepth() >= 4 &&
   typeof process?.stderr?.getColorDepth === 'function' &&
-  process?.stderr?.getColorDepth() >= 4
+  process.stderr.getColorDepth() >= 4
 ) {
   RESET = '\x1b[0m';
   FG_BLUE = '\x1b[34m';

--- a/new-docs/content/any/project/changelogs/next.md
+++ b/new-docs/content/any/project/changelogs/next.md
@@ -10,7 +10,11 @@ draft: true
 
 ## `oso` 0.11.2
 
-### `Oso.query` and others no longer require mutable reference
+### Rust
+
+#### Other bugs & improvements
+
+##### `Oso.query` and others no longer require mutable reference
 
 Thank you [Fisher Darling](https://github.com/fisherdarling)
 for [pointing out](https://github.com/osohq/oso/issues/773) that many
@@ -18,6 +22,17 @@ methods on `oso::Oso` do not require a mutable reference.
 
 With this small change, it is no longer necessary to wrap `oso::Oso` in a
 mutex in order to use across threads.
+
+### Node.js
+
+#### Other bugs & improvements
+
+##### It's now possible to use Oso in Web Workers
+
+Big thanks to [@togmund](https://github.com/togmund) for submitting a patch
+that enables Oso to run in
+[Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API)
+contexts like Cloudflare Workers.
 
 ## `RELEASED_PACKAGE_1` NEW_VERSION
 

--- a/new-docs/spelling/allowed_words.txt
+++ b/new-docs/spelling/allowed_words.txt
@@ -21,6 +21,7 @@ Bundler
 bundlers
 cgo
 classpath
+Cloudflare
 codebase
 constructable
 coroutine
@@ -131,6 +132,7 @@ structs
 subclasses
 submittedBy
 superclasses
+togmund
 toolchain
 traceback
 transactional


### PR DESCRIPTION
## Summary
Processes which run in a web worker do not have access to the `window` object.
(source: https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope)

Instead, workers have a global scope interface which contains information usually conveyed by Window objects.
(source: https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope)

Running Oso, by way of Webpack in a browser within the context of a Web Worker without checking for the `WorkerGlobalScope` will throw errors related to `process.stdout.getColorDepth` && `process.stderr.getColorDepth`.

Adding a check here for `WorkerGlobalScope` will allow Oso to run in a Worker, and notably services like CloudFlare Workers, which run in that scope.
(source: https://developers.cloudflare.com/workers/runtime-apis/web-standards#web-global-apis)

PR checklist:

<!-- Delete if no entry is required. -->
- [x] Added changelog entry.
