### PR TITLE
no debug symbols in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ exclude = [
 ]
 
 [profile.release]
-debug = true
+# Set this to true if you need to debug release builds
+debug = false
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
Drastically lowers the size of the static lib which in turn super duper drastically lowers the size of the go package.