### PR TITLE
More partial performance improvements

### DIFF
--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -538,7 +538,7 @@ mod test {
 
         let mut q = p.new_query_from_term(term!(call!("h", [sym!("x"), sym!("y")])), false);
         assert_partial_expressions!(next_binding(&mut q)?,
-            "x" => "y.x = _this and y.x matches X{}",
+            "x" => "_this matches X{} and y.x = _this",
             "y" => "_this.x matches X{}"
         );
         assert_query_done!(q);

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -428,8 +428,8 @@ mod test {
 
         let mut q = p.new_query_from_term(term!(call!("i", [sym!("x"), sym!("y")])), false);
         assert_partial_expressions!(next_binding(&mut q)?,
-            "x" => "_this matches _y_39 and y = _y_39 and _y_39 matches _z_40",
-            "y" => "x matches _y_39 and _this = _y_39 and _y_39 matches _z_40");
+            "x" => "_this matches y and y matches _z_40",
+            "y" => "x matches _this and _this matches _z_40");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("j", [sym!("x"), sym!("y")])), false);
@@ -529,16 +529,12 @@ mod test {
             term!(call!("h", [sym!("x"), btreemap! {sym!("x") => term!(1)}])),
             false,
         );
-        assert_partial_expression!(
-            next_binding(&mut q)?,
-            "x",
-            "1 matches X{}"
-        );
+        assert_partial_expression!(next_binding(&mut q)?, "x", "_this matches X{} and 1 = _this");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("h", [sym!("x"), sym!("y")])), false);
         assert_partial_expressions!(next_binding(&mut q)?,
-            "x" => "y.x matches X{}",
+            "x" => "_this matches X{} and y.x = _this",
             "y" => "_this.x matches X{}"
         );
         assert_query_done!(q);
@@ -608,13 +604,13 @@ mod test {
         assert_partial_expression!(
             maybe_binding(&mut q).unwrap(),
             "x",
-            "1 matches X{}"
+            "_this matches X{} and 1 = _this"
         );
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("j", [sym!("x"), sym!("y")])), false);
         assert_partial_expressions!(next_binding(&mut q)?,
-            "x" => "y matches Y{} and y.x matches X{}",
+            "x" => "y matches Y{} and _this matches X{} and y.x = _this",
             "y" => "_this matches Y{} and _this.x matches X{}"
         );
         assert_query_done!(q);
@@ -863,19 +859,19 @@ mod test {
                k(y) if x = y and y == z and z = 1 and x = 2;"#,
         )?;
         let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "1 > 1");
+        assert_partial_expression!(next_binding(&mut q)?, "x", "_this > 1 and _this = 1");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("g", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "1 > 1");
+        assert_partial_expression!(next_binding(&mut q)?, "x", "_this > 1 and _this == 1");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("h", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "2 > 1");
+        assert_partial_expression!(next_binding(&mut q)?, "x", "_this > 1 and _this = 2");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("i", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "2 > 1");
+        assert_partial_expression!(next_binding(&mut q)?, "x", "_this > 1 and _this == 2");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("j", [sym!("y")])), false);

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -538,7 +538,7 @@ mod test {
 
         let mut q = p.new_query_from_term(term!(call!("h", [sym!("x"), sym!("y")])), false);
         assert_partial_expressions!(next_binding(&mut q)?,
-            "x" => "_this matches X{} and y.x = _this",
+            "x" => "y.x = _this and y.x matches X{}",
             "y" => "_this.x matches X{}"
         );
         assert_query_done!(q);
@@ -1223,11 +1223,11 @@ mod test {
         )?;
 
         let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "_this.foo != 1");
+        assert_partial_expression!(next_binding(&mut q)?, "x", "1 != _this.foo");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("g", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "_this.foo != 1");
+        assert_partial_expression!(next_binding(&mut q)?, "x", "1 != _this.foo");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("h", [sym!("x")])), false);

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -1407,11 +1407,11 @@ mod test {
                g(x) if not (x.foo.bar = y);"#,
         )?;
         let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "_this.foo != _y_9");
+        assert_partial_expression!(next_binding(&mut q)?, "x", "_y_9 != _this.foo");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("g", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "_this.foo.bar != _y_18");
+        assert_partial_expression!(next_binding(&mut q)?, "x", "_y_18 != _this.foo.bar");
         assert_query_done!(q);
         Ok(())
     }


### PR DESCRIPTION
Queries that yield many constraints can take a long time to run. Most of that time is spent simplifying the resulting constraint expressions, and most of _that_ time is spent picking up and applying unifications one at a time. This work attempts to speed up such queries by doing more simplification work up front.

The current implementation is significantly faster (~2x), but drops some constraints (i.e., it is not correct). Draft status can be removed when it's both fast and correct.

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
