### PR TITLE
Copy host _before_ constructing Polar terms.

### DIFF
--- a/languages/go/polar.go
+++ b/languages/go/polar.go
@@ -117,9 +117,10 @@ func (p Polar) queryStr(query string) (*Query, error) {
 }
 
 func (p Polar) queryRule(name string, args ...interface{}) (*Query, error) {
+	host := p.host.Copy()
 	polarArgs := make([]Term, len(args))
 	for idx, arg := range args {
-		converted, err := p.host.ToPolar(arg)
+		converted, err := host.ToPolar(arg)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +135,7 @@ func (p Polar) queryRule(name string, args ...interface{}) (*Query, error) {
 	if err != nil {
 		return nil, err
 	}
-	newQuery := newQuery(*ffiQuery, p.host.Copy())
+	newQuery := newQuery(*ffiQuery, host)
 	return &newQuery, nil
 }
 

--- a/new-docs/content/any/project/changelogs/2021-03-31.md
+++ b/new-docs/content/any/project/changelogs/2021-03-31.md
@@ -1,0 +1,15 @@
+---
+title: Release 2021-03-31
+menuTitle: 2021-03-31
+any: true
+description: >-
+  Changelog for Release 2021-03-31 (oso 0.11.3) containing new features,
+  bug fixes, and more.
+draft: true
+---
+
+## `go-oso` 0.11.3
+
+### Other bugs & improvements
+
+- Fixed a concurrency bug in the Go library causing panics when constructing new queries


### PR DESCRIPTION
This was preventing the main Oso instance from being threadsafe,
and causing runtime panics due to concurrent map reads.

This was also probably leaking memory, since every query to IsAllowed
would be creating new entries in the shared instance of Oso.

I don't know how to write a test to catch this behaviour in
a non-flaky way.

I had something like this:

```go
type Sleeper struct{}

func (s *Sleeper) sleep() bool {
	time.Sleep(20 * time.Millisecond)
	return true
}

func TestParallelism(t *testing.T) {
	o, _ := oso.NewOso()
	o.RegisterClass(reflect.TypeOf(Sleeper{}), nil)
	o.LoadString(`
		allow(_, _, _) if Sleeper.sleep();
	`)
	checks := make([]bool, 100)
	for idx := range checks {
		go func() {
			checks[idx], _ = o.IsAllowed(nil, nil, nil)
		}()
	}
}
```



PR checklist:


- [x] Added changelog entry.
