### PR TITLE
Deduplicate spelling dictionary

### DIFF
--- a/new-docs/spelling/Makefile
+++ b/new-docs/spelling/Makefile
@@ -8,6 +8,6 @@ spelling-requirements: .make.spelling-requirements.installed
 	touch $@
 
 sort-allowed-words: allowed_words.txt
-	LANG=C sort -fo allowed_words.txt allowed_words.txt
+	LANG=C sort -fuo allowed_words.txt allowed_words.txt
 
 .PHONY: spelling spelling-requirements sort-allowed-words


### PR DESCRIPTION
I noticed that I used a word in https://github.com/osohq/oso/pull/815 ("ad-hoc") that was in the old docs spelling dictionary, but not the new docs dictionary, so I merged the old into the new. This also adds adds a flag to `sort` to deduplicate our spelling dictionary.