### PR TITLE
[Go] Remove logging call from query logic

### DIFF
--- a/languages/go/query.go
+++ b/languages/go/query.go
@@ -135,7 +135,6 @@ func (q *Query) Next() (*map[string]interface{}, error) {
 }
 
 func (q Query) handleMakeExternal(event types.QueryEventMakeExternal) error {
-	fmt.Printf("%v", event)
 	id := uint64(event.InstanceId)
 	call, _ := event.Constructor.Value.ValueVariant.(ValueCall)
 	if call.Kwargs != nil {


### PR DESCRIPTION
Removes a superfluous logging call from the Golang query parsing logic. As is, this logging call floods stdout with noise.