### PR TITLE
Correct follower backtracking bug.

### DIFF
--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -849,7 +849,6 @@ mod test {
         assert_eq!(bm.variable_state(&y), VariableState::Unbound);
     }
 
-    // TODO (dhatch): Test backtrack with followers.
     #[test]
     fn test_backtrack_followers() {
         // Regular bindings

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -321,9 +321,9 @@ impl BindingManager {
     }
 
     pub fn variable_state_at_point(&self, variable: &Symbol, bsp: &Bsp) -> VariableState {
-        let bsp = bsp.bindings_index;
+        let index = bsp.bindings_index;
         let mut next = variable;
-        while let Some(value) = self.value(next, bsp) {
+        while let Some(value) = self.value(next, index) {
             match value.value() {
                 Value::Expression(_) => return VariableState::Partial,
                 Value::Variable(v) | Value::RestVariable(v) => {
@@ -538,9 +538,9 @@ impl BindingManager {
         variable: &Symbol,
         bsp: &Bsp,
     ) -> BindingManagerVariableState {
-        let bsp = bsp.bindings_index;
+        let index = bsp.bindings_index;
         let mut path = vec![variable];
-        while let Some(value) = self.value(path.last().unwrap(), bsp) {
+        while let Some(value) = self.value(path.last().unwrap(), index) {
             match value.value() {
                 Value::Expression(e) => return BindingManagerVariableState::Partial(e),
                 Value::Variable(v) | Value::RestVariable(v) => {

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -403,7 +403,7 @@ impl BindingManager {
     }
 
     pub fn remove_follower(&mut self, follower_id: &FollowerId) -> Option<BindingManager> {
-        self.followers.remove(follower_id).map(|follower| follower)
+        self.followers.remove(follower_id)
     }
 }
 

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -823,5 +823,27 @@ mod test {
         assert_eq!(bm.variable_state(&y), VariableState::Unbound);
     }
 
+
     // TODO (dhatch): Test backtrack with followers.
+    #[test]
+    fn test_backtrack_followers() {
+        // Regular bindings
+        let mut b1 = BindingManager::new();
+        b1.bind(&sym!("x"), term!(sym!("y"))).unwrap();
+        b1.bind(&sym!("z"), term!(sym!("x"))).unwrap();
+
+        let b2 = BindingManager::new();
+        let b2_id = b1.add_follower(b2);
+
+
+        b1.add_constraint(&term!(op!(Gt, term!(sym!("x")), term!(1)))).unwrap();
+
+        let bsp = b1.bsp();
+
+        b1.bind(&sym!("a"), term!(sym!("x"))).unwrap();
+
+        b1.backtrack(bsp);
+        let b2 = b1.remove_follower(&b2_id).unwrap();
+        assert!(matches!(b2.variable_state(&sym!("a")), VariableState::Unbound));
+    }
 }

--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -209,6 +209,7 @@ impl Runnable for Inverter {
                         let constraints =
                             results_to_constraints(self.results.drain(..).collect::<Vec<_>>());
                         let mut bsp = Bsp::default();
+                        // Use mem swap to avoid cloning bsps.
                         std::mem::swap(&mut self.bsp, &mut bsp);
                         let constraints = filter_inverted_constraints(constraints, &self.vm, bsp);
 

--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -173,9 +173,9 @@ fn filter_inverted_constraints(
 ) -> Bindings {
     constraints
         .into_iter()
-        .filter(move |(k, _)| {
+        .filter(|(k, _)| {
             !(matches!(
-                vm.variable_state_at_point(k, bsp.clone()),
+                vm.variable_state_at_point(k, &bsp),
                 VariableState::Unbound | VariableState::Bound(_)
             ))
         })

--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -173,9 +173,9 @@ fn filter_inverted_constraints(
 ) -> Bindings {
     constraints
         .into_iter()
-        .filter(|(k, _)| {
+        .filter(move |(k, _)| {
             !(matches!(
-                vm.variable_state_at_point(k, bsp),
+                vm.variable_state_at_point(k, bsp.clone()),
                 VariableState::Unbound | VariableState::Bound(_)
             ))
         })
@@ -208,8 +208,9 @@ impl Runnable for Inverter {
                         // out to the parent VM.
                         let constraints =
                             results_to_constraints(self.results.drain(..).collect::<Vec<_>>());
-                        let constraints =
-                            filter_inverted_constraints(constraints, &self.vm, self.bsp);
+                        let mut bsp = Bsp::default();
+                        std::mem::swap(&mut self.bsp, &mut bsp);
+                        let constraints = filter_inverted_constraints(constraints, &self.vm, bsp);
 
                         if !constraints.is_empty() {
                             // Return inverted constraints to parent VM.

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -674,7 +674,7 @@ impl PolarVirtualMachine {
     /// Retrieve the current non-constant bindings as a hash map.
     pub fn bindings(&self, include_temps: bool) -> Bindings {
         self.binding_manager
-            .bindings_after(include_temps, self.csp.clone())
+            .bindings_after(include_temps, &self.csp)
     }
 
     /// Retrive internal binding stack for debugger.
@@ -697,7 +697,7 @@ impl PolarVirtualMachine {
     }
 
     /// Investigate the state of a variable at some point and return a variable state variant.
-    pub fn variable_state_at_point(&self, variable: &Symbol, bsp: Bsp) -> VariableState {
+    pub fn variable_state_at_point(&self, variable: &Symbol, bsp: &Bsp) -> VariableState {
         self.binding_manager.variable_state_at_point(variable, bsp)
     }
 
@@ -909,7 +909,7 @@ impl PolarVirtualMachine {
                     trace,
                     trace_stack,
                 }) => {
-                    self.binding_manager.backtrack(bsp.clone());
+                    self.binding_manager.backtrack(&bsp);
                     if let Some(mut alternative) = alternatives.pop() {
                         if alternatives.is_empty() {
                             self.goals = goals;

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -348,7 +348,7 @@ impl PolarVirtualMachine {
 
         impl<'vm> Visitor for VarVisitor<'vm> {
             fn visit_variable(&mut self, v: &Symbol) {
-                if matches!(self.vm.variable_state(v), VariableState::Partial()) {
+                if matches!(self.vm.variable_state(v), VariableState::Partial) {
                     self.has_partial = true;
                 }
             }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -239,7 +239,7 @@ pub struct PolarVirtualMachine {
     stack_limit: usize,
 
     /// Binding stack constant below here.
-    csp: usize,
+    csp: Bsp,
 
     /// Interactive debugger.
     pub debugger: Debugger,
@@ -304,7 +304,7 @@ impl PolarVirtualMachine {
             query_start_time: None,
             query_timeout: QUERY_TIMEOUT_S,
             stack_limit: MAX_STACK_SIZE,
-            csp: 0,
+            csp: Bsp::default(),
             choices: vec![],
             queries: vec![],
             tracing,
@@ -673,7 +673,8 @@ impl PolarVirtualMachine {
 
     /// Retrieve the current non-constant bindings as a hash map.
     pub fn bindings(&self, include_temps: bool) -> Bindings {
-        self.binding_manager.bindings_after(include_temps, self.csp)
+        self.binding_manager
+            .bindings_after(include_temps, self.csp.clone())
     }
 
     /// Retrive internal binding stack for debugger.
@@ -908,7 +909,7 @@ impl PolarVirtualMachine {
                     trace,
                     trace_stack,
                 }) => {
-                    self.binding_manager.backtrack(bsp);
+                    self.binding_manager.backtrack(bsp.clone());
                     if let Some(mut alternative) = alternatives.pop() {
                         if alternatives.is_empty() {
                             self.goals = goals;


### PR DESCRIPTION
Found this bug while investigating grounding & negation. The followers in the binding manager had an assumption that every binding or add constraint operation would always result in the same number of new bindings in the binding stack in the parent and followers.

This is not necessarily true (see the added regression test). If a variable is bound in a cycle in a parent binding manager, but not in a follower, adding a constraint on that variable will add multiple new bindings in the parent (one for each member of the cycle), but only 1 in the child. This results in failing to erase enough bindings in the follower on a backtrack. 

I picked this up from this panic:

```
panic!("Unexpected bound variable {} in constraint.", var);
```

To fix this, the `Bsp` records every `Bsp` in the followers. This could make things slightly slower because it needs to be cloned sometimes. We could try making `followers` in `Bsps` a `Vec` which may make cloning slightly faster.

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.