### PR TITLE
Correct links to data filtering examples in documentation.

### DIFF
--- a/docs/content/python/guides/data_access/django.md
+++ b/docs/content/python/guides/data_access/django.md
@@ -62,7 +62,7 @@ The corresponding policy looks as follows:
 ### Trying it out
 
 If you want to follow along, clone the Oso repository from [GitHub](https://github.com/osohq/oso) and `cd`
-into it and then into the `docs/examples/list-filtering/django` directory.
+into it and then into the `docs/examples/data_access/django` directory.
 Then, run `make setup` to install dependencies (primarily Django and
 `django-oso`) and seed the database.
 

--- a/docs/content/python/guides/data_access/sqlalchemy.md
+++ b/docs/content/python/guides/data_access/sqlalchemy.md
@@ -212,7 +212,7 @@ above).
 ```
 
 This full example is available on
-[GitHub](https://github.com/osohq/oso/tree/main/docs/examples/list-filtering/sqlalchemy).
+[GitHub](https://github.com/osohq/oso/tree/main/docs/examples/data_access/sqlalchemy).
 
 ## How Oso authorizes SQLAlchemy Data
 


### PR DESCRIPTION
We referenced the example directory in the documentation, but it's since been renamed.