### PR TITLE
Respect linenos=true on Polar literalIncludes

### DIFF
--- a/docs/layouts/shortcodes/literalInclude.html
+++ b/docs/layouts/shortcodes/literalInclude.html
@@ -237,7 +237,7 @@
     {{ $gitHubRef = (printf "%s/blob/main/%s#L%d-L%d" $gitHub $pathTrim $gFirstLine $gLastLine) }}
 {{ end }}
 
-<div class="code" id="{{ $id | urlize }}">
+<div class="code{{ if $syntax }} language-{{ $syntax }}{{ end }}" id="{{ $id | urlize }}">
   <div class="filename rounded-t-md bg-gray-200 text-gray-700 text-sm py-2">
     {{- with $syntax -}}
       <span class="px-2{{ if eq . "go" }} block w-10{{end}}">
@@ -253,13 +253,16 @@
         <a class="float-right mr-2" href="{{ $gitHubRef }}"><button class="btn-outline">Browse on GitHub</button></a>
     {{ end }}
   </div>
-  {{ $syntax  = $syntax | default "plaintext" }}
   {{ if $linenos }}
       {{ if $hlOpts }}
           {{ $hlOpts = (printf "linenos=table,linenostart=%d,%s" $gFirstLine $hlOpts) }}
       {{ else }}
           {{ $hlOpts = (printf "linenos=table,linenostart=%d" $gFirstLine) }}
       {{ end }}
+  {{ end }}
+  {{ $syntax = $syntax | default "plaintext" }}
+  {{ if (eq $syntax "polar") }}
+    {{ $syntax = "plaintext" }}
   {{ end }}
   {{- highlight $content $syntax $hlOpts -}}
 </div>

--- a/docs/themes/oso-webpack/index.js
+++ b/docs/themes/oso-webpack/index.js
@@ -165,12 +165,46 @@ import('monaco-editor-core').then(monaco => {
     const backtickBlocks = document.querySelectorAll('code.language-polar');
     const polarSnippets = [...literalIncludes, ...backtickBlocks];
     for (const el of polarSnippets) {
+      let spans = el.children;
+      let spanStyles = {};
+      for (let i = 0; i < spans.length; i++) {
+        spanStyles[normalizeSpaces(spans[i].innerText.trimEnd())] =
+          spans[i].style.cssText;
+      }
       monaco.editor
         .colorize(el.innerText, 'polar', { theme: 'polarTheme' })
         .then(colored => {
           el.innerHTML = colored;
           el.parentNode.classList.add('polar-code-in-here');
+          let highlightChildren = el.children;
+          for (let i = 0; i < highlightChildren.length; i++) {
+            let text = highlightChildren[i].innerText.trimEnd();
+            if (text.indexOf('implies') != -1) {
+              console.log(text);
+              console.log(Object.getOwnPropertyNames(spanStyles)[0]);
+              console.log(Object.getOwnPropertyNames(spanStyles)[0] == text);
+            }
+            let style = spanStyles[highlightChildren[i].innerText.trimEnd()];
+            if (typeof style !== 'undefined') {
+              console.log('set style');
+              highlightChildren[i].setAttribute('style', style);
+            }
+
+            if (
+              highlightChildren[i].tagName === 'SPAN' &&
+              highlightChildren[i].children[0].tagName == 'SPAN' &&
+              highlightChildren[i].innerText == ''
+            ) {
+              // THere are random empty spans that show up in chrome. Trying to remove them proves difficult.
+              // It's fine in safari.
+            }
+          }
         });
     }
   });
 });
+
+// It seems that monaco makes spaces U+00A0 (160) instead of U+0020 (32).
+function normalizeSpaces(str) {
+  return str.replaceAll(String.fromCharCode(32), String.fromCharCode(160));
+}

--- a/docs/themes/oso-webpack/index.js
+++ b/docs/themes/oso-webpack/index.js
@@ -159,9 +159,12 @@ import('monaco-editor-core').then(monaco => {
   monaco.editor.setTheme('polarTheme');
 
   window.addEventListener('load', () => {
-    let polarCode = document.getElementsByClassName('language-polar');
-    for (let i = 0; i < polarCode.length; i++) {
-      let el = polarCode[i];
+    const literalIncludes = document.querySelectorAll(
+      'div.language-polar > div.highlight code.language-plaintext'
+    );
+    const backtickBlocks = document.querySelectorAll('code.language-polar');
+    const polarSnippets = [...literalIncludes, ...backtickBlocks];
+    for (const el of polarSnippets) {
       monaco.editor
         .colorize(el.innerText, 'polar', { theme: 'polarTheme' })
         .then(colored => {


### PR DESCRIPTION
Currently broken when the "hl_lines" highlighting option is also provided. E.g., without `hlOpts="hl_lines=6"`:

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/17556281/116326973-be51e000-a793-11eb-81c5-6c572aa0ab42.png">

And with `hlOpts="hl_lines=6"`:

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/17556281/116326933-a9754c80-a793-11eb-9b1e-2c506e9d85f4.png">
