### PR TITLE
Get elements when needed instead of as constants

### DIFF
--- a/docs/themes/oso-tailwind/assets/js/nav.js
+++ b/docs/themes/oso-tailwind/assets/js/nav.js
@@ -34,12 +34,12 @@ if (langButton) {
   );
 }
 
-const searchModal = document.getElementById('search-modal');
-const searchInput = document.getElementById('search-input');
-const searchBackground = document.getElementById('search-background');
-
 // Close dropdown sideBars if the user clicks outside of them
 window.onclick = function(event) {
+  const searchModal = document.getElementById('search-modal');
+  const searchInput = document.getElementById('search-input');
+  const searchBackground = document.getElementById('search-background');
+
   console.log(event.target);
   switch (event.target) {
     case navButton:
@@ -51,13 +51,13 @@ window.onclick = function(event) {
     case langButton:
       break;
     case searchInput:
-      break
+      break;
     case searchModal:
       window.hideSearch(event);
-      break
+      break;
     case searchBackground:
       window.hideSearch(event);
-      break
+      break;
     default:
       // default to hidden
       var contents = [navContent, langsideBar, sideBarContent, navToggleOpen];

--- a/docs/themes/oso-webpack/index.js
+++ b/docs/themes/oso-webpack/index.js
@@ -167,25 +167,30 @@ import('monaco-editor-core').then(monaco => {
     }
   });
 });
-const searchResultsContainer = document.getElementById(
-  'search-results-container'
-);
+
 // hide the search box
-window.hideSearch = function(e) {
+window.hideSearch = function(_e) {
+  const searchModal = document.getElementById('search-modal');
   if (searchModal.style.display == '') {
     searchModal.style.display = 'none';
   }
 };
 
-// load up a reference to the search input and add an event listener
-const searchInput = document.getElementById('search-input');
-if (searchInput) {
-  searchInput.addEventListener('input', e => window.searchInputKeyUp(e));
-}
+window.addEventListener('load', () => {
+  const searchInput = document.getElementById('search-input');
+  if (searchInput) {
+    searchInput.addEventListener('input', e => window.searchInputKeyUp(e));
+  }
+});
 
 // this handles when the button on the left nav is clicked and it toggles the search box
 window.searchButtonClick = function(e) {
   e.preventDefault();
+  const searchModal = document.getElementById('search-modal');
+  const searchInput = document.getElementById('search-input');
+  const searchResultsContainer = document.getElementById(
+    'search-results-container'
+  );
 
   if (searchModal.style.display == 'none') {
     searchInput.value = '';
@@ -241,6 +246,10 @@ import('algoliasearch').then(algolia => {
       });
       count += 1;
     });
+
+    const searchResultsContainer = document.getElementById(
+      'search-results-container'
+    );
     searchResultsContainer.innerHTML = results;
   };
 
@@ -277,6 +286,8 @@ import('algoliasearch').then(algolia => {
   };
 
   window.searchInputKeyUp = function(event) {
+    const searchInput = document.getElementById('search-input');
+
     event.preventDefault();
     var term = searchInput.value;
 

--- a/docs/themes/oso-webpack/index.js
+++ b/docs/themes/oso-webpack/index.js
@@ -178,9 +178,7 @@ window.hideSearch = function(_e) {
 
 window.addEventListener('load', () => {
   const searchInput = document.getElementById('search-input');
-  if (searchInput) {
-    searchInput.addEventListener('input', e => window.searchInputKeyUp(e));
-  }
+  searchInput.addEventListener('input', e => window.searchInputKeyUp(e));
 });
 
 // this handles when the button on the left nav is clicked and it toggles the search box


### PR DESCRIPTION
This fixes some race conditions occuring in production preventing search from working.
And, it makes the code a bit easier to read (no references across webpack and nav.js)