### PR TITLE
Use real type for resource id columns

### DIFF
--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/oso.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/oso.py
@@ -30,7 +30,7 @@ class SQLAlchemyOso(Oso):
         self.base = sqlalchemy_base
         self._roles_enabled = False
 
-    def enable_roles(self, user_model, resource_id_column_type, session_maker):
+    def enable_roles(self, user_model, session_maker):
         """Enable the Oso role management API.
         Oso will create SQLAlchemy models to create and assign roles to users (stored in `user_model`).
         The roles API methods will be available on the `roles` property of `SQLAlchemyOso`.
@@ -39,7 +39,6 @@ class SQLAlchemyOso(Oso):
             oso=self,
             sqlalchemy_base=self.base,
             user_model=user_model,
-            resource_id_column_type=resource_id_column_type,
             session_maker=session_maker,
         )
         self._roles_enabled = True

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/oso.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/oso.py
@@ -30,7 +30,7 @@ class SQLAlchemyOso(Oso):
         self.base = sqlalchemy_base
         self._roles_enabled = False
 
-    def enable_roles(self, user_model, session_maker):
+    def enable_roles(self, user_model, resource_id_column_type, session_maker):
         """Enable the Oso role management API.
         Oso will create SQLAlchemy models to create and assign roles to users (stored in `user_model`).
         The roles API methods will be available on the `roles` property of `SQLAlchemyOso`.
@@ -39,6 +39,7 @@ class SQLAlchemyOso(Oso):
             oso=self,
             sqlalchemy_base=self.base,
             user_model=user_model,
+            resource_id_column_type=resource_id_column_type,
             session_maker=session_maker,
         )
         self._roles_enabled = True

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -504,6 +504,7 @@ class OsoRoles:
     def __init__(
         self, oso, sqlalchemy_base, user_model, resource_id_column_type, session_maker
     ):
+        self.resource_id_column_type = resource_id_column_type
         self.session_maker = session_maker
 
         for cls in session_maker.class_.__mro__:
@@ -720,7 +721,11 @@ class OsoRoles:
         for _, resource in self.config.resources.items():
             python_class = resource.python_class
             type = resource.type
-            id_field = inspect(python_class).primary_key[0].name
+            id_field, id_type = get_pk(python_class)
+            if not isinstance(id_type, self.resource_id_column_type):
+                raise OsoError(
+                    "All resource ids must match the passed in resource id type."
+                )
             table = python_class.__tablename__
             self.role_allow_list_filter_queries[
                 type

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -526,6 +526,11 @@ class OsoRoles:
             elif resource_id_column_type.__class__ != id_type.__class__:
                 raise OsoError("All resource ids must match have the same id type.")
 
+        if resource_id_column_type is None:
+            raise OsoError(
+                "No models registered, must register models on Base before enabling roles."
+            )
+
         self.resource_id_column_type = resource_id_column_type
 
         models = sqlalchemy_base._decl_class_registry

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -80,7 +80,7 @@ def init_oso(engine, Base, User, Organization, Repository, Issue):
     session = Session()
 
     oso = SQLAlchemyOso(Base)
-    oso.enable_roles(User, Session)
+    oso.enable_roles(User, String, Session)
 
     # @NOTE: Right now this has to happen after enabling oso roles to get the
     #        tables.
@@ -155,21 +155,21 @@ def test_oso_roles_init(auth_sessionmaker, Base, User):
 
     # - Passing an auth session to OsoRoles raises an exception
     with pytest.raises(OsoError):
-        oso.enable_roles(user_model=User, session_maker=auth_sessionmaker)
+        oso.enable_roles(user_model=User, resource_id_column_type=String, session_maker=auth_sessionmaker)
 
     Session = sessionmaker(bind=engine)
     session = Session()
 
     # - Passing a session instead of Session factory to OsoRoles raises an exception
     with pytest.raises(AttributeError):
-        oso.enable_roles(User, session)
+        oso.enable_roles(User, String, session)
 
     class FakeClass:
         pass
 
     # - Passing a non-SQLAlchemy user model to OsoRoles raises an exception
     with pytest.raises(TypeError):
-        oso.enable_roles(FakeClass, Session)
+        oso.enable_roles(FakeClass, String, Session)
 
     # - Passing a bad declarative_base to OsoRoles raises an exception
     with pytest.raises(AttributeError):

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -2224,7 +2224,6 @@ def test_mismatched_id_types_throws_error(engine, Base, User):
         id = Column(Integer(), primary_key=True)
 
     Session = sessionmaker(bind=engine)
-    session = Session()
 
     oso = SQLAlchemyOso(Base)
 

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -2231,16 +2231,17 @@ def test_mismatched_id_types_throws_error(engine, Base, User):
         oso.enable_roles(User, Session)
 
 
-def test_integer_ids(engine, Base, User):
+@pytest.mark.parametrize("sa_type,one_id", [(String, "1"), (Integer, 1)])
+def test_id_types(engine, Base, User, sa_type, one_id):
     class One(Base):
         __tablename__ = "ones"
 
-        id = Column(Integer(), primary_key=True)
+        id = Column(sa_type(), primary_key=True)
 
     class Two(Base):
         __tablename__ = "twos"
 
-        id = Column(Integer(), primary_key=True)
+        id = Column(sa_type(), primary_key=True)
 
     Session = sessionmaker(bind=engine)
     session = Session()
@@ -2261,7 +2262,7 @@ def test_integer_ids(engine, Base, User):
     oso.roles.synchronize_data()
 
     steve = User(name="steve")
-    one = One(id=1)
+    one = One(id=one_id)
 
     session.add(steve)
     session.add(one)


### PR DESCRIPTION
Lets us type the resource id correctly (instead of casting it to a string).
Makes the sql more efficient and able to use indexes.