### PR TITLE
Rewrite list filter queries to not table scan.

### DIFF
--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -178,8 +178,6 @@ def list_filter_query(kind, resource, relationships, id_field):
                 found_parent = True
                 break
 
-    # user_id, resource_type, action or role
-
     sql = ""
     assert kind in ["role_allow", "user_in_role"]
     # Get the roles to start from.
@@ -254,7 +252,7 @@ def list_filter_query(kind, resource, relationships, id_field):
         role_joins += f"and {urr_table}.resource_id = r.{rel.parent_table}_id"
         role_filters += f" or {urr_table}.resource_id is not NULL"
 
-    # TODO: join to parents
+    # Join to parents
     sql += f"""
     resources_with_parents as (
         select
@@ -264,7 +262,7 @@ def list_filter_query(kind, resource, relationships, id_field):
     )
     """
 
-    # @TODO: join to roles and filter
+    # Join to roles and filter by having a role
     sql += f"""
     select
       r.id
@@ -272,8 +270,6 @@ def list_filter_query(kind, resource, relationships, id_field):
     {role_joins}
     {role_filters}
     """
-
-    # TODO: add the null checks
 
     return sql
 

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -245,11 +245,13 @@ def list_filter_query(kind, resource, relationships, id_field):
         parent_pk, _ = get_pk(rel.parent_python_class)
         parent_ids += f", {rel.parent_table}.{parent_pk} as {rel.parent_table}_id"
         parent_joins += f"\njoin {rel.parent_table}"
-        parent_joins += f"\non {rel.child_table}.{rel.child_join_column} = {rel.parent_table}.{rel.parent_join_column}"
+        parent_joins += f"\non {rel.child_table}.{rel.child_join_column} "
+        parent_joins += f"= {rel.parent_table}.{rel.parent_join_column}"
 
         urr_table = f"urr{i+1}"
         role_joins += f"\nleft join user_relevant_roles {urr_table}"
-        role_joins += f"\non {urr_table}.resource_type = '{rel.parent_type}' and {urr_table}.resource_id = r.{rel.parent_table}_id"
+        role_joins += f"\non {urr_table}.resource_type = '{rel.parent_type}' "
+        role_joins += f"and {urr_table}.resource_id = r.{rel.parent_table}_id"
         role_filters += f" or {urr_table}.resource_id is not NULL"
 
     # TODO: join to parents
@@ -950,7 +952,8 @@ class OsoRoles:
                 user_role.role = role_name
             else:
                 raise OsoError(
-                    f"User {user} already has a role for this resource. To reassign, call with `reassign=True`."
+                    f"User {user} already has a role for this resource."
+                    + "To reassign, call with `reassign=True`."
                 )
         else:
             user_pk_name, _ = get_pk(user.__class__)

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -183,7 +183,7 @@ def list_filter_query(kind, resource, relationships, id_field):
     # Get the roles to start from.
     if kind == "role_allow":
         # Any role with the permission.
-        sql += f"""
+        sql += """
         with allow_permission as (
             select
                 p.id
@@ -195,11 +195,11 @@ def list_filter_query(kind, resource, relationships, id_field):
             from role_permissions rp
             join allow_permission ap
             on rp.permission_id = ap.id
-        ), 
+        ),
         """
     elif kind == "user_in_role":
         # The passed in role.
-        sql += f"""
+        sql += """
         with starting_roles as (
             select
                 r.name as role
@@ -233,7 +233,7 @@ def list_filter_query(kind, resource, relationships, id_field):
 
     parent_ids = ""
     parent_joins = ""
-    role_joins = f"left join user_relevant_roles urr"
+    role_joins = "left join user_relevant_roles urr"
     role_joins += (
         f"\non urr.resource_type = '{resource.type}' and urr.resource_id = r.{id_field}"
     )

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -95,7 +95,7 @@ def role_allow_query(
             join relevant_roles rr
             on rr.role = ur.role
             join resources r
-            on r.type = ur.resource_type and cast(r.id as text) = ur.resource_id
+            on r.type = ur.resource_type and r.id = ur.resource_id
             where ur.user_id = :user_id
         ) select * from user_in_role
     """
@@ -156,7 +156,7 @@ def user_in_role_query(
             join relevant_roles rr
             on rr.role = ur.role
             join resources r
-            on r.type = ur.resource_type and cast(r.id as text) = ur.resource_id
+            on r.type = ur.resource_type and r.id = ur.resource_id
             where ur.user_id = :user_id
         ) select * from user_in_role
     """
@@ -514,6 +514,25 @@ class OsoRoles:
         user_pk_name, user_pk_type = get_pk(user_model)
         user_table_name = user_model.__tablename__
 
+        resource_id_column_type = None
+        for name, model in oso.base._decl_class_registry.items():
+            if name == "_sa_module_registry":
+                continue
+            if model == user_model:
+                continue
+            _, id_type = get_pk(model)
+            if resource_id_column_type is None:
+                resource_id_column_type = id_type
+            elif resource_id_column_type.__class__ != id_type.__class__:
+                raise OsoError("All resources must have the same id type.")
+
+        if resource_id_column_type is None:
+            raise OsoError(
+                "No models registered, must register models on Base before enabling roles."
+            )
+
+        self.resource_id_column_type = resource_id_column_type
+
         models = sqlalchemy_base._decl_class_registry
 
         # @NOTE: This is pretty hacky, also will break if the user defines their own classes with these names, so we should
@@ -530,7 +549,7 @@ class OsoRoles:
                 )
                 resource_type = Column(String, index=True)
                 resource_id = Column(
-                    String, index=True
+                    resource_id_column_type, index=True
                 )  # Most things can turn into a string lol.
                 role = Column(String, index=True)
 
@@ -688,7 +707,7 @@ class OsoRoles:
                 select p.{parent_id}
                 from {child_table} c
                 join {parent_table} p
-                on cast(c.{child_join_column} as text) = cast(p.{parent_join_column} as text)
+                on c.{child_join_column} = p.{parent_join_column}
                 where c.{child_id} = resources.id"""
 
             id_query += ""
@@ -704,7 +723,7 @@ class OsoRoles:
         id_query += "end as id"
         type_query += "end as type"
 
-        resource_id_field = "cast(:resource_id as text)"
+        resource_id_field = ":resource_id"
 
         has_relationships = len(self.config.relationships) > 0
         self.role_allow_sql_query = role_allow_query(
@@ -718,7 +737,7 @@ class OsoRoles:
         for _, resource in self.config.resources.items():
             python_class = resource.python_class
             type = resource.type
-            id_field = inspect(python_class).primary_key[0].name
+            id_field, _ = get_pk(python_class)
             table = python_class.__tablename__
             self.role_allow_list_filter_queries[
                 type
@@ -727,7 +746,7 @@ class OsoRoles:
                   {id_field}
                 from {table} R
                 where exists (
-                  {role_allow_query(id_query, type_query, child_types, "cast(R."+id_field+" as text)", has_relationships)}
+                  {role_allow_query(id_query, type_query, child_types, "R."+id_field, has_relationships)}
                 )
             """
             self.user_in_role_list_filter_queries[
@@ -737,7 +756,7 @@ class OsoRoles:
                   {id_field}
                 from {table} R
                 where exists (
-                  {user_in_role_query(id_query, type_query, child_types, "cast(R."+id_field+" as text)", has_relationships)}
+                  {user_in_role_query(id_query, type_query, child_types, "R."+id_field, has_relationships)}
                 )
             """
 

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -2382,6 +2382,14 @@ def test_roles(init_oso, auth_sessionmaker, User, Organization, Repository, Issu
     assert demo_repo.id in result_ids
     assert ios.id not in result_ids
 
+    oso.actor = leina
+    oso.checked_permissions = {Issue: "edit"}
+    auth_session = auth_sessionmaker()
+
+    results = auth_session.query(Issue).all()
+    assert len(results) == 1
+    result_ids = [repo.id for repo in results]
+    assert bug.id in result_ids
     assert not oso.is_allowed(gabe, "edit", bug)
     oso.roles.assign_role(gabe, osohq, "org_member", session=session)
     assert not oso.is_allowed(gabe, "edit", bug)

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -53,7 +53,7 @@ def Repository(Base):
         __tablename__ = "repositories"
 
         id = Column(String(), primary_key=True)
-        org_id = Column(String(), ForeignKey("organizations.id"))
+        org_id = Column(String(), ForeignKey("organizations.id"), index=True)
         org = relationship("Organization")
 
     return Repository

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -2388,7 +2388,7 @@ def test_roles(init_oso, auth_sessionmaker, User, Organization, Repository, Issu
 
     results = auth_session.query(Issue).all()
     assert len(results) == 1
-    result_ids = [repo.id for repo in results]
+    result_ids = [issue.id for issue in results]
     assert bug.id in result_ids
     assert not oso.is_allowed(gabe, "edit", bug)
     oso.roles.assign_role(gabe, osohq, "org_member", session=session)


### PR DESCRIPTION
Creates a query that looks something like this

```
with allow_permission as (
    -- Find the permission
    select
            p.id
    from permissions p
    where p.resource_type = 'Repository' and p.name = 'pull' -- action and resource type
), permission_roles as (
    -- find roles with the permission
    select
            rp.role
    from role_permissions rp
    join allow_permission ap
    on rp.permission_id = ap.id
), relevant_roles as (
    -- recursively find all roles that have the permission or
    -- imply a role that has the permission
    with recursive relevant_roles (role) as (
            select
                    role
            from permission_roles
            union
            select
                    ri.from_role
            from role_implications ri
            join relevant_roles rr
            on ri.to_role = rr.role
    ) select * from relevant_roles
), user_relevant_roles as (
    select
        *
    from user_roles ur
    join relevant_roles rr
    on rr.role = ur.role
    where ur.user_id = 1 -- user_id
)
select
  R.id
from repositories R
join user_relevant_roles urr
on urr.resource_type = 'Repository' and urr.resource_id = R.id
union
select
  R.id
from repositories R
join organizations P
on R.org_id = P.id
join user_relevant_roles urr
on urr.resource_type = 'Organization' and urr.resource_id = P.id
```