### PR TITLE
Fix bug with lookups in rule head

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -8,17 +8,17 @@ description: >-
 draft: true
 ---
 
-## `RELEASED_PACKAGE_1` NEW_VERSION
+## `oso` v0.12.4
 
-### LANGUAGE (e.g., 'Core' or 'Python' or 'Node.js')
+### Core
 
 #### Breaking changes
 
 <!-- TODO: remove warning and replace with "None" if no breaking changes. -->
 
 {{% callout "Warning" "orange" %}}
-  This release contains breaking changes. Be sure to follow migration steps
-  before upgrading.
+This release contains breaking changes. Be sure to follow migration steps
+before upgrading.
 {{% /callout %}}
 
 ##### Breaking change 1
@@ -37,6 +37,4 @@ Link to [relevant documentation section]().
 
 #### Other bugs & improvements
 
-- Bulleted list
-- Of smaller improvements
-- Potentially with doc [links]().
+- Fixed bug with dot lookups in the head of a rule ([#933](https://github.com/osohq/oso/pull/933)).

--- a/languages/python/oso/tests/conftest.py
+++ b/languages/python/oso/tests/conftest.py
@@ -74,7 +74,7 @@ def is_allowed(polar):
     """Check if actor may perform action on resource."""
 
     def _is_allowed(actor, action, resource):
-        return polar.is_allowed(actor, action, resource)
+        return len(list(polar.query_rule("allow", actor, action, resource))) > 0
 
     return _is_allowed
 

--- a/languages/python/oso/tests/conftest.py
+++ b/languages/python/oso/tests/conftest.py
@@ -70,6 +70,16 @@ def qeval(query):
 
 
 @pytest.fixture
+def is_allowed(polar):
+    """Check if actor may perform action on resource."""
+
+    def _is_allowed(actor, action, resource):
+        return polar.is_allowed(actor, action, resource)
+
+    return _is_allowed
+
+
+@pytest.fixture
 def qvar(query):
     """Query something and pull out the results for the variable v"""
 

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from math import inf, isnan, nan
 from pathlib import Path
+from enum import Enum
 
 from polar import (
     polar_class,
@@ -12,7 +13,6 @@ from polar import (
     Pattern,
 )
 from polar.partial import TypeConstraint
-from polar.exceptions import InvalidCallError, UnexpectedPolarTypeError
 
 import pytest
 
@@ -123,7 +123,7 @@ def test_external(polar, qvar, qeval):
     polar.register_class(Foo)
     assert qvar("new Foo().a = x", "x", one=True) == "a"
     with pytest.raises(
-        InvalidCallError, match="tried to call 'a' but it is not callable"
+        exceptions.InvalidCallError, match="tried to call 'a' but it is not callable"
     ):
         assert not qeval("new Foo().a() = x")
     assert not qvar("new Foo().b = x", "x", one=True) == "b"
@@ -894,5 +894,52 @@ def test_unexpected_expression(polar):
     """Ensure expression type raises error from core."""
     polar.load_str("f(x) if x > 2;")
 
-    with pytest.raises(UnexpectedPolarTypeError):
+    with pytest.raises(exceptions.UnexpectedPolarTypeError):
         next(polar.query_rule("f", Variable("x")))
+
+
+def test_lookup_in_head(polar):
+    # Test with enums
+    class Actions(Enum):
+        READ = 1
+        WRITE = 2
+
+    polar.register_constant(Actions, "Actions")
+    p = """allow("leina", Actions.READ, "doc");"""
+    polar.load_str(p)
+
+    assert len(list(polar.query_rule("allow", "leina", Actions.WRITE, "doc"))) == 0
+    assert len(list(polar.query_rule("allow", "leina", "READ", "doc"))) == 0
+    assert len(list(polar.query_rule("allow", "leina", 1, "doc"))) == 0
+    assert len(list(polar.query_rule("allow", "leina", Actions, "doc"))) == 0
+    assert len(list(polar.query_rule("allow", "leina", Actions.READ, "doc"))) == 1
+
+    # Test lookup in specializer raises error
+    p = """allow("leina", action: Actions.READ, "doc");"""
+    with pytest.raises(exceptions.UnrecognizedToken):
+        polar.load_str(p)
+
+    # Test with normal class
+    class Resource:
+        def __init__(self, action):
+            self.action = action
+
+    polar.register_class(Resource, name="Resource")
+    p = """allow("leina", resource.action, resource: Resource);"""
+    polar.load_str(p)
+
+    r = Resource("read")
+
+    assert len(list(polar.query_rule("allow", "leina", "write", r))) == 0
+    assert len(list(polar.query_rule("allow", "leina", "read", r))) == 1
+
+
+# def test_specialize_on_constant(polar):
+#     const_dict = {"foo": "bar"}
+#     polar.register_constant(const_dict, "MY_DICT")
+
+#     p = """allow("leina", "read", resource: MY_DICT);"""
+#     polar.load_str(p)
+
+#     assert len(list(polar.query_rule("allow", "leina", "read", {"foo": "bar"}))) == 1
+#     assert len(list(polar.query_rule("allow", "leina", "read", {}))) == 0

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -932,14 +932,3 @@ def test_lookup_in_head(polar):
 
     assert len(list(polar.query_rule("allow", "leina", "write", r))) == 0
     assert len(list(polar.query_rule("allow", "leina", "read", r))) == 1
-
-
-# def test_specialize_on_constant(polar):
-#     const_dict = {"foo": "bar"}
-#     polar.register_constant(const_dict, "MY_DICT")
-
-#     p = """allow("leina", "read", resource: MY_DICT);"""
-#     polar.load_str(p)
-
-#     assert len(list(polar.query_rule("allow", "leina", "read", {"foo": "bar"}))) == 1
-#     assert len(list(polar.query_rule("allow", "leina", "read", {}))) == 0

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2953,10 +2953,10 @@ impl Runnable for PolarVirtualMachine {
             self.log_with(|| format!("=> {}", value.to_string()), &[]);
 
             // Fetch variable to unify with call result.
-            let sym = &self.get_call_sym(&call_id).to_owned();
+            let sym = (&self).get_call_sym(&call_id).to_owned();
 
             self.push_goal(Goal::Unify {
-                left: Term::new_temporary(Value::Variable(sym.to_owned())),
+                left: Term::new_temporary(Value::Variable(sym)),
                 right: value,
             })?;
         } else {

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2174,8 +2174,8 @@ impl PolarVirtualMachine {
                 // Unification of the `next_term` variable with the result of `NextExternal` happens in `fn external_call_result()`
                 // `external_call_result` is the handler for results from both `LookupExternal` and `NextExternal`, so neither can bind the
                 // call ID variable to `false`.
-                let next_term = self.kb.read().unwrap().gensym("next_value");
-                let call_id = self.new_call_id(&next_term);
+                let next_sym = self.kb.read().unwrap().gensym("next_value");
+                let call_id = self.new_call_id(&next_sym);
 
                 // append unify goal to be evaluated after
                 // next result is fetched
@@ -2186,7 +2186,7 @@ impl PolarVirtualMachine {
                     },
                     Goal::Unify {
                         left: item.clone(),
-                        right: Term::new_temporary(Value::Variable(next_term)),
+                        right: Term::new_temporary(Value::Variable(next_sym)),
                     },
                 ])?;
             }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2940,6 +2940,15 @@ impl Runnable for PolarVirtualMachine {
                 .clone();
 
             if let VariableState::Bound(_) = self.variable_state(sym) {
+                self.log_with(
+                    || {
+                        format!(
+                            "Variable {} is bound, pushing Goal::Unify{{left: {}, right: {}}}",
+                            sym, sym, value
+                        )
+                    },
+                    &[],
+                );
                 // If the variable is already bound, unify the result with the variable.
                 // This is necessary for lookups done in rule heads, because the variable will be bound to whatever arg was passed in.
                 self.push_goal(Goal::Unify {
@@ -2948,6 +2957,7 @@ impl Runnable for PolarVirtualMachine {
                 })?;
             } else {
                 // if the variable isn't bound, rebind
+                self.log_with(|| format!("Variable {} is not bound, rebinding", sym), &[]);
                 self.rebind_external_answer(sym, value);
             }
         } else {

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2952,7 +2952,7 @@ impl Runnable for PolarVirtualMachine {
             self.log_with(|| format!("=> {}", value.to_string()), &[]);
 
             // Fetch variable to unify with call result.
-            let sym = (&self).get_call_sym(call_id).to_owned();
+            let sym = self.get_call_sym(call_id).to_owned();
 
             self.push_goal(Goal::Unify {
                 left: Term::new_temporary(Value::Variable(sym)),

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -419,7 +419,7 @@ impl PolarVirtualMachine {
         (call_id, Term::new_temporary(Value::Variable(sym)))
     }
 
-    fn get_call_sym(&self, call_id: &u64) -> &Symbol {
+    fn get_call_sym(&self, call_id: u64) -> &Symbol {
         self.call_id_symbols
             .get(&call_id)
             .expect("unregistered external call ID")
@@ -540,7 +540,7 @@ impl PolarVirtualMachine {
         match goal {
             Goal::LookupExternal { call_id, .. } | Goal::NextExternal { call_id, .. } => {
                 assert!(matches!(
-                    self.variable_state(self.get_call_sym(&call_id)),
+                    self.variable_state(self.get_call_sym(call_id)),
                     VariableState::Unbound
                 ));
             }
@@ -2953,7 +2953,7 @@ impl Runnable for PolarVirtualMachine {
             self.log_with(|| format!("=> {}", value.to_string()), &[]);
 
             // Fetch variable to unify with call result.
-            let sym = (&self).get_call_sym(&call_id).to_owned();
+            let sym = (&self).get_call_sym(call_id).to_owned();
 
             self.push_goal(Goal::Unify {
                 left: Term::new_temporary(Value::Variable(sym)),

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2939,7 +2939,7 @@ impl Runnable for PolarVirtualMachine {
         if let Some(value) = term {
             self.log_with(|| format!("=> {}", value.to_string()), &[]);
 
-            // get the variable to bind result to
+            // Fetch variable to unify with call result.
             let sym = &self
                 .call_id_symbols
                 .get(&call_id)

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2171,7 +2171,7 @@ impl PolarVirtualMachine {
             // Push an `ExternalLookup` goal for external instances
             (_, Value::ExternalInstance(_)) => {
                 // Generate symbol for next result and leave the variable unbound, so that unification with the result does not fail
-                // Unification of the `next_term` variable with the result of `NextExternal` happens in `fn external_call_result()`
+                // Unification of the `next_sym` variable with the result of `NextExternal` happens in `fn external_call_result()`
                 // `external_call_result` is the handler for results from both `LookupExternal` and `NextExternal`, so neither can bind the
                 // call ID variable to `false`.
                 let next_sym = self.kb.read().unwrap().gensym("next_value");

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -536,13 +536,12 @@ impl PolarVirtualMachine {
             }
             .into());
         }
-        // For LookupExternal and NextExternal goals, make sure that the call id result variable is unbound
         match goal {
             Goal::LookupExternal { call_id, .. } | Goal::NextExternal { call_id, .. } => {
                 assert!(matches!(
                     self.variable_state(self.get_call_sym(call_id)),
                     VariableState::Unbound
-                ));
+                ), "The call_id result variables for LookupExternal and NextExternal goals must be unbound.");
             }
             _ => (),
         }


### PR DESCRIPTION
Fixes #913

Issue was in rebinding variables to the results of external calls, even when the variable may already be bound.
This is an issue for lookups in rule heads, as the result variable for the lookup will already be bound to the argument passed into the rule.

E.g.,
The following code will fail.

```
oso.load_str("""allow("leina", Actions.READ, "doc");""")

assert not oso.is_allowed("leina", Actions.WRITE, "doc");

```

The Polar log explains a bit about what's happening:

```
RULE: allow("leina", Actions.READ, "doc") if ;
[debug]       QUERY: Actions.READ = _value_1_3, BINDINGS: {_value_1_3 = <Actions.WRITE: 2>, Actions = <enum 'Actions'>}
[debug]         QUERY: <enum 'Actions'>.READ = _value_1_3, BINDINGS: {_value_1_3 = <Actions.WRITE: 2>}
[debug]           LOOKUP: <enum 'Actions'>.READ()
[debug]           => <Actions.READ: 1>
[debug]           BACKTRACK
[debug]           HALT

```

What happens is that the argument passed in (`Actions.WRITE`) is bound to a temporary variable `_value_1_3`. We then query for `Actions.READ`.
The bug was caused by rebinding the result of the lookup to `_value_1_3` without checking if `_value_1_3` was already bound.
Rebinding the variable ignores the argument passed in, when what we should do is unify the result with `_value_1_3`, so that if the variable is bound we check that it matches the result. 

In order to switch from rebinding to unification in `external_call_result`, it was also necessary to change the way we initialize the result variables for external calls. Previously, we initialized the variable associated with an external `call_id` to `false`, which would always cause unification with a result to fail (unless the result was `false`). This was done with `new_call_var`, which takes an initial value.

To fix this, I stopped initializing to the `call_id` variable to `false` only for `LookupExternal` and `NextExternal` goals. For other goals `ExternalOp`, `ExternalIsa`, etc., where the result is always a boolean, we rely on the default value of the result variable being false, so I didn't change those. 


PR checklist:

<!-- Delete if no entry is required. -->

- [x]  Added changelog entry.
- [x] Regression test in the core.