### PR TITLE
Diff docs on PR run.

### DIFF
--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -159,7 +159,7 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
       - name: Comment
-        uses: peter-evans/create_or_update_comment@v1
+        uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.number }}
           body: ${{ steps.get-comment-body.outputs.body }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -2,11 +2,24 @@
 name: Docs Diff
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 jobs:
+  check-label:
+    name: Check for "Docs" label
+    runs-on: ubuntu-latest
+    outputs:
+      hadLabel: ${{ steps.label.outcome == "skipped" }}
+    steps:
+      - id: label
+        name: Check for "Docs" label
+        run: exit 1 # Fail the job!
+        if: "!contains(github.event.pull_request.labels.*.name, 'Docs')"
+        continue-on-error: true
   build-head:
     name: Build docs on HEAD.
     runs-on: ubuntu-latest
+    needs: check-label
+    if: ${{ !needs.check-id.outputs.hadLabel }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -64,6 +77,8 @@ jobs:
   build-base:
     name: Build docs on base.
     runs-on: ubuntu-latest
+    needs: check-label
+    if: ${{ !needs.check-id.outputs.hadLabel }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -122,7 +137,8 @@ jobs:
           path: docs/public
   diff:
     name: Diff
-    needs: [build-head, build-base]
+    needs: [check-label, build-head, build-base]
+    if: ${{ !needs.check-id.outputs.hadLabel }}
     runs-on: ubuntu-latest
     steps:
       - name: Pull old build of docs.
@@ -147,9 +163,10 @@ jobs:
       - id: get-comment-body
         run: |
           body=$(cat <<EOF
-            This PR contains docs changes. Comment "Docs changes ok" and rerun the job
-            if you expected this, and review the changes by running the docs locally,
-            checking for out of date code snippets.
+            This PR contains docs changes.
+
+            Add the "Docs" label to the PR if you expected this. Otherwise,
+            you should review the changes and determine if they are correct.
 
             Diff:
 
@@ -161,14 +178,6 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
         if: ${{ steps.diff.outcome == 'failure' }}
-      - name: Look for bot comment.
-        id: comment-bot-check
-        uses: peter-evans/find-comment@v1
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: "Docs changes ok"
-          comment-author: "github-actions[bot]"
-        if: ${{ steps.diff.outcome == 'failure' }}
       - name: Comment
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -176,15 +185,4 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.get-comment-body.outputs.body }}
           edit-mode: replace
-        if: ${{ steps.diff.outcome == 'failure' }}
-      - name: Look for resolving comment.
-        id: comment-check
-        uses: peter-evans/find-comment@v1
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: "Docs changes ok"
-          comment-author: ${{ github.event.pull_request.user.login }}
-        if: ${{ steps.diff.outcome == 'failure' }}
-      - name: Make sure comment exists.
-        run: test ${{ steps.comment-check.outputs.comment-id }} -gt 0
         if: ${{ steps.diff.outcome == 'failure' }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -3,6 +3,8 @@ name: Docs Diff
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
 jobs:
   build-head:
     name: Build docs on HEAD.

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -143,6 +143,7 @@ jobs:
         run: rm -rf head/java/reference/api head/python/reference/api head/ruby/reference/api head/node/reference/api
 
       - name: Diff
+        id: diff
         run: set -o pipefail && diff -q --recursive base head | tee diff.txt
         continue-on-error: true
       - id: get-comment-body
@@ -161,17 +162,22 @@ jobs:
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
-        if: ${{ failure() }}
+        if: ${{ steps.diff.outcome == "failure" }}
       - name: Comment
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.get-comment-body.outputs.body }}
-        if: ${{ failure() }}
+        if: ${{ steps.diff.outcome == "failure" }}
       - name: Look for resolving comment.
+        id: comment-check
         uses: peter-evans/find-comment@v1
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: "Docs changes ok"
           comment-author: ${{ github.event.pull_request.user.login }}
-        if: ${{ failure() }}
+        if: ${{ steps.diff.outcome == "failure" }}
+      - name: Make sure comment exists.
+        uses: peter-evans/find-comment@v1
+        run: test -n ${{ steps.comment-check.comment-id }}
+        if: ${{ steps.diff.outcome == "failure" }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -188,10 +188,3 @@ jobs:
       - name: Make sure comment exists.
         run: test ${{ steps.comment-check.outputs.comment-id }} -gt 0
         if: ${{ steps.diff.outcome == 'failure' }}
-      - name: Thumbs up
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ steps.comment-bot.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          reactions: +1
-        if: ${{ steps.diff.outcome == 'failure' }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -141,7 +141,7 @@ jobs:
         run: rm -rf head/java/reference/api head/python/reference/api head/ruby/reference/api head/node/reference/api
 
       - name: Diff
-        run: diff --recursive base head | tee diff.txt
+        run: diff -q --recursive base head | tee diff.txt
       - id: get-comment-body
         run: |
           body=$(cat <<EOF

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: new-docs
-          path: docs/_build
+          path: docs/public
   build-base:
     name: Build docs on base.
     runs-on: ubuntu-latest
@@ -119,7 +119,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: old-docs
-          path: docs/_build
+          path: docs/public
   diff:
     name: Diff
     needs: [build-head, build-base]

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -160,8 +160,7 @@ jobs:
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
-        with:
-          continue-on-error: true
+        continue-on-error: true
       - name: Comment
         uses: peter-evans/create-or-update-comment@v1
         with:

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -162,4 +162,4 @@ jobs:
         uses: peter-evans/create_or_update_comment@v1
         with:
           issue-number: ${{ github.event.number }}
-          body: : ${{ steps.get-comment-body.outputs.body }}
+          body: ${{ steps.get-comment-body.outputs.body }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -139,5 +139,27 @@ jobs:
         run: rm -rf base/java/reference/api base/python/reference/api base/ruby/reference/api base/node/reference/api
       - name: Remove ignored files (generated api docs)
         run: rm -rf head/java/reference/api head/python/reference/api head/ruby/reference/api head/node/reference/api
+
       - name: Diff
-        run: diff --recursive base head
+        run: diff --recursive base head | tee diff.txt
+      - id: get-comment-body
+        run: |
+          body=$(cat <<EOF
+            This PR contains docs changes. Comment "Docs changes ok" if you expected this,
+            or review the changes by running the docs locally, checking for out of date
+            code snippets.
+
+            Diff:
+
+          EOF
+          )
+          body=$(cat <(echo $body) diff.txt)
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
+      - name: Comment
+        uses: peter-evans/create_or_update_comment@v1
+        with:
+          issue-number: ${{ github.event.number }}
+          body: : ${{ steps.get-comment-body.outputs.body }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -162,13 +162,13 @@ jobs:
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
-        if: ${{ steps.diff.outcome == "failure" }}
+        if: ${{ steps.diff.outcome == 'failure' }}
       - name: Comment
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.get-comment-body.outputs.body }}
-        if: ${{ steps.diff.outcome == "failure" }}
+        if: ${{ steps.diff.outcome == 'failure' }}
       - name: Look for resolving comment.
         id: comment-check
         uses: peter-evans/find-comment@v1
@@ -176,7 +176,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: "Docs changes ok"
           comment-author: ${{ github.event.pull_request.user.login }}
-        if: ${{ steps.diff.outcome == "failure" }}
+        if: ${{ steps.diff.outcome == 'failure' }}
       - name: Make sure comment exists.
         run: test -n ${{ steps.comment-check.comment-id }}
-        if: ${{ steps.diff.outcome == "failure" }}
+        if: ${{ steps.diff.outcome == 'failure' }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -135,5 +135,9 @@ jobs:
         with:
           name: new-docs
           path: head
+      - name: Remove ignored files (generated api docs)
+        run: rm -rf base/java/reference/api base/python/reference/api base/ruby/reference/api base/node/reference/api
+      - name: Remove ignored files (generated api docs)
+        run: rm -rf head/java/reference/api head/python/reference/api head/ruby/reference/api head/node/reference/api
       - name: Diff
         run: diff --recursive base head

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -3,8 +3,6 @@ name: Docs Diff
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  pull_request_review_comment:
-    types: [created, edited, deleted]
 jobs:
   build-head:
     name: Build docs on HEAD.
@@ -149,9 +147,9 @@ jobs:
       - id: get-comment-body
         run: |
           body=$(cat <<EOF
-            This PR contains docs changes. Comment "Docs changes ok" if you expected this,
-            or review the changes by running the docs locally, checking for out of date
-            code snippets.
+            This PR contains docs changes. Comment "Docs changes ok" and rerun the job
+            if you expected this, and review the changes by running the docs locally,
+            checking for out of date code snippets.
 
             Diff:
 
@@ -174,7 +172,7 @@ jobs:
       - name: Comment
         uses: peter-evans/create-or-update-comment@v1
         with:
-          comment-id: ${{ steps.comment-bot-check.comment-id }}
+          comment-id: ${{ steps.comment-bot-check.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.get-comment-body.outputs.body }}
           edit-mode: replace
@@ -195,5 +193,5 @@ jobs:
         with:
           comment-id: ${{ steps.comment-bot.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          reaction: "+1"
+          reactions: +1
         if: ${{ steps.diff.outcome == 'failure' }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: github.base_ref
+          ref: ${{ github.base_ref }}
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -143,7 +143,7 @@ jobs:
         run: rm -rf head/java/reference/api head/python/reference/api head/ruby/reference/api head/node/reference/api
 
       - name: Diff
-        run: diff -q --recursive base head | tee diff.txt
+        run: set -o pipefail && diff -q --recursive base head | tee diff.txt
       - id: get-comment-body
         run: |
           body=$(cat <<EOF

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -66,7 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        ref: github.base_ref
+        with:
+          ref: github.base_ref
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -1,0 +1,138 @@
+# Check for changes in docs output.
+name: Docs Diff
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build-head:
+    name: Build docs on HEAD.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
+      ### Setup dependencies
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: "3.7"
+      - name: Install Ruby + gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 2.4
+          working-directory: "languages/ruby"
+      - name: Install yard
+        run: gem install yard
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      ### Build Rust WASM target
+      - name: Add WebAssembly target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build Rust WASM
+        run: make wasm-build
+      ### Build Python package
+      - name: Build Python
+        run: make python-build
+      ### Build docs
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.79.1'
+      - name: Build Hugo docs
+        run: make build
+        working-directory: docs
+      - name: Upload new build of docs.
+        uses: actions/upload-artifact@v2
+        with:
+          name: new-docs
+          path: docs/_build
+  build-base:
+    name: Build docs on base.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        ref: github.base_ref
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
+      ### Setup dependencies
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: "3.7"
+      - name: Install Ruby + gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 2.4
+          working-directory: "languages/ruby"
+      - name: Install yard
+        run: gem install yard
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      ### Build Rust WASM target
+      - name: Add WebAssembly target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build Rust WASM
+        run: make wasm-build
+      ### Build Python package
+      - name: Build Python
+        run: make python-build
+      ### Build docs
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.79.1'
+      - name: Build Hugo docs
+        run: make build
+        working-directory: docs
+      - name: Upload old build of docs.
+        uses: actions/upload-artifact@v2
+        with:
+          name: old-docs
+          path: docs/_build
+  diff:
+    name: Diff
+    needs: [build-head, build-base]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull old build of docs.
+        uses: actions/download-artifact@v2
+        with:
+          name: old-docs
+          path: base
+      - name: Pull new build of docs.
+        uses: actions/download-artifact@v2
+        with:
+          name: new-docs
+          path: head
+      - name: Diff
+        run: diff --recursive base head

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -178,6 +178,5 @@ jobs:
           comment-author: ${{ github.event.pull_request.user.login }}
         if: ${{ steps.diff.outcome == "failure" }}
       - name: Make sure comment exists.
-        uses: peter-evans/find-comment@v1
         run: test -n ${{ steps.comment-check.comment-id }}
         if: ${{ steps.diff.outcome == "failure" }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -144,6 +144,7 @@ jobs:
 
       - name: Diff
         run: set -o pipefail && diff -q --recursive base head | tee diff.txt
+        continue-on-error: true
       - id: get-comment-body
         run: |
           body=$(cat <<EOF
@@ -160,7 +161,7 @@ jobs:
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
-        continue-on-error: true
+        if: ${{ failure() }}
       - name: Comment
         uses: peter-evans/create-or-update-comment@v1
         with:

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -188,12 +188,12 @@ jobs:
           comment-author: ${{ github.event.pull_request.user.login }}
         if: ${{ steps.diff.outcome == 'failure' }}
       - name: Make sure comment exists.
-        run: test ${{ steps.comment-check.comment-id }} -gt 0
+        run: test ${{ steps.comment-check.outputs.comment-id }} -gt 0
         if: ${{ steps.diff.outcome == 'failure' }}
       - name: Thumbs up
         uses: peter-evans/create-or-update-comment@v1
         with:
-          comment-id: ${{ steps.comment-bot.comment-id }}
+          comment-id: ${{ steps.comment-bot.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           reaction: "+1"
         if: ${{ steps.diff.outcome == 'failure' }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -163,11 +163,21 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
         if: ${{ steps.diff.outcome == 'failure' }}
+      - name: Look for bot comment.
+        id: comment-bot-check
+        uses: peter-evans/find-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: "Docs changes ok"
+          comment-author: "github-actions[bot]"
+        if: ${{ steps.diff.outcome == 'failure' }}
       - name: Comment
         uses: peter-evans/create-or-update-comment@v1
         with:
+          comment-id: ${{ steps.comment-bot-check.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.get-comment-body.outputs.body }}
+          edit-mode: replace
         if: ${{ steps.diff.outcome == 'failure' }}
       - name: Look for resolving comment.
         id: comment-check
@@ -178,5 +188,12 @@ jobs:
           comment-author: ${{ github.event.pull_request.user.login }}
         if: ${{ steps.diff.outcome == 'failure' }}
       - name: Make sure comment exists.
-        run: test -n ${{ steps.comment-check.comment-id }}
+        run: test ${{ steps.comment-check.comment-id }} -gt 0
+        if: ${{ steps.diff.outcome == 'failure' }}
+      - name: Thumbs up
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.comment-bot.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          reaction: "+1"
         if: ${{ steps.diff.outcome == 'failure' }}

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -158,8 +158,18 @@ jobs:
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
+        with:
+          continue-on-error: true
       - name: Comment
         uses: peter-evans/create-or-update-comment@v1
         with:
-          issue-number: ${{ github.event.number }}
+          issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.get-comment-body.outputs.body }}
+        if: ${{ failure() }}
+      - name: Look for resolving comment.
+        uses: peter-evans/find-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: "Docs changes ok"
+          comment-author: ${{ github.event.pull_request.user.login }}
+        if: ${{ failure() }}

--- a/docs/content/any/_index.md
+++ b/docs/content/any/_index.md
@@ -10,3 +10,5 @@ Oso gives you a mental model and an authorization system – a set of APIs built
 Oso lets you offload the thinking of how to design authorization and build features fast, while keeping the flexibility to extend and customize as you see fit.
 
 Developers can typically write a working Oso policy in <5 minutes, add Oso to an app in <30 minutes, and use Oso to solve real authorization problems within a few hours. To get started, you add the library to your application, create a new Oso instance and load an Oso policy. You can mix and match any of Oso's authorization APIs to implement features like roles with custom policies that you write to suit your application.
+
+Test....

--- a/docs/content/python/new-roles/getting-started.md
+++ b/docs/content/python/new-roles/getting-started.md
@@ -219,6 +219,8 @@ route handlers
     linenos=true
     >}}
 
+I changed this!
+
 ### Making a query without authorization
 
 We can make queries without any authorization by setting the `checked_permissions=None`


### PR DESCRIPTION
Add a job that looks for changes in the docs made by a diff by building the docs against the branch and base branch.

If there are changes, will comment on the PR, as in #937 and require a comment to acknowledge the changes (you must manually re-run the job). The intent of this is to catch PRs that inadvertently break the docs, like changes to code included in code snippets.

If you make a PR changing the docs intentionally, just comment "Docs changes ok" after uploading, and the job will pass on the first run.

If you don't make any changes to the docs (#936), the job also passes, with no comment required.

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.