### PR TITLE
Replace type specializer with class value in resource configuration

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -20,7 +20,6 @@ before upgrading.
 {{% /callout %}}
 
 We've made some updates to the syntax of the `resource` predicate, used to configure resources + roles for sqlalchemy-oso-preview. The goal of these changes is to improve the readability of the configuration and make the roles
-features more intuitive to use.
 
 #### Rename "perms" -> "permissions" in resource roles configuration
 
@@ -31,10 +30,15 @@ We have renamed this field to `permissions` for clarity.
 
 Previously, we required role names to be globally unique. Now, role names will be internally namespaced, removing the globally unique requirement. Like permissions, the role namespace is the resource name specified in the `resource` predicate. Roles names must be unique within a single resource namespace. Roles associated with other resources must be referenced using the namespace. Roles within the same resource can be referenced without the namespace.
 
+#### Remove the `_type:` syntax from the `resource` predicate
+
+The `resource` predicate used to take the resource type parameter as a specializer. Now the predicate takes this parameter as a direct argument, removing the need for the `resource(_type: ResourceType, ...)` syntax. Now, the syntax is `resource(ResourceType, ...)`.
+
 Below is an example `resource` predicate that reflects the above changes. For a more in-depth example, see our [documentation](TODO!!!!) and [example repository](TODO!!!).
 
 ```polar
-    resource(_type: Organization, "org", actions, roles) if
+    # Removed `_type: ` from first argument
+    resource(Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
             member: {

--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -19,7 +19,7 @@ This release contains breaking changes. Be sure to follow migration steps
 before upgrading.
 {{% /callout %}}
 
-We've made some updates to the syntax of the `resource` predicate, used to configure resources + roles for sqlalchemy-oso-preview. The goal of these changes is to improve the readability of the config and make the roles
+We've made some updates to the syntax of the `resource` predicate, used to configure resources + roles for sqlalchemy-oso-preview. The goal of these changes is to improve the readability of the configuration and make the roles
 features more intuitive to use.
 
 #### Rename "perms" -> "permissions" in resource roles configuration

--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -1,9 +1,9 @@
 ---
-title: Release YYYY-MM-DD
-menuTitle: YYYY-MM-DD
+title: Release 2021-05-16
+menuTitle: 2021-05-16
 any: true
 description: >-
-  Changelog for Release YYYY-MM-DD (RELEASED_VERSIONS) containing new features,
+  Changelog for Release 2021-05-16 (sqlalchemy-oso-preview) containing new features,
   bug fixes, and more.
 draft: true
 ---
@@ -15,13 +15,39 @@ draft: true
 <!-- TODO: remove warning and replace with "None" if no breaking changes. -->
 
 {{% callout "Warning" "orange" %}}
-  This release contains breaking changes. Be sure to follow migration steps
-  before upgrading.
+This release contains breaking changes. Be sure to follow migration steps
+before upgrading.
 {{% /callout %}}
 
-#### Breaking change 1
+We've made some updates to the syntax of the `resource` predicate, used to configure resources + roles for sqlalchemy-oso-preview. The goal of these changes is to improve the readability of the config and make the roles
+features more intuitive to use.
 
-Summary of breaking change.
+#### Rename "perms" -> "permissions" in resource roles configuration
+
+The `roles` parameter of the `resource` previously included a field called `perms` to specify the role permissions.
+We have renamed this field to `permissions` for clarity.
+
+#### Add namespaces to role names
+
+Previously, we required role names to be globally unique. Now, role names will be internally namespaced, removing the globally unique requirement. Like permissions, the role namespace is the resource name specified in the `resource` predicate. Roles names must be unique within a single resource namespace. Roles associated with other resources must be referenced using the namespace. Roles within the same resource can be referenced without the namespace.
+
+Below is an example `resource` predicate that reflects the above changes. For a more in-depth example, see our [documentation](TODO!!!!) and [example repository](TODO!!!).
+
+```polar
+    resource(_type: Organization, "org", actions, roles) if
+        actions = ["invite", "list_repos"] and
+        roles = {
+            member: {
+                # `perms` renamed to `permissions`
+                permissions: ["invite"]
+            },
+            owner: {
+                permissions: ["list_repos"],
+                # Roles from a different resource are now referenced by namespace
+                implies: ["member", "repo:reader"]
+            }
+        };
+```
 
 Link to [migration guide]().
 

--- a/docs/content/python/new-roles/getting-started.md
+++ b/docs/content/python/new-roles/getting-started.md
@@ -334,10 +334,10 @@ resource(_type: Org, "org", actions, roles) if
     actions = ["read", "create_repo"] and
     roles = {
         org_member: {
-            perms: ["read"],
+            permissions: ["read"],
         },
         org_owner: {
-            perms: ["read", "create_repo"],
+            permissions: ["read", "create_repo"],
         }
     };
 ```
@@ -364,10 +364,10 @@ We could have written this rule without a body, like:
 resource( _type: Org, "org", ["read", "create_repo"],
     {
         org_member: {
-            perms: ["read"],
+            permissions: ["read"],
         },
         org_owner: {
-            perms: ["read", "create_repo"],
+            permissions: ["read", "create_repo"],
         }
     }
 );
@@ -429,10 +429,10 @@ resource(_type: Org, "org", actions, roles) if
     actions = ["read", "create_repo"] and
     roles = {
         org_member: {
-            perms: ["read"],
+            permissions: ["read"],
         },
         org_owner: {
-            perms: ["create_repo"],
+            permissions: ["create_repo"],
             implies: ["org_member"]
         }
     };

--- a/docs/spelling/allowed_words.txt
+++ b/docs/spelling/allowed_words.txt
@@ -126,6 +126,7 @@ multitenant
 musl
 mutex
 namespace
+namespaced
 namespaces
 natively
 nbsp

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -488,18 +488,12 @@ def read_config(oso):
     )
     role_definitions = []
     for result in role_resources:
-        resource_def = result["bindings"]["resource"]
-        assert resource_def.operator == "And"
-        assert len(resource_def.args) == 1
-        arg = resource_def.args[0]
-        type = isa_type(arg)
+        python_class = result["bindings"]["resource"]
+        assert python_class in oso.host.classes.values()
 
         resource_name = result["bindings"]["name"]
         permissions = result["bindings"]["permissions"]
         role_defs = result["bindings"]["roles"]
-
-        assert type in oso.host.classes
-        python_class = oso.host.classes[type]
 
         if isinstance(permissions, Variable):
             permissions = []

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -421,11 +421,11 @@ def read_config(oso):
     #     ] and
     #     roles = {
     #         repo_write: {
-    #             perms: ["push", "issue:edit"],
+    #             permissions: ["push", "issue:edit"],
     #             implies: ["repo_read"]
     #         },
     #         repo_read: {
-    #             perms: ["pull"]
+    #             permissions: ["pull"]
     #         }
     #     };
     # The first argument lets us use a specializer to say what the python class is.
@@ -433,7 +433,7 @@ def read_config(oso):
     # The third arg should be bound to a list of actions defined for the resource.
     # The fouth arg should be bound to a map from role name to role definition.
     #   Each role definitions has two fields,
-    #     perms which says which permissions the role has
+    #     permissions which says which permissions the role has
     #     and implies which says which other roles are implied by having this one.
     role_resources = oso.query_rule(
         "resource",
@@ -507,12 +507,12 @@ def read_config(oso):
                 raise OsoError(f"Duplicate role name {name}")
 
             for key in role_def.keys():
-                if key not in ("perms", "implies"):
+                if key not in ("permissions", "implies"):
                     raise OsoError(f"Invalid key in role definition :'{key}'")
 
             role_permissions = []
-            if "perms" in role_def:
-                for permission in role_def["perms"]:
+            if "permissions" in role_def:
+                for permission in role_def["permissions"]:
                     perm = parse_permission(permission, python_class, config)
                     role_permissions.append(perm)
 

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -311,6 +311,7 @@ class Resource:
 @dataclass
 class Config:
     resources: Dict[str, Resource]
+    class_to_resource_name: Dict[Any, str]
     permissions: List[Permission]
     roles: Dict[str, Role]
     relationships: List[Relationship]
@@ -338,11 +339,47 @@ def parse_permission(permission, python_class, config):
     return perm
 
 
+def parse_role_name(role_name, resource_class, config, other_ok=False):
+    """Parse a role name and return a normalized role name (with namspace).
+
+    :param role_name: un-normalized role name
+    :type role_name: str
+    :param resource_class: python class of resource inside which this role was defined
+    :type resource_class: Any
+    :param config: role config
+    :type config: Config
+    :param other_ok: Flag to indicate if a namespace other than `resource_name` is allowed, defaults to False
+    :type other_ok: bool, optional
+    :return: Normalized role name (with namespace)
+    :rtype: str
+    """
+    assert resource_class in config.class_to_resource_name
+    resource_name = config.class_to_resource_name[resource_class]
+    if ":" in role_name:
+        namespace, _ = role_name.split(":", 1)
+        if namespace not in config.resources:
+            raise OsoError(f"Invalid role namespace {namespace}.")
+    else:
+        role_name = f"{resource_name}:{role_name}"
+
+    return role_name
+
+
 def read_config(oso):
+    """Queries the Oso policy for resource and relationship configurations
+
+    :param oso: Oso object with correct policy loaded
+    :type oso: Oso
+    :return: configuration object that stores resource, permissions, roles, and relationships
+    :rtype: Config
     """
-    Queries the polar policy for the configuration
-    """
-    config = Config(resources={}, permissions=[], roles={}, relationships=[])
+    config = Config(
+        resources={},
+        class_to_resource_name={},
+        permissions=[],
+        roles={},
+        relationships=[],
+    )
 
     # Register relationships
     role_relationships = oso.query_rule(
@@ -451,7 +488,7 @@ def read_config(oso):
         arg = resource_def.args[0]
         type = isa_type(arg)
 
-        name = result["bindings"]["name"]
+        resource_name = result["bindings"]["name"]
         permissions = result["bindings"]["permissions"]
         role_defs = result["bindings"]["roles"]
 
@@ -474,17 +511,18 @@ def read_config(oso):
         if len(permissions) == 0 and len(role_names) == 0:
             raise OsoError("Must define actions or roles for resource.")
 
-        if name in config.resources:
-            raise OsoError(f"Duplicate resource name {name}")
+        if resource_name in config.resources:
+            raise OsoError(f"Duplicate resource name {resource_name}")
 
         resource = Resource(
             python_class=python_class,
             type=python_class.__name__,
-            name=name,
+            name=resource_name,
             actions=permissions,
             roles=role_names,
         )
         config.resources[resource.name] = resource
+        config.class_to_resource_name[python_class] = resource_name
 
         permissions = [
             Permission(
@@ -502,9 +540,20 @@ def read_config(oso):
         if isinstance(role_defs, Variable):
             continue  # No roles defined
 
-        for name, role_def in role_defs.items():
-            if name in config.roles:
-                raise OsoError(f"Duplicate role name {name}")
+        for role_name, role_def in role_defs.items():
+            # preprocess role name
+            role_name = parse_role_name(role_name, python_class, config)
+            # split = role_name.split(":")
+            # if len(split) > 1:
+            #     if split[0] != resource_name:
+            #         raise OsoError(
+            #             f"Cannot define role for resource {split[0]} inside resource definition for {resource_name}."
+            #         )
+            # else:
+            #     role_name = f"{resource_name}:{role_name}"
+
+            if role_name in config.roles:
+                raise OsoError(f"Duplicate role name {role_name}")
 
             for key in role_def.keys():
                 if key not in ("permissions", "implies"):
@@ -518,13 +567,16 @@ def read_config(oso):
 
             implied_roles = []
             if "implies" in role_def:
-                implied_roles = role_def["implies"]
+                implied_roles = [
+                    parse_role_name(role, python_class, config, other_ok=True)
+                    for role in role_def["implies"]
+                ]
 
             if len(role_permissions) == 0 and len(implied_roles) == 0:
                 raise OsoError("Must define permissions or implied roles for a role.")
 
             role = Role(
-                name=name,
+                name=role_name,
                 python_class=python_class,
                 type=python_class.__name__,
                 permissions=role_permissions,
@@ -533,15 +585,15 @@ def read_config(oso):
             config.roles[role.name] = role
 
     # Validate config
-    for name, role in config.roles.items():
+    for role_name, role in config.roles.items():
         for permission in role.permissions:
             if permission.python_class != role.python_class:
                 for _, other_role in config.roles.items():
                     if other_role.python_class == permission.python_class:
                         raise OsoError(
-                            f"Permission {permission.name} on {permission.type} "
-                            + f"can not go on role {name} on {role.type} "
-                            + f"because {permission.type} has it's own roles. Use an implication."
+                            f"""Permission {permission.name} on {permission.type}
+                            can not go on role {role_name} on {role.type}
+                            because {permission.type} has it's own roles. Use an implication."""
                         )
 
                 cls = permission.python_class
@@ -555,14 +607,16 @@ def read_config(oso):
                     if not stepped:
                         raise OsoError(
                             f"Permission {permission.name} on {permission.type} "
-                            + f"can not go on role {name} on {role.type} "
+                            + f"can not go on role {role_name} on {role.type} "
                             + "because no relationship exists."
                         )
 
         for implied in role.implied_roles:
             # Make sure implied role exists
             if implied not in config.roles:
-                raise OsoError(f"Role '{implied}' implied by '{name}' does not exist.")
+                raise OsoError(
+                    f"Role '{implied}' implied by '{role_name}' does not exist."
+                )
             implied_role = config.roles[implied]
             # Make sure implied role is on a valid class
             cls = implied_role.python_class
@@ -575,7 +629,7 @@ def read_config(oso):
                         break
                 if not stepped:
                     raise OsoError(
-                        f"Role {name} on {role.type} "
+                        f"Role {role_name} on {role.type} "
                         + f"can not imply role {implied} on {implied_role.type} "
                         + "because no relationship exists."
                     )
@@ -684,7 +738,7 @@ class OsoRoles:
             class Role(oso.base):
                 __tablename__ = "roles"
                 name = Column(String, primary_key=True)
-                resource_type = Column(String)
+                resource_type = Column(String, primary_key=True)
 
         if models.get("RolePermission"):
             RolePermission = models["RolePermission"]
@@ -907,6 +961,7 @@ class OsoRoles:
 
     def _get_user_role(self, session, user, resource, role_name):
         """Gets user role for resource if exists"""
+        role_name = parse_role_name(role_name, type(resource), self.config)
         if role_name not in self.config.roles:
             raise OsoError(f"Could not find role {role_name}")
 
@@ -914,9 +969,9 @@ class OsoRoles:
 
         if not resource.__class__ == role.python_class:
             raise OsoError(
-                f'No Role "{role_name}" '
-                + "for resource {resource} "
-                + "(expected resource to be of type {role.type})."
+                f"""No Role "{role_name}"
+                for resource {resource}
+                (expected resource to be of type {role.type})."""
             )
 
         user_pk_name, _ = get_pk(user.__class__)
@@ -939,6 +994,9 @@ class OsoRoles:
 
     @ensure_configured
     def assign_role(self, user, resource, role_name, session=None, reassign=True):
+        role_name = parse_role_name(role_name, type(resource), self.config)
+        assert ":" in role_name
+
         if not session:
             my_session = self._get_session()
         else:
@@ -974,6 +1032,8 @@ class OsoRoles:
 
     @ensure_configured
     def remove_role(self, user, resource, role_name, session=None):
+        role_name = parse_role_name(role_name, type(resource), self.config)
+        assert ":" in role_name
         if not session:
             my_session = self._get_session()
         else:

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -427,8 +427,8 @@ def read_config(oso):
             child_relationships = inspect(child_python_class).relationships
             if child_attr not in child_relationships:
                 raise OsoError(
-                    f"Invalid Relationship: {child_attr} "
-                    + "is not a sqlalchemy relationship field."
+                    f"""Invalid Relationship: {child_attr}
+                    is not a sqlalchemy relationship field."""
                 )
             rel = child_relationships[child_attr]
             parent_join_column = list(rel.remote_side)[0].name
@@ -544,15 +544,6 @@ def read_config(oso):
         for role_name, role_def in role_defs.items():
             # preprocess role name
             role_name = parse_role_name(role_name, python_class, config)
-            # split = role_name.split(":")
-            # if len(split) > 1:
-            #     if split[0] != resource_name:
-            #         raise OsoError(
-            #             f"Cannot define role for resource {split[0]} inside resource definition for {resource_name}."
-            #         )
-            # else:
-            #     role_name = f"{resource_name}:{role_name}"
-
             if role_name in config.roles:
                 raise OsoError(f"Duplicate role name {role_name}")
 
@@ -607,9 +598,9 @@ def read_config(oso):
                             break
                     if not stepped:
                         raise OsoError(
-                            f"Permission {permission.name} on {permission.type} "
-                            + f"can not go on role {role_name} on {role.type} "
-                            + "because no relationship exists."
+                            f"""Permission {permission.name} on {permission.type}
+                            can not go on role {role_name} on {role.type}
+                            because no relationship exists."""
                         )
 
         for implied in role.implied_roles:
@@ -630,9 +621,9 @@ def read_config(oso):
                         break
                 if not stepped:
                     raise OsoError(
-                        f"Role {role_name} on {role.type} "
-                        + f"can not imply role {implied} on {implied_role.type} "
-                        + "because no relationship exists."
+                        f"""Role {role_name} on {role.type}
+                        can not imply role {implied} on {implied_role.type}
+                        because no relationship exists."""
                     )
             # Make sure implied roles dont have overlapping permissions.
             # @TODO: Follow implication chair further than just one.
@@ -640,9 +631,9 @@ def read_config(oso):
             for implied_perm in implied_role.permissions:
                 if implied_perm in permissions:
                     raise OsoError(
-                        f"Invalid implication. Role {role} has permission {implied_perm.name} "
-                        + f"on {implied_perm.type} but implies role {implied} "
-                        + f"which also has permission {implied_perm.name} on {implied_perm.type}"
+                        f"""Invalid implication. Role {role} has permission {implied_perm.name}
+                        on {implied_perm.type} but implies role {implied}
+                        which also has permission {implied_perm.name} on {implied_perm.type}"""
                     )
 
     if len(config.resources) == 0:
@@ -692,9 +683,9 @@ class OsoRoles:
                 canonical_model = model
             elif resource_id_column_type.__class__ != id_type.__class__:
                 raise OsoError(
-                    "All resources must have the same primary key type:"
-                    + f"\n\t{model} has PK type {id_type}"
-                    + f"\n\t{canonical_model} has PK type {resource_id_column_type}"
+                    f"""All resources must have the same primary key type:
+                    \n\t{model} has PK type {id_type}
+                    \n\t{canonical_model} has PK type {resource_id_column_type}"""
                 )
 
         if resource_id_column_type is None:
@@ -1011,8 +1002,8 @@ class OsoRoles:
                 user_role.role = role_name
             else:
                 raise OsoError(
-                    f"User {user} already has a role for this resource."
-                    + "To reassign, call with `reassign=True`."
+                    f"""User {user} already has a role for this resource.
+                    To reassign, call with `reassign=True`."""
                 )
         else:
             user_pk_name, _ = get_pk(user.__class__)

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -353,7 +353,7 @@ def parse_role_name(role_name, resource_class, config, other_ok=False):
     :return: Normalized role name (with namespace)
     :rtype: str
     """
-    if not resource_class in config.class_to_resource_name:
+    if resource_class not in config.class_to_resource_name:
         raise OsoError(f"Unrecognized resource type {resource_class}.")
     resource_name = config.class_to_resource_name[resource_class]
     if ":" in role_name:

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles2.py
@@ -366,6 +366,11 @@ def parse_role_name(role_name, resource_class, config, other_ok=False):
     return role_name
 
 
+def remove_role_namespace(role_name):
+    _, name = role_name.split(":", 1)
+    return name
+
+
 def read_config(oso):
     """Queries the Oso policy for resource and relationship configurations
 
@@ -1049,7 +1054,7 @@ class OsoRoles:
         roles = []
         for name, role in self.config.roles.items():
             if role.python_class == resource_class:
-                roles.append(name)
+                roles.append(remove_role_namespace(name))
         return roles
 
     @ensure_configured
@@ -1070,7 +1075,10 @@ class OsoRoles:
             )
             .all()
         )
-        return [{"user_id": ur.user_id, "role": ur.role} for ur in user_roles]
+        return [
+            {"user_id": ur.user_id, "role": remove_role_namespace(ur.role)}
+            for ur in user_roles
+        ]
 
     @ensure_configured
     def assignments_for_user(self, user, session=None):
@@ -1092,7 +1100,7 @@ class OsoRoles:
             {
                 "resource_type": ur.resource_type,
                 "resource_id": ur.resource_id,
-                "role": ur.role,
+                "role": remove_role_namespace(ur.role),
             }
             for ur in user_roles
         ]

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -415,7 +415,29 @@ def test_relationship_without_resources(init_oso):
         oso.roles.synchronize_data()
 
 
-def test_duplicate_role_name(init_oso, sample_data):
+def test_duplicate_role_name_same_resource(init_oso):
+    oso, session = init_oso
+    policy = """
+    resource(_type: Organization, "org", actions, roles) if
+        actions = [
+            "invite", "create_repo"
+        ] and
+        roles = {
+            owner: {
+                permissions: ["invite"],
+                implies: ["member", "repo:member"]
+            },
+            owner: {
+                permissions: ["create_repo"]
+            }
+        };
+        """
+    oso.load_str(policy)
+    with pytest.raises(OsoError):
+        oso.roles.synchronize_data()
+
+
+def test_duplicate_role_name_different_resources(init_oso, sample_data):
     # duplicate role name throws an error
     # Organization and Repository resources both have role named "member"
     oso, session = init_oso
@@ -453,7 +475,6 @@ def test_duplicate_role_name(init_oso, sample_data):
     """
     oso.load_str(policy)
 
-    # with pytest.raises(OsoError):
     oso.roles.synchronize_data()
 
     osohq = sample_data["osohq"]

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -247,7 +247,7 @@ def test_bad_namespace_perm(init_oso):
         ] and
         roles = {
             member: {
-                perms: ["repo:pull"]
+                permissions: ["repo:pull"]
             }
         };
     """
@@ -277,7 +277,7 @@ def test_resource_with_roles_no_actions(init_oso, sample_data):
         ] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 
@@ -311,7 +311,7 @@ def test_duplicate_resource_name(init_oso):
         actions = ["invite"] and
         roles = {
             member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -323,7 +323,7 @@ def test_duplicate_resource_name(init_oso):
         ] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
     """
@@ -341,7 +341,7 @@ def test_nested_dot_relationship(init_oso):
         actions = ["invite"] and
         roles = {
             member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -367,7 +367,7 @@ def test_bad_relationship_lookup(init_oso):
         actions = ["invite"] and
         roles = {
             member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -426,7 +426,7 @@ def test_duplicate_role_name(init_oso):
         ] and
         roles = {
             member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -437,7 +437,7 @@ def test_duplicate_role_name(init_oso):
         ] and
         roles = {
             member: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
     """
@@ -486,7 +486,7 @@ def test_undeclared_permission(init_oso):
         ] and
         roles = {
             org_member: {
-                perms: ["create_repo"]
+                permissions: ["create_repo"]
             }
         };
     """
@@ -536,7 +536,7 @@ def test_role_implication_without_relationship(init_oso):
         ] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
     """
@@ -555,7 +555,7 @@ def test_role_permission_without_relationship(init_oso):
         ] and
         roles = {
             org_member: {
-                perms: ["repo:push"]
+                permissions: ["repo:push"]
             }
         };
 
@@ -581,7 +581,7 @@ def test_invalid_role_permission(init_oso):
         roles = {
             org_member: {
                 # THIS IS NOT ALLOWED
-                perms: ["repo:push"]
+                permissions: ["repo:push"]
             }
         };
 
@@ -592,7 +592,7 @@ def test_invalid_role_permission(init_oso):
         ] and
         roles = {
             repo_read: {
-                perms: ["push"]
+                permissions: ["push"]
             }
 
         };
@@ -616,10 +616,10 @@ def test_permission_assignment_to_implied_role(init_oso):
         ] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             },
             org_owner: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["org_member"]
             }
 
@@ -716,7 +716,7 @@ def test_overlapping_permissions(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["repo_read"]
             }
         };
@@ -728,11 +728,11 @@ def test_overlapping_permissions(init_oso, sample_data):
         ] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             },
             repo_write: {
                 # repo_write is more permissive than org_member
-                perms: ["push"],
+                permissions: ["push"],
                 implies: ["repo_read"]
             }
         };
@@ -774,7 +774,7 @@ def test_homogeneous_role_perm(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -800,7 +800,7 @@ def test_homogeneous_role_perm(init_oso, sample_data):
         roles = {
             org_member: {
                 # REMOVE INVITE AND ADD LIST_REPOS
-                perms: ["list_repos"]
+                permissions: ["list_repos"]
             }
         };
 
@@ -827,7 +827,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite", "repo:pull"]
+                permissions: ["invite", "repo:pull"]
             }
         };
 
@@ -864,7 +864,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -899,10 +899,10 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
         actions = ["list_repos", "invite"] and
         roles = {
             org_member: {
-                perms: ["list_repos", "issue:edit"]
+                permissions: ["list_repos", "issue:edit"]
             },
             org_owner: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["org_member"]
             }
         };
@@ -948,7 +948,7 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -985,7 +985,7 @@ def test_homogeneous_role_implication(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             },
             org_owner: {
                 implies: ["org_member"]
@@ -1017,11 +1017,11 @@ def test_homogeneous_role_implication(init_oso, sample_data):
         actions = ["invite", "list_repos"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             },
             org_owner: {
                 # REMOVE "implies"
-                perms: ["list_repos"]
+                permissions: ["list_repos"]
             }
         };
 
@@ -1051,7 +1051,7 @@ def test_parent_child_role_implication(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["repo_read"]
             }
         };
@@ -1063,7 +1063,7 @@ def test_parent_child_role_implication(init_oso, sample_data):
         ] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 
@@ -1095,7 +1095,7 @@ def test_parent_child_role_implication(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -1131,7 +1131,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["issue_editor"]
             }
         };
@@ -1142,7 +1142,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
         ] and
         roles = {
             issue_editor: {
-                perms: ["edit"]
+                permissions: ["edit"]
             }
         };
 
@@ -1175,7 +1175,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -1185,7 +1185,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
         ] and
         roles = {
             issue_editor: {
-                perms: ["edit"]
+                permissions: ["edit"]
             }
         };
 
@@ -1217,7 +1217,7 @@ def test_chained_role_implication(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["repo_read"]
 
             }
@@ -1230,7 +1230,7 @@ def test_chained_role_implication(init_oso, sample_data):
         ] and
         roles = {
             repo_read: {
-                perms: ["pull"],
+                permissions: ["pull"],
                 implies: ["issue_editor"]
             }
         };
@@ -1241,7 +1241,7 @@ def test_chained_role_implication(init_oso, sample_data):
         ] and
         roles = {
             issue_editor: {
-                perms: ["edit"]
+                permissions: ["edit"]
             }
         };
 
@@ -1283,7 +1283,7 @@ def test_chained_role_implication(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -1294,7 +1294,7 @@ def test_chained_role_implication(init_oso, sample_data):
         ] and
         roles = {
             repo_read: {
-                perms: ["pull"],
+                permissions: ["pull"],
                 implies: ["issue_editor"]
             }
         };
@@ -1305,7 +1305,7 @@ def test_chained_role_implication(init_oso, sample_data):
         ] and
         roles = {
             issue_editor: {
-                perms: ["edit"]
+                permissions: ["edit"]
             }
         };
 
@@ -1350,7 +1350,7 @@ def test_assign_role_wrong_resource_type(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -1375,7 +1375,7 @@ def test_assign_remove_nonexistent_role(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -1403,7 +1403,7 @@ def test_remove_unassigned_role(init_oso, sample_data):
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -1428,10 +1428,10 @@ def test_assign_remove_user_role(init_oso, sample_data):
         actions = ["invite", "list_repos"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             },
             org_owner: {
-                perms: ["list_repos"]
+                permissions: ["list_repos"]
             }
         };
 
@@ -1502,10 +1502,10 @@ def test_reassign_user_role(init_oso, sample_data):
         actions = ["invite", "list_repos"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             },
             org_owner: {
-                perms: ["list_repos"],
+                permissions: ["list_repos"],
                 implies: ["org_member", "repo_read"]
             }
         };
@@ -1514,7 +1514,7 @@ def test_reassign_user_role(init_oso, sample_data):
         actions = ["pull"] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 
@@ -1581,7 +1581,7 @@ def test_authorizing_related_fields(
         actions = ["invite", "read"] and
         roles = {
             org_member: {
-                perms: ["invite", "read"],
+                permissions: ["invite", "read"],
                 implies: ["repo_read"]
             }
         };
@@ -1590,7 +1590,7 @@ def test_authorizing_related_fields(
         actions = ["pull"] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 
@@ -1630,7 +1630,7 @@ def test_data_filtering_role_allows_not(
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -1671,7 +1671,7 @@ def test_data_filtering_role_allows_and(
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["repo_read"]
             }
         };
@@ -1680,7 +1680,7 @@ def test_data_filtering_role_allows_and(
         actions = ["pull"] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 
@@ -1732,7 +1732,7 @@ def test_data_filtering_role_allows_explicit_or(
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["repo_read"]
             }
         };
@@ -1741,7 +1741,7 @@ def test_data_filtering_role_allows_explicit_or(
         actions = ["pull"] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 
@@ -1801,7 +1801,7 @@ def test_data_filtering_role_allows_implicit_or(
         actions = ["read"] and
         roles = {
             org_member: {
-                perms: ["read"]
+                permissions: ["read"]
             }
         };
 
@@ -1839,7 +1839,7 @@ def test_data_filtering_user_in_role_not(
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -1880,7 +1880,7 @@ def test_data_filtering_user_in_role_and(
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["repo_read"]
             }
         };
@@ -1889,7 +1889,7 @@ def test_data_filtering_user_in_role_and(
         actions = ["pull"] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 
@@ -1941,7 +1941,7 @@ def test_data_filtering_user_in_role_explicit_or(
         actions = ["invite"] and
         roles = {
             org_member: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["repo_read"]
             }
         };
@@ -1950,7 +1950,7 @@ def test_data_filtering_user_in_role_explicit_or(
         actions = ["pull"] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 
@@ -2010,7 +2010,7 @@ def test_data_filtering_user_in_role_implicit_or(
         actions = ["read"] and
         roles = {
             org_member: {
-                perms: ["read"]
+                permissions: ["read"]
             }
         };
 
@@ -2051,7 +2051,7 @@ def test_data_filtering_combo(
         actions = ["read"] and
         roles = {
             org_member: {
-                perms: ["read"]
+                permissions: ["read"]
             }
         };
 
@@ -2093,10 +2093,10 @@ def test_read_api(init_oso, sample_data, Repository, Organization):
         actions = ["invite", "list_repos"] and
         roles = {
             org_member: {
-                perms: ["list_repos"]
+                permissions: ["list_repos"]
             },
             org_owner: {
-                perms: ["invite"]
+                permissions: ["invite"]
             }
         };
 
@@ -2104,7 +2104,7 @@ def test_read_api(init_oso, sample_data, Repository, Organization):
         actions = ["pull"] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 
@@ -2173,7 +2173,7 @@ def test_user_in_role(
         actions = ["pull"] and
         roles = {
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 
@@ -2284,7 +2284,7 @@ def test_id_types(engine, Base, User, sa_type, one_id):
     Base.metadata.create_all(engine)
 
     policy = """
-    resource(_type: One, "one", ["read"], {boss: {perms: ["read"]}});
+    resource(_type: One, "one", ["read"], {boss: {permissions: ["read"]}});
     resource(_type: Two, "two", ["read"], _roles);
 
     allow(actor, action, resource) if
@@ -2318,11 +2318,11 @@ def test_roles(init_oso, auth_sessionmaker, User, Organization, Repository, Issu
         ] and
         roles = {
             org_member: {
-                perms: ["create_repo"],
+                permissions: ["create_repo"],
                 implies: ["repo_read"]
             },
             org_owner: {
-                perms: ["invite"],
+                permissions: ["invite"],
                 implies: ["org_member", "repo_write"]
             }
         };
@@ -2334,11 +2334,11 @@ def test_roles(init_oso, auth_sessionmaker, User, Organization, Repository, Issu
         ] and
         roles = {
             repo_write: {
-                perms: ["push", "issue:edit"],
+                permissions: ["push", "issue:edit"],
                 implies: ["repo_read"]
             },
             repo_read: {
-                perms: ["pull"]
+                permissions: ["pull"]
             }
         };
 

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -222,7 +222,7 @@ def test_empty_role(init_oso):
     # defining role with no permissions/implications throws an error
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite"
         ] and
@@ -241,7 +241,7 @@ def test_bad_namespace_perm(init_oso):
     # - assigning permission with bad namespace throws an error
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite"
         ] and
@@ -263,14 +263,14 @@ def test_resource_with_roles_no_actions(init_oso, sample_data):
     # - only define roles, no actions (role has actions/implications from different resource)
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", _, roles) if
+    resource(Organization, "org", _, roles) if
         roles = {
             member: {
                 implies: ["repo:reader"]
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -307,7 +307,7 @@ def test_duplicate_resource_name(init_oso):
     # - duplicate resource name throws an error
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -316,7 +316,7 @@ def test_duplicate_resource_name(init_oso):
         };
 
     # DUPLICATE RESOURCE NAME "org"
-    resource(_type: Repository, "org", actions, roles) if
+    resource(Repository, "org", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -337,7 +337,7 @@ def test_nested_dot_relationship(init_oso):
     # - multiple dot lookups throws an error for now
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -345,7 +345,7 @@ def test_nested_dot_relationship(init_oso):
             }
         };
 
-    resource(_type: Issue, "issue", actions, roles) if
+    resource(Issue, "issue", actions, roles) if
         actions = [
             "edit"
         ];
@@ -363,7 +363,7 @@ def test_bad_relationship_lookup(init_oso):
     # - nonexistent attribute lookup throws an error for now
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -371,7 +371,7 @@ def test_bad_relationship_lookup(init_oso):
             }
         };
 
-    resource(_type: Repository, "repo", actions, _) if
+    resource(Repository, "repo", actions, _) if
         actions = [
             "pull"
         ];
@@ -389,7 +389,7 @@ def test_bad_relationship_lookup(init_oso):
 def test_relationship_without_specializer(init_oso):
     oso, session = init_oso
     policy = """
-    resource(_type: Repository, "repo", actions, _) if
+    resource(Repository, "repo", actions, _) if
         actions = [
             "pull"
         ];
@@ -418,7 +418,7 @@ def test_relationship_without_resources(init_oso):
 def test_duplicate_role_name_same_resource(init_oso):
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite", "create_repo"
         ] and
@@ -442,7 +442,7 @@ def test_duplicate_role_name_different_resources(init_oso, sample_data):
     # Organization and Repository resources both have role named "member"
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite", "create_repo"
         ] and
@@ -456,7 +456,7 @@ def test_duplicate_role_name_different_resources(init_oso, sample_data):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -503,7 +503,7 @@ def test_resource_actions(init_oso):
     # only define actions, not roles
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite"
         ];
@@ -516,7 +516,7 @@ def test_duplicate_action(init_oso):
     # - duplicate action
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite",
             "invite"
@@ -532,7 +532,7 @@ def test_undeclared_permission(init_oso):
     # - assign permission that wasn't declared
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite"
         ] and
@@ -552,7 +552,7 @@ def test_undeclared_role(init_oso):
     # - imply role that wasn't declared
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite"
         ] and
@@ -571,7 +571,7 @@ def test_role_implication_without_relationship(init_oso):
     # - imply role without valid relationship
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite"
         ] and
@@ -581,7 +581,7 @@ def test_role_implication_without_relationship(init_oso):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -601,7 +601,7 @@ def test_role_permission_without_relationship(init_oso):
     # - assign permission without valid relationship
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite"
         ] and
@@ -611,7 +611,7 @@ def test_role_permission_without_relationship(init_oso):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -626,7 +626,7 @@ def test_invalid_role_permission(init_oso):
     # assigning permission on related role type errors if role exists for permission resource
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite"
         ] and
@@ -637,7 +637,7 @@ def test_invalid_role_permission(init_oso):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -662,7 +662,7 @@ def test_permission_assignment_to_implied_role(init_oso):
     # assigning the same permission to two roles where one implies the other throws an error
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite"
         ] and
@@ -687,7 +687,7 @@ def test_incorrect_arity_resource(init_oso):
     # - use resource predicate with incorrect arity
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions) if
+    resource(Organization, "org", actions) if
         actions = [
             "invite"
         ];
@@ -701,7 +701,7 @@ def test_undefined_resource_arguments(init_oso):
     # - use resource predicate without defining actions/roles
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles);
+    resource(Organization, "org", actions, roles);
     """
     oso.load_str(policy)
     with pytest.raises(OsoError):
@@ -712,7 +712,7 @@ def test_wrong_type_resource_arguments(init_oso):
     # - use resource predicate with field types
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -764,7 +764,7 @@ def test_overlapping_permissions(init_oso, sample_data):
     # - Assigning a more permissive and less permissive role to the same user grants most permissive access
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -773,7 +773,7 @@ def test_overlapping_permissions(init_oso, sample_data):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -822,7 +822,7 @@ def test_homogeneous_role_perm(init_oso, sample_data):
     # - Adding a permission of same resource type to a role grants assignee access
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -847,7 +847,7 @@ def test_homogeneous_role_perm(init_oso, sample_data):
 
     # - Removing a permission of same resource type from a role revokes assignee access
     new_policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
             member: {
@@ -875,7 +875,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
     # - Adding a permission of child resource type to a role grants assignee access
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -883,7 +883,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -912,7 +912,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
 
     # - Removing a permission of child resource type from a role revokes assignee access
     new_policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -920,7 +920,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -947,7 +947,7 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
     # - Adding a permission of grandchild resource type to a role grants assignee access (without intermediate resource)
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["list_repos", "invite"] and
         roles = {
             member: {
@@ -959,7 +959,7 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
             }
         };
 
-    resource(_type: Issue, "issue", actions, _) if
+    resource(Issue, "issue", actions, _) if
         actions = [
             "edit"
         ];
@@ -996,7 +996,7 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
 
     # - Removing a permission of grandchild resource type from a role revokes assignee access
     new_policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1004,7 +1004,7 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
             }
         };
 
-    resource(_type: Issue, "issue", actions, _) if
+    resource(Issue, "issue", actions, _) if
         actions = [
             "edit"
         ];
@@ -1033,7 +1033,7 @@ def test_homogeneous_role_implication(init_oso, sample_data):
     # - Adding a role implication of same resource type to a role grants assignee access
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1065,7 +1065,7 @@ def test_homogeneous_role_implication(init_oso, sample_data):
 
     # - Removing a role implication of same resource type from a role revokes assignee access
     new_policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
             member: {
@@ -1099,7 +1099,7 @@ def test_parent_child_role_implication(init_oso, sample_data):
     # - Adding a role implication of child resource type to a role grants assignee access to child
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1108,7 +1108,7 @@ def test_parent_child_role_implication(init_oso, sample_data):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -1143,7 +1143,7 @@ def test_parent_child_role_implication(init_oso, sample_data):
 
     # - Removing a role implication of child resource type from a role revokes assignee access to child
     new_policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1151,7 +1151,7 @@ def test_parent_child_role_implication(init_oso, sample_data):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -1179,7 +1179,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
     #   without intermediate parent resource
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1188,7 +1188,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
             }
         };
 
-    resource(_type: Issue, "issue", actions, roles) if
+    resource(Issue, "issue", actions, roles) if
         actions = [
             "edit"
         ] and
@@ -1223,7 +1223,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
 
     # - Removing a permission of grandchild resource type from a role revokes assignee access
     new_policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1231,7 +1231,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
             }
         };
 
-    resource(_type: Issue, "issue", actions, roles) if
+    resource(Issue, "issue", actions, roles) if
         actions = [
             "edit"
         ] and
@@ -1265,7 +1265,7 @@ def test_chained_role_implication(init_oso, sample_data):
     # role access to grandchild resource
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1275,7 +1275,7 @@ def test_chained_role_implication(init_oso, sample_data):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -1287,7 +1287,7 @@ def test_chained_role_implication(init_oso, sample_data):
             }
         };
 
-    resource(_type: Issue, "issue", actions, roles) if
+    resource(Issue, "issue", actions, roles) if
         actions = [
             "edit"
         ] and
@@ -1331,7 +1331,7 @@ def test_chained_role_implication(init_oso, sample_data):
     # - Removing a role implication from grandparent->parent->child resource role types revokes assignee of grandparent
     # role access to grandchild resource
     new_policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1339,7 +1339,7 @@ def test_chained_role_implication(init_oso, sample_data):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -1351,7 +1351,7 @@ def test_chained_role_implication(init_oso, sample_data):
             }
         };
 
-    resource(_type: Issue, "issue", actions, roles) if
+    resource(Issue, "issue", actions, roles) if
         actions = [
             "edit"
         ] and
@@ -1398,7 +1398,7 @@ def test_assign_role_wrong_resource_type(init_oso, sample_data):
     # - Assigning to role with wrong resource type throws an error
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1423,7 +1423,7 @@ def test_assign_remove_nonexistent_role(init_oso, sample_data):
     # - Assigning/removing non-existent role throws an error
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1451,7 +1451,7 @@ def test_remove_unassigned_role(init_oso, sample_data):
     # - Removing role that user doesn't have returns false
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1476,7 +1476,7 @@ def test_assign_remove_user_role(init_oso, sample_data):
     # - Adding user-role assignment grants access
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
             member: {
@@ -1550,7 +1550,7 @@ def test_reassign_user_role(init_oso, sample_data):
     # - Implied roles for the same resource type are mutually exclusive on user-role assignment
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
             member: {
@@ -1562,7 +1562,7 @@ def test_reassign_user_role(init_oso, sample_data):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
             reader: {
@@ -1629,7 +1629,7 @@ def test_authorizing_related_fields(
 ):
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite", "read"] and
         roles = {
             member: {
@@ -1638,7 +1638,7 @@ def test_authorizing_related_fields(
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
             reader: {
@@ -1678,7 +1678,7 @@ def test_data_filtering_role_allows_not(
 ):
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1719,7 +1719,7 @@ def test_data_filtering_role_allows_and(
 ):
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1728,7 +1728,7 @@ def test_data_filtering_role_allows_and(
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
             reader: {
@@ -1780,7 +1780,7 @@ def test_data_filtering_role_allows_explicit_or(
 ):
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1789,7 +1789,7 @@ def test_data_filtering_role_allows_explicit_or(
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
             reader: {
@@ -1849,7 +1849,7 @@ def test_data_filtering_role_allows_implicit_or(
     # Users can read their own data.
     allow(user: User, "read", user);
 
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["read"] and
         roles = {
             member: {
@@ -1887,7 +1887,7 @@ def test_data_filtering_user_in_role_not(
 ):
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1928,7 +1928,7 @@ def test_data_filtering_user_in_role_and(
 ):
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1937,7 +1937,7 @@ def test_data_filtering_user_in_role_and(
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
             reader: {
@@ -1989,7 +1989,7 @@ def test_data_filtering_user_in_role_explicit_or(
 ):
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
             member: {
@@ -1998,7 +1998,7 @@ def test_data_filtering_user_in_role_explicit_or(
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
             reader: {
@@ -2062,7 +2062,7 @@ def test_data_filtering_user_in_role_implicit_or(
     # Users can read their own data.
     allow(user: User, "read", user);
 
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["read"] and
         roles = {
             member: {
@@ -2103,7 +2103,7 @@ def test_data_filtering_combo(
     # Users can read their own data.
     allow(user: User, "read", user);
 
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["read"] and
         roles = {
             member: {
@@ -2145,7 +2145,7 @@ def test_data_filtering_combo(
 def test_read_api(init_oso, sample_data, Repository, Organization):
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
             member: {
@@ -2156,7 +2156,7 @@ def test_read_api(init_oso, sample_data, Repository, Organization):
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
             reader: {
@@ -2215,7 +2215,7 @@ def test_user_in_role(
 ):
     oso, session = init_oso
     policy = """
-    resource(_type: Organization, "org", _actions, roles) if
+    resource(Organization, "org", _actions, roles) if
         roles = {
             member: {
                 implies: ["repo:reader"]
@@ -2225,7 +2225,7 @@ def test_user_in_role(
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
             reader: {
@@ -2340,8 +2340,8 @@ def test_id_types(engine, Base, User, sa_type, one_id):
     Base.metadata.create_all(engine)
 
     policy = """
-    resource(_type: One, "one", ["read"], {boss: {permissions: ["read"]}});
-    resource(_type: Two, "two", ["read"], _roles);
+    resource(One, "one", ["read"], {boss: {permissions: ["read"]}});
+    resource(Two, "two", ["read"], _roles);
 
     allow(actor, action, resource) if
         Roles.role_allows(actor, action, resource);
@@ -2369,7 +2369,7 @@ def test_roles_integration(
     oso, session = init_oso
 
     policy = """
-    resource(_type: Organization, "org", actions, roles) if
+    resource(Organization, "org", actions, roles) if
         actions = [
             "invite",
             "create_repo"
@@ -2385,7 +2385,7 @@ def test_roles_integration(
             }
         };
 
-    resource(_type: Repository, "repo", actions, roles) if
+    resource(Repository, "repo", actions, roles) if
         actions = [
             "push",
             "pull"
@@ -2400,7 +2400,7 @@ def test_roles_integration(
             }
         };
 
-    resource(_type: Issue, "issue", actions, _) if
+    resource(Issue, "issue", actions, _) if
         actions = [
             "edit"
         ];

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -415,18 +415,22 @@ def test_relationship_without_resources(init_oso):
         oso.roles.synchronize_data()
 
 
-def test_duplicate_role_name(init_oso):
+def test_duplicate_role_name(init_oso, sample_data):
     # duplicate role name throws an error
     # Organization and Repository resources both have role named "member"
     oso, session = init_oso
     policy = """
     resource(_type: Organization, "org", actions, roles) if
         actions = [
-            "invite"
+            "invite", "create_repo"
         ] and
         roles = {
+            owner: {
+                permissions: ["invite"],
+                implies: ["member", "repo:member"]
+            },
             member: {
-                permissions: ["invite"]
+                permissions: ["create_repo"]
             }
         };
 
@@ -440,11 +444,38 @@ def test_duplicate_role_name(init_oso):
                 permissions: ["pull"]
             }
         };
+
+    parent(repo: Repository, parent_org: Organization) if
+        repo.org = parent_org;
+
+    allow(actor, action, resource) if
+        Roles.role_allows(actor, action, resource);
     """
     oso.load_str(policy)
 
-    with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+    # with pytest.raises(OsoError):
+    oso.roles.synchronize_data()
+
+    osohq = sample_data["osohq"]
+    oso_repo = sample_data["oso_repo"]
+    leina = sample_data["leina"]
+    steve = sample_data["steve"]
+    gabe = sample_data["gabe"]
+
+    oso.roles.assign_role(leina, osohq, "owner", session)
+    oso.roles.assign_role(steve, oso_repo, "member", session)
+    oso.roles.assign_role(gabe, osohq, "member", session)
+    session.commit()
+
+    assert oso.is_allowed(leina, "invite", osohq)
+    assert oso.is_allowed(leina, "pull", oso_repo)
+
+    assert not oso.is_allowed(steve, "invite", osohq)
+    assert oso.is_allowed(steve, "pull", oso_repo)
+
+    assert not oso.is_allowed(gabe, "invite", osohq)
+    assert oso.is_allowed(gabe, "create_repo", osohq)
+    assert not oso.is_allowed(gabe, "pull", oso_repo)
 
 
 def test_resource_actions(init_oso):

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -2183,12 +2183,12 @@ def test_read_api(init_oso, sample_data, Repository, Organization):
     # - [ ] Test getting all roles for a resource
     repo_roles = oso.roles.for_resource(Repository, session)
     assert len(repo_roles) == 1
-    assert repo_roles[0] == "repo:reader"
+    assert repo_roles[0] == "reader"
 
     org_roles = oso.roles.for_resource(Organization, session)
     assert len(org_roles) == 2
-    assert "org:member" in org_roles
-    assert "org:owner" in org_roles
+    assert "member" in org_roles
+    assert "owner" in org_roles
 
     # - [ ] Test getting all role assignments for a resource
     oso.roles.assign_role(leina, osohq, "member", session=session)
@@ -2363,7 +2363,9 @@ def test_id_types(engine, Base, User, sa_type, one_id):
 # LEGACY TEST
 
 
-def test_roles(init_oso, auth_sessionmaker, User, Organization, Repository, Issue):
+def test_roles_integration(
+    init_oso, auth_sessionmaker, User, Organization, Repository, Issue
+):
     oso, session = init_oso
 
     policy = """
@@ -2491,9 +2493,9 @@ def test_roles(init_oso, auth_sessionmaker, User, Organization, Repository, Issu
     assert not oso.is_allowed(gabe, "edit", bug)
 
     org_roles = oso.roles.for_resource(Repository)
-    assert set(org_roles) == {"repo:reader", "repo:writer"}
+    assert set(org_roles) == {"reader", "writer"}
     oso_assignments = oso.roles.assignments_for_resource(osohq)
     assert oso_assignments == [
-        {"user_id": leina.id, "role": "org:owner"},
-        {"user_id": steve.id, "role": "org:member"},
+        {"user_id": leina.id, "role": "owner"},
+        {"user_id": steve.id, "role": "member"},
     ]

--- a/languages/python/sqlalchemy-oso/tests/test_roles2.py
+++ b/languages/python/sqlalchemy-oso/tests/test_roles2.py
@@ -266,7 +266,7 @@ def test_resource_with_roles_no_actions(init_oso, sample_data):
     resource(_type: Organization, "org", _, roles) if
         roles = {
             member: {
-                implies: ["repo_read"]
+                implies: ["repo:reader"]
             }
         };
 
@@ -276,7 +276,7 @@ def test_resource_with_roles_no_actions(init_oso, sample_data):
             "pull"
         ] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -297,7 +297,7 @@ def test_resource_with_roles_no_actions(init_oso, sample_data):
     oso_repo = sample_data["oso_repo"]
 
     oso.roles.assign_role(leina, osohq, "member", session)
-    oso.roles.assign_role(steve, oso_repo, "repo_read", session)
+    oso.roles.assign_role(steve, oso_repo, "reader", session)
 
     assert oso.is_allowed(leina, "pull", oso_repo)
     assert oso.is_allowed(steve, "pull", oso_repo)
@@ -322,7 +322,7 @@ def test_duplicate_resource_name(init_oso):
             "pull"
         ] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -516,7 +516,7 @@ def test_undeclared_permission(init_oso):
             "invite"
         ] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["create_repo"]
             }
         };
@@ -536,7 +536,7 @@ def test_undeclared_role(init_oso):
             "invite"
         ] and
         roles = {
-            org_member: {
+            member: {
                 implies: ["fake_role"]
             }
         };
@@ -555,8 +555,8 @@ def test_role_implication_without_relationship(init_oso):
             "invite"
         ] and
         roles = {
-            org_member: {
-                implies: ["repo_read"]
+            member: {
+                implies: ["repo:reader"]
             }
         };
 
@@ -566,7 +566,7 @@ def test_role_implication_without_relationship(init_oso):
             "pull"
         ] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -585,7 +585,7 @@ def test_role_permission_without_relationship(init_oso):
             "invite"
         ] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["repo:push"]
             }
         };
@@ -610,7 +610,7 @@ def test_invalid_role_permission(init_oso):
             "invite"
         ] and
         roles = {
-            org_member: {
+            member: {
                 # THIS IS NOT ALLOWED
                 permissions: ["repo:push"]
             }
@@ -622,7 +622,7 @@ def test_invalid_role_permission(init_oso):
             "pull"
         ] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["push"]
             }
 
@@ -646,12 +646,12 @@ def test_permission_assignment_to_implied_role(init_oso):
             "invite"
         ] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             },
-            org_owner: {
+            owner: {
                 permissions: ["invite"],
-                implies: ["org_member"]
+                implies: ["org:member"]
             }
 
         };
@@ -694,7 +694,7 @@ def test_wrong_type_resource_arguments(init_oso):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 # incorrect key name
                 actions: ["invite"]
             }
@@ -746,9 +746,9 @@ def test_overlapping_permissions(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"],
-                implies: ["repo_read"]
+                implies: ["repo:reader"]
             }
         };
 
@@ -758,13 +758,13 @@ def test_overlapping_permissions(init_oso, sample_data):
             "pull"
         ] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             },
-            repo_write: {
-                # repo_write is more permissive than org_member
+            writer: {
+                # writer is more permissive than reader
                 permissions: ["push"],
-                implies: ["repo_read"]
+                implies: ["reader"]
             }
         };
 
@@ -782,10 +782,10 @@ def test_overlapping_permissions(init_oso, sample_data):
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    # repo_write is more permissive than org_member
-    oso.roles.assign_role(leina, osohq, "org_member")
-    oso.roles.assign_role(steve, osohq, "org_member")
-    oso.roles.assign_role(leina, oso_repo, "repo_write")
+    # writer is more permissive than member
+    oso.roles.assign_role(leina, osohq, "member")
+    oso.roles.assign_role(steve, osohq, "member")
+    oso.roles.assign_role(leina, oso_repo, "writer")
 
     assert oso.is_allowed(leina, "pull", oso_repo)
     assert oso.is_allowed(leina, "invite", osohq)
@@ -804,7 +804,7 @@ def test_homogeneous_role_perm(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
@@ -819,7 +819,7 @@ def test_homogeneous_role_perm(init_oso, sample_data):
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
 
     assert oso.is_allowed(leina, "invite", osohq)
     assert not oso.is_allowed(steve, "invite", osohq)
@@ -829,7 +829,7 @@ def test_homogeneous_role_perm(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
-            org_member: {
+            member: {
                 # REMOVE INVITE AND ADD LIST_REPOS
                 permissions: ["list_repos"]
             }
@@ -857,7 +857,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite", "repo:pull"]
             }
         };
@@ -883,7 +883,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
 
     assert oso.is_allowed(leina, "invite", osohq)
     assert oso.is_allowed(leina, "pull", oso_repo)
@@ -894,7 +894,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
@@ -929,12 +929,12 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["list_repos", "invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["list_repos", "issue:edit"]
             },
-            org_owner: {
+            owner: {
                 permissions: ["invite"],
-                implies: ["org_member"]
+                implies: ["member"]
             }
         };
 
@@ -961,14 +961,14 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
 
     assert oso.is_allowed(leina, "list_repos", osohq)
     assert oso.is_allowed(leina, "edit", oso_bug)
     assert not oso.is_allowed(leina, "invite", osohq)
     assert not oso.is_allowed(steve, "edit", oso_bug)
 
-    oso.roles.assign_role(steve, osohq, "org_owner", session=session)
+    oso.roles.assign_role(steve, osohq, "owner", session=session)
     assert oso.is_allowed(steve, "edit", oso_bug)
     assert oso.is_allowed(steve, "list_repos", osohq)
     assert oso.is_allowed(steve, "invite", osohq)
@@ -978,7 +978,7 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
@@ -1015,11 +1015,11 @@ def test_homogeneous_role_implication(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             },
-            org_owner: {
-                implies: ["org_member"]
+            owner: {
+                implies: ["member"]
             }
         };
 
@@ -1036,8 +1036,8 @@ def test_homogeneous_role_implication(init_oso, sample_data):
 
     assert not oso.is_allowed(leina, "invite", osohq)
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
-    oso.roles.assign_role(steve, osohq, "org_owner", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
+    oso.roles.assign_role(steve, osohq, "owner", session=session)
 
     assert oso.is_allowed(leina, "invite", osohq)
     assert oso.is_allowed(steve, "invite", osohq)
@@ -1047,10 +1047,10 @@ def test_homogeneous_role_implication(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             },
-            org_owner: {
+            owner: {
                 # REMOVE "implies"
                 permissions: ["list_repos"]
             }
@@ -1081,9 +1081,9 @@ def test_parent_child_role_implication(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"],
-                implies: ["repo_read"]
+                implies: ["repo:reader"]
             }
         };
 
@@ -1093,7 +1093,7 @@ def test_parent_child_role_implication(init_oso, sample_data):
             "pull"
         ] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -1113,8 +1113,8 @@ def test_parent_child_role_implication(init_oso, sample_data):
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    # org_member implies repo_read which has the "pull" permission
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
+    # member implies reader which has the "pull" permission
+    oso.roles.assign_role(leina, osohq, "member", session=session)
 
     assert oso.is_allowed(leina, "invite", osohq)
     assert oso.is_allowed(leina, "pull", oso_repo)
@@ -1125,7 +1125,7 @@ def test_parent_child_role_implication(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
@@ -1161,9 +1161,9 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"],
-                implies: ["issue_editor"]
+                implies: ["issue:editor"]
             }
         };
 
@@ -1172,7 +1172,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
             "edit"
         ] and
         roles = {
-            issue_editor: {
+            editor: {
                 permissions: ["edit"]
             }
         };
@@ -1194,7 +1194,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
 
     assert oso.is_allowed(leina, "invite", osohq)
     assert oso.is_allowed(leina, "edit", oso_bug)
@@ -1205,7 +1205,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
@@ -1215,7 +1215,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
             "edit"
         ] and
         roles = {
-            issue_editor: {
+            editor: {
                 permissions: ["edit"]
             }
         };
@@ -1247,9 +1247,9 @@ def test_chained_role_implication(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"],
-                implies: ["repo_read"]
+                implies: ["repo:reader"]
 
             }
         };
@@ -1260,9 +1260,9 @@ def test_chained_role_implication(init_oso, sample_data):
             "pull"
         ] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"],
-                implies: ["issue_editor"]
+                implies: ["issue:editor"]
             }
         };
 
@@ -1271,7 +1271,7 @@ def test_chained_role_implication(init_oso, sample_data):
             "edit"
         ] and
         roles = {
-            issue_editor: {
+            editor: {
                 permissions: ["edit"]
             }
         };
@@ -1294,8 +1294,8 @@ def test_chained_role_implication(init_oso, sample_data):
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
-    oso.roles.assign_role(steve, oso_repo, "repo_read", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
+    oso.roles.assign_role(steve, oso_repo, "reader", session=session)
 
     # leina can invite to the org, pull from the repo, and edit the issue
     assert oso.is_allowed(leina, "invite", osohq)
@@ -1313,7 +1313,7 @@ def test_chained_role_implication(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
@@ -1324,9 +1324,9 @@ def test_chained_role_implication(init_oso, sample_data):
             "pull"
         ] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"],
-                implies: ["issue_editor"]
+                implies: ["issue:editor"]
             }
         };
 
@@ -1335,7 +1335,7 @@ def test_chained_role_implication(init_oso, sample_data):
             "edit"
         ] and
         roles = {
-            issue_editor: {
+            editor: {
                 permissions: ["edit"]
             }
         };
@@ -1380,7 +1380,7 @@ def test_assign_role_wrong_resource_type(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
@@ -1395,7 +1395,7 @@ def test_assign_role_wrong_resource_type(init_oso, sample_data):
     leina = sample_data["leina"]
 
     with pytest.raises(OsoError):
-        oso.roles.assign_role(leina, oso_repo, "org_member", session=session)
+        oso.roles.assign_role(leina, oso_repo, "member", session=session)
 
 
 def test_assign_remove_nonexistent_role(init_oso, sample_data):
@@ -1405,7 +1405,7 @@ def test_assign_remove_nonexistent_role(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
@@ -1420,10 +1420,10 @@ def test_assign_remove_nonexistent_role(init_oso, sample_data):
     leina = sample_data["leina"]
 
     with pytest.raises(OsoError):
-        oso.roles.assign_role(leina, osohq, "org_owner", session=session)
+        oso.roles.assign_role(leina, osohq, "owner", session=session)
 
     with pytest.raises(OsoError):
-        oso.roles.remove_role(leina, osohq, "org_owner", session=session)
+        oso.roles.remove_role(leina, osohq, "owner", session=session)
 
 
 def test_remove_unassigned_role(init_oso, sample_data):
@@ -1433,7 +1433,7 @@ def test_remove_unassigned_role(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
@@ -1447,7 +1447,7 @@ def test_remove_unassigned_role(init_oso, sample_data):
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
 
-    removed = oso.roles.remove_role(leina, osohq, "org_member", session=session)
+    removed = oso.roles.remove_role(leina, osohq, "member", session=session)
     assert not removed
 
 
@@ -1458,10 +1458,10 @@ def test_assign_remove_user_role(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             },
-            org_owner: {
+            owner: {
                 permissions: ["list_repos"]
             }
         };
@@ -1476,7 +1476,7 @@ def test_assign_remove_user_role(init_oso, sample_data):
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
 
     # Assign leina member role
     leina_roles = (
@@ -1485,10 +1485,10 @@ def test_assign_remove_user_role(init_oso, sample_data):
         .all()
     )
     assert len(leina_roles) == 1
-    assert leina_roles[0].role == "org_member"
+    assert leina_roles[0].role == "org:member"
 
     # Assign steve owner role
-    oso.roles.assign_role(steve, osohq, "org_owner", session=session)
+    oso.roles.assign_role(steve, osohq, "owner", session=session)
 
     steve_roles = (
         session.query(oso.roles.UserRole)
@@ -1496,14 +1496,14 @@ def test_assign_remove_user_role(init_oso, sample_data):
         .all()
     )
     assert len(steve_roles) == 1
-    assert steve_roles[0].role == "org_owner"
+    assert steve_roles[0].role == "org:owner"
 
     assert oso.is_allowed(leina, "invite", osohq)
     assert not oso.is_allowed(steve, "invite", osohq)
     assert oso.is_allowed(steve, "list_repos", osohq)
 
     # - Removing user-role assignment revokes access
-    removed = oso.roles.remove_role(leina, osohq, "org_member", session=session)
+    removed = oso.roles.remove_role(leina, osohq, "member", session=session)
     assert removed
     leina_roles = (
         session.query(oso.roles.UserRole)
@@ -1519,7 +1519,7 @@ def test_assign_remove_user_role(init_oso, sample_data):
         .all()
     )
     assert len(steve_roles) == 1
-    assert steve_roles[0].role == "org_owner"
+    assert steve_roles[0].role == "org:owner"
 
     assert not oso.is_allowed(leina, "invite", osohq)
     assert oso.is_allowed(steve, "list_repos", osohq)
@@ -1532,19 +1532,19 @@ def test_reassign_user_role(init_oso, sample_data):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             },
-            org_owner: {
+            owner: {
                 permissions: ["list_repos"],
-                implies: ["org_member", "repo_read"]
+                implies: ["member", "repo:reader"]
             }
         };
 
     resource(_type: Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -1562,30 +1562,30 @@ def test_reassign_user_role(init_oso, sample_data):
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session)
+    oso.roles.assign_role(leina, osohq, "member", session)
     leina_roles = (
         session.query(oso.roles.UserRole)
         .filter(oso.roles.UserRole.user_id == leina.id)
         .all()
     )
     assert len(leina_roles) == 1
-    assert leina_roles[0].role == "org_member"
+    assert leina_roles[0].role == "org:member"
 
-    oso.roles.assign_role(steve, osohq, "org_owner", session)
+    oso.roles.assign_role(steve, osohq, "owner", session)
     steve_roles = (
         session.query(oso.roles.UserRole)
         .filter(oso.roles.UserRole.user_id == steve.id)
         .all()
     )
     assert len(steve_roles) == 1
-    assert steve_roles[0].role == "org_owner"
+    assert steve_roles[0].role == "org:owner"
 
     # reassigning with reassign=False throws an error
     with pytest.raises(OsoError):
-        oso.roles.assign_role(leina, osohq, "org_owner", reassign=False)
+        oso.roles.assign_role(leina, osohq, "owner", reassign=False)
 
     # reassign with reassign=True
-    oso.roles.assign_role(leina, osohq, "org_owner", session)
+    oso.roles.assign_role(leina, osohq, "owner", session)
 
     leina_roles = (
         session.query(oso.roles.UserRole)
@@ -1593,7 +1593,7 @@ def test_reassign_user_role(init_oso, sample_data):
         .all()
     )
     assert len(leina_roles) == 1
-    assert leina_roles[0].role == "org_owner"
+    assert leina_roles[0].role == "org:owner"
 
 
 # TEST DATA FILTERING
@@ -1611,16 +1611,16 @@ def test_authorizing_related_fields(
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite", "read"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite", "read"],
-                implies: ["repo_read"]
+                implies: ["repo:reader"]
             }
         };
 
     resource(_type: Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -1637,7 +1637,7 @@ def test_authorizing_related_fields(
     osohq = sample_data["osohq"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(steve, osohq, "org_member", session)
+    oso.roles.assign_role(steve, osohq, "member", session)
 
     oso.actor = steve
 
@@ -1660,7 +1660,7 @@ def test_data_filtering_role_allows_not(
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
@@ -1676,8 +1676,8 @@ def test_data_filtering_role_allows_not(
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
-    oso.roles.assign_role(steve, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
+    oso.roles.assign_role(steve, osohq, "member", session=session)
 
     # This is just to ensure we don't modify the policy above.
     assert not oso.is_allowed(leina, "invite", osohq)
@@ -1701,16 +1701,16 @@ def test_data_filtering_role_allows_and(
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"],
-                implies: ["repo_read"]
+                implies: ["repo:reader"]
             }
         };
 
     resource(_type: Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -1730,9 +1730,9 @@ def test_data_filtering_role_allows_and(
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
-    oso.roles.assign_role(leina, apple, "org_member", session=session)
-    oso.roles.assign_role(steve, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
+    oso.roles.assign_role(leina, apple, "member", session=session)
+    oso.roles.assign_role(steve, osohq, "member", session=session)
 
     # This is just to ensure we don't modify the policy above.
     assert oso.is_allowed(leina, "invite", osohq)
@@ -1762,16 +1762,16 @@ def test_data_filtering_role_allows_explicit_or(
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"],
-                implies: ["repo_read"]
+                implies: ["repo:reader"]
             }
         };
 
     resource(_type: Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -1791,7 +1791,7 @@ def test_data_filtering_role_allows_explicit_or(
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(steve, apple, "org_member", session=session)
+    oso.roles.assign_role(steve, apple, "member", session=session)
 
     # This is just to ensure we don't modify the policy above.
     assert oso.is_allowed(steve, "invite", osohq)
@@ -1831,7 +1831,7 @@ def test_data_filtering_role_allows_implicit_or(
     resource(_type: Organization, "org", actions, roles) if
         actions = ["read"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["read"]
             }
         };
@@ -1845,7 +1845,7 @@ def test_data_filtering_role_allows_implicit_or(
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
 
     # This is just to ensure we don't modify the policy above.
     assert oso.is_allowed(leina, "read", leina)
@@ -1869,13 +1869,13 @@ def test_data_filtering_user_in_role_not(
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"]
             }
         };
 
     allow(actor, action, resource) if
-        not Roles.user_in_role(actor, "org_member", resource);
+        not Roles.user_in_role(actor, "member", resource);
     """
     oso.load_str(policy)
     oso.roles.synchronize_data()
@@ -1885,8 +1885,8 @@ def test_data_filtering_user_in_role_not(
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
-    oso.roles.assign_role(steve, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
+    oso.roles.assign_role(steve, osohq, "member", session=session)
 
     # This is just to ensure we don't modify the policy above.
     assert not oso.is_allowed(leina, "invite", osohq)
@@ -1910,16 +1910,16 @@ def test_data_filtering_user_in_role_and(
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"],
-                implies: ["repo_read"]
+                implies: ["repo:reader"]
             }
         };
 
     resource(_type: Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -1928,7 +1928,7 @@ def test_data_filtering_user_in_role_and(
         repo.org = parent_org;
 
     allow(actor, action, resource) if
-        Roles.user_in_role(actor, "org_member", resource) and
+        Roles.user_in_role(actor, "member", resource) and
         resource.id = "osohq";
     """
     oso.load_str(policy)
@@ -1939,9 +1939,9 @@ def test_data_filtering_user_in_role_and(
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
-    oso.roles.assign_role(leina, apple, "org_member", session=session)
-    oso.roles.assign_role(steve, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
+    oso.roles.assign_role(leina, apple, "member", session=session)
+    oso.roles.assign_role(steve, osohq, "member", session=session)
 
     # This is just to ensure we don't modify the policy above.
     assert oso.is_allowed(leina, "invite", osohq)
@@ -1971,16 +1971,16 @@ def test_data_filtering_user_in_role_explicit_or(
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["invite"],
-                implies: ["repo_read"]
+                implies: ["repo:reader"]
             }
         };
 
     resource(_type: Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -1989,7 +1989,10 @@ def test_data_filtering_user_in_role_explicit_or(
         repo.org = parent_org;
 
     allow(actor, action, resource) if
-        Roles.user_in_role(actor, "org_member", resource) or
+        Roles.role_allows(actor, action, resource);
+
+    allow(actor, _, resource) if
+        Roles.user_in_role(actor, "member", resource) or
         resource.id = "osohq";
     """
     oso.load_str(policy)
@@ -2000,7 +2003,8 @@ def test_data_filtering_user_in_role_explicit_or(
     leina = sample_data["leina"]
     steve = sample_data["steve"]
 
-    oso.roles.assign_role(steve, apple, "org_member", session=session)
+    oso.roles.assign_role(steve, apple, "member", session=session)
+    session.commit()
 
     # This is just to ensure we don't modify the policy above.
     assert oso.is_allowed(steve, "invite", osohq)
@@ -2040,13 +2044,13 @@ def test_data_filtering_user_in_role_implicit_or(
     resource(_type: Organization, "org", actions, roles) if
         actions = ["read"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["read"]
             }
         };
 
     allow(actor, action, resource) if
-        Roles.user_in_role(actor, "org_member", resource);
+        Roles.user_in_role(actor, "member", resource);
     """
     oso.load_str(policy)
     oso.roles.synchronize_data()
@@ -2054,7 +2058,7 @@ def test_data_filtering_user_in_role_implicit_or(
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
 
     # This is just to ensure we don't modify the policy above.
     assert oso.is_allowed(leina, "read", leina)
@@ -2081,14 +2085,14 @@ def test_data_filtering_combo(
     resource(_type: Organization, "org", actions, roles) if
         actions = ["read"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["read"]
             }
         };
 
     allow(actor, action, resource) if
         role_allows = Roles.role_allows(actor, action, resource) and
-        user_in_role = Roles.user_in_role(actor, "org_member", resource) and
+        user_in_role = Roles.user_in_role(actor, "member", resource) and
         role_allows and user_in_role;
     """
     # You can't directly `and` the two Roles calls right now but it does work if you do it like ^
@@ -2098,7 +2102,7 @@ def test_data_filtering_combo(
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
 
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
 
     # This is just to ensure we don't modify the policy above.
     assert oso.is_allowed(leina, "read", leina)
@@ -2123,10 +2127,10 @@ def test_read_api(init_oso, sample_data, Repository, Organization):
     resource(_type: Organization, "org", actions, roles) if
         actions = ["invite", "list_repos"] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["list_repos"]
             },
-            org_owner: {
+            owner: {
                 permissions: ["invite"]
             }
         };
@@ -2134,7 +2138,7 @@ def test_read_api(init_oso, sample_data, Repository, Organization):
     resource(_type: Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -2158,19 +2162,19 @@ def test_read_api(init_oso, sample_data, Repository, Organization):
     # - [ ] Test getting all roles for a resource
     repo_roles = oso.roles.for_resource(Repository, session)
     assert len(repo_roles) == 1
-    assert repo_roles[0] == "repo_read"
+    assert repo_roles[0] == "repo:reader"
 
     org_roles = oso.roles.for_resource(Organization, session)
     assert len(org_roles) == 2
-    assert "org_member" in org_roles
-    assert "org_owner" in org_roles
+    assert "org:member" in org_roles
+    assert "org:owner" in org_roles
 
     # - [ ] Test getting all role assignments for a resource
-    oso.roles.assign_role(leina, osohq, "org_member", session=session)
-    oso.roles.assign_role(leina, oso_repo, "repo_read", session=session)
+    oso.roles.assign_role(leina, osohq, "member", session=session)
+    oso.roles.assign_role(leina, oso_repo, "reader", session=session)
 
-    oso.roles.assign_role(steve, osohq, "org_owner", session=session)
-    oso.roles.assign_role(steve, ios, "repo_read", session=session)
+    oso.roles.assign_role(steve, osohq, "owner", session=session)
+    oso.roles.assign_role(steve, ios, "reader", session=session)
 
     osohq_assignments = oso.roles.assignments_for_resource(osohq, session)
     assert len(osohq_assignments) == 2
@@ -2192,18 +2196,18 @@ def test_user_in_role(
     policy = """
     resource(_type: Organization, "org", _actions, roles) if
         roles = {
-            org_member: {
-                implies: ["repo_read"]
+            member: {
+                implies: ["repo:reader"]
             },
-            org_owner: {
-                implies: ["org_member"]
+            owner: {
+                implies: ["member"]
             }
         };
 
     resource(_type: Repository, "repo", actions, roles) if
         actions = ["pull"] and
         roles = {
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -2213,7 +2217,7 @@ def test_user_in_role(
 
 
     allow(actor, "read", repo: Repository) if
-        Roles.user_in_role(actor, "repo_read", repo);
+        Roles.user_in_role(actor, "reader", repo);
     """
     oso.load_str(policy)
     oso.roles.synchronize_data()
@@ -2224,8 +2228,8 @@ def test_user_in_role(
     steve = sample_data["steve"]
     gabe = sample_data["gabe"]
 
-    oso.roles.assign_role(leina, osohq, "org_member")
-    oso.roles.assign_role(steve, oso_repo, "repo_read")
+    oso.roles.assign_role(leina, osohq, "member")
+    oso.roles.assign_role(steve, oso_repo, "reader")
 
     # Without data filtering
     assert oso.is_allowed(leina, "read", oso_repo)
@@ -2348,13 +2352,13 @@ def test_roles(init_oso, auth_sessionmaker, User, Organization, Repository, Issu
             "create_repo"
         ] and
         roles = {
-            org_member: {
+            member: {
                 permissions: ["create_repo"],
-                implies: ["repo_read"]
+                implies: ["repo:reader"]
             },
-            org_owner: {
+            owner: {
                 permissions: ["invite"],
-                implies: ["org_member", "repo_write"]
+                implies: ["member", "repo:writer"]
             }
         };
 
@@ -2364,11 +2368,11 @@ def test_roles(init_oso, auth_sessionmaker, User, Organization, Repository, Issu
             "pull"
         ] and
         roles = {
-            repo_write: {
+            writer: {
                 permissions: ["push", "issue:edit"],
-                implies: ["repo_read"]
+                implies: ["reader"]
             },
-            repo_read: {
+            reader: {
                 permissions: ["pull"]
             }
         };
@@ -2416,8 +2420,8 @@ def test_roles(init_oso, auth_sessionmaker, User, Organization, Repository, Issu
 
     # @NOTE: Need the users and resources in the db before assigning roles
     # so you have to call session.commit() first.
-    oso.roles.assign_role(leina, osohq, "org_owner", session=session)
-    oso.roles.assign_role(steve, osohq, "org_member", session=session)
+    oso.roles.assign_role(leina, osohq, "owner", session=session)
+    oso.roles.assign_role(steve, osohq, "member", session=session)
 
     assert oso.is_allowed(leina, "invite", osohq)
     assert oso.is_allowed(leina, "create_repo", osohq)
@@ -2454,21 +2458,21 @@ def test_roles(init_oso, auth_sessionmaker, User, Organization, Repository, Issu
     result_ids = [issue.id for issue in results]
     assert bug.id in result_ids
     assert not oso.is_allowed(gabe, "edit", bug)
-    oso.roles.assign_role(gabe, osohq, "org_member", session=session)
+    oso.roles.assign_role(gabe, osohq, "member", session=session)
     assert not oso.is_allowed(gabe, "edit", bug)
-    oso.roles.assign_role(gabe, osohq, "org_owner", session=session)
+    oso.roles.assign_role(gabe, osohq, "owner", session=session)
     assert oso.is_allowed(gabe, "edit", bug)
-    oso.roles.assign_role(gabe, osohq, "org_member", session=session)
+    oso.roles.assign_role(gabe, osohq, "member", session=session)
     assert not oso.is_allowed(gabe, "edit", bug)
-    oso.roles.assign_role(gabe, osohq, "org_owner", session=session)
+    oso.roles.assign_role(gabe, osohq, "owner", session=session)
     assert oso.is_allowed(gabe, "edit", bug)
-    oso.roles.remove_role(gabe, osohq, "org_owner", session=session)
+    oso.roles.remove_role(gabe, osohq, "owner", session=session)
     assert not oso.is_allowed(gabe, "edit", bug)
 
     org_roles = oso.roles.for_resource(Repository)
-    assert set(org_roles) == {"repo_read", "repo_write"}
+    assert set(org_roles) == {"repo:reader", "repo:writer"}
     oso_assignments = oso.roles.assignments_for_resource(osohq)
     assert oso_assignments == [
-        {"user_id": leina.id, "role": "org_owner"},
-        {"user_id": steve.id, "role": "org_member"},
+        {"user_id": leina.id, "role": "org:owner"},
+        {"user_id": steve.id, "role": "org:member"},
     ]


### PR DESCRIPTION
Broke this configuration syntax change out from #938. TBD on whether or not it goes in--waiting to determine if it will add unnecessary complication to the polar-only roles evaluation implementation. 

TODO: 
- [x] Make the resource `_type` argument take a class as the arg instead of expecting a specializer
- [ ] Add tests to every language to confirm that classes can be passed as arguments directly and read using variable arguments

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
