### PR TITLE
clean up golang memory leaks

### DIFF
--- a/languages/go/oso.go
+++ b/languages/go/oso.go
@@ -142,6 +142,7 @@ func (o Oso) IsAllowed(actor interface{}, action interface{}, resource interface
 	if err != nil {
 		return false, err
 	} else if results != nil {
+		defer query.Cleanup()
 		return true, nil
 	} else {
 		return false, nil

--- a/languages/go/oso.go
+++ b/languages/go/oso.go
@@ -75,6 +75,7 @@ Accepts the string to query for.
 Returns a channel of resulting binding maps, and a channel for errors.
 As the query is evaluated, all resulting bindings will be written to the results channel,
 and any errors will be written to the error channel.
+The results channel must be completely consumed or it will leak memory.
 */
 func (o Oso) QueryStr(q string) (<-chan map[string]interface{}, <-chan error) {
 	if query, err := (*o.p).queryStr(q); err != nil {
@@ -95,6 +96,7 @@ Accepts the name of the rule to query, and a variadic list of rule arguments.
 Returns a channel of resulting binding maps, and a channel for errors.
 As the query is evaluated, all resulting bindings will be written to the results channel,
 and any errors will be written to the error channel.
+The results channel must be completely consumed or it will leak memory.
 */
 func (o Oso) QueryRule(name string, args ...interface{}) (<-chan map[string]interface{}, <-chan error) {
 	if query, err := (*o.p).queryRule(name, args...); err != nil {
@@ -142,6 +144,7 @@ func (o Oso) IsAllowed(actor interface{}, action interface{}, resource interface
 	if err != nil {
 		return false, err
 	} else if results != nil {
+		// Manually clean up query since we are not pulling all results.
 		defer query.Cleanup()
 		return true, nil
 	} else {

--- a/languages/go/query.go
+++ b/languages/go/query.go
@@ -35,6 +35,10 @@ func newQuery(ffiQuery ffi.QueryFfi, host host.Host) Query {
 	}
 }
 
+func (q *Query) Cleanup() {
+	q.ffiQuery.Delete()
+}
+
 func (q *Query) resultsChannel() (<-chan map[string]interface{}, <-chan error) {
 	results := make(chan map[string]interface{}, 1)
 	errors := make(chan error, 1)
@@ -94,7 +98,7 @@ func (q *Query) Next() (*map[string]interface{}, error) {
 
 		switch ev := event.QueryEventVariant.(type) {
 		case QueryEventDone:
-			defer q.ffiQuery.Delete()
+			defer q.Cleanup()
 			return nil, nil
 		case QueryEventDebug:
 			err = q.handleDebug(ev)
@@ -128,6 +132,7 @@ func (q *Query) Next() (*map[string]interface{}, error) {
 			return nil, fmt.Errorf("unexpected query event: %v", ev)
 		}
 		if err != nil {
+			defer q.Cleanup()
 			return nil, err
 		}
 	}

--- a/languages/go/query.go
+++ b/languages/go/query.go
@@ -129,6 +129,7 @@ func (q *Query) Next() (*map[string]interface{}, error) {
 		case QueryEventNextExternal:
 			err = q.handleNextExternal(ev)
 		default:
+			defer q.Cleanup()
 			return nil, fmt.Errorf("unexpected query event: %v", ev)
 		}
 		if err != nil {


### PR DESCRIPTION
Clean up golang memory leaks.
Wasn't calling query_free in all cases, wasn't calling string_free in some cases and wasn't freeing Cstrings allocated from go to pass through ffi calls.

fixes #944