### PR TITLE
Fix Go svg not showing up in Safari

### DIFF
--- a/docs/fontawesome/go.svg
+++ b/docs/fontawesome/go.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg preserveAspectRatio="xMinYMid meet" version="1.1" id="Layer_1"
+<svg style="height: inherit; width: inherit;" preserveAspectRatio="xMinYMid meet" version="1.1" id="Layer_1"
 	xmlns="http://www.w3.org/2000/svg"
 	xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 254.5 225" xml:space="preserve">
 	<style type="text/css">


### PR DESCRIPTION
Doing this with inline style as it's a well encapsulated asset