### PR TITLE
Api doc linking

### DIFF
--- a/docs/content/any/getting-started/policies/index.md
+++ b/docs/content/any/getting-started/policies/index.md
@@ -71,7 +71,7 @@ policies may be expressed.
 To use Oso for authorization, your application must first:
 
 1. Load the Oso library: `from oso import Oso`
-2. Create an {{% apiDeepLink "Oso" /%}} instance: `oso = Oso()`
+2. Create an {{% apiDeepLink class="Oso" /%}} instance: `oso = Oso()`
 3. Load a policy: `oso.load_file(policy)`.
 
 Then, at authorization time, you can call:

--- a/docs/content/any/getting-started/policies/index.md
+++ b/docs/content/any/getting-started/policies/index.md
@@ -71,7 +71,7 @@ policies may be expressed.
 To use Oso for authorization, your application must first:
 
 1. Load the Oso library: `from oso import Oso`
-2. Create an `Oso` instance: `oso = Oso()`
+2. Create an {{% apiDeepLink "Oso" /%}} instance: `oso = Oso()`
 3. Load a policy: `oso.load_file(policy)`.
 
 Then, at authorization time, you can call:

--- a/docs/content/any/getting-started/quickstart/index.md
+++ b/docs/content/any/getting-started/quickstart/index.md
@@ -93,7 +93,7 @@ resource is an instance of the `Expense` class.
 Okay, so what just happened?
 
 When we ask Oso for a policy decision via
-{{% apiDeepLink class="Oso" %}}{{< exampleGet "isAllowed" >}}{{% /apiDeepLink %}}
+{{% apiDeepLink module="oso" class="Oso" %}}{{< exampleGet "isAllowed" >}}{{% /apiDeepLink %}}
 , the Oso engine
 searches through its knowledge base to determine whether the provided
 **actor**, **action**, and **resource** satisfy any **allow** rules. In the

--- a/docs/content/any/getting-started/quickstart/index.md
+++ b/docs/content/any/getting-started/quickstart/index.md
@@ -92,7 +92,9 @@ resource is an instance of the `Expense` class.
 
 Okay, so what just happened?
 
-When we ask Oso for a policy decision via `Oso.{{% exampleGet "isAllowed" %}}()`, the Oso engine
+When we ask Oso for a policy decision via
+{{% apiDeepLink "Oso" %}}{{< exampleGet "isAllowed" >}}{{% /apiDeepLink %}}
+, the Oso engine
 searches through its knowledge base to determine whether the provided
 **actor**, **action**, and **resource** satisfy any **allow** rules. In the
 above case, we passed in `"alice@example.com"` as the **actor**, `"GET"` as the

--- a/docs/content/any/getting-started/quickstart/index.md
+++ b/docs/content/any/getting-started/quickstart/index.md
@@ -93,7 +93,7 @@ resource is an instance of the `Expense` class.
 Okay, so what just happened?
 
 When we ask Oso for a policy decision via
-{{% apiDeepLink "Oso" %}}{{< exampleGet "isAllowed" >}}{{% /apiDeepLink %}}
+{{% apiDeepLink class="Oso" %}}{{< exampleGet "isAllowed" >}}{{% /apiDeepLink %}}
 , the Oso engine
 searches through its knowledge base to determine whether the provided
 **actor**, **action**, and **resource** satisfy any **allow** rules. In the

--- a/docs/content/any/reference/tooling/repl/index.md
+++ b/docs/content/any/reference/tooling/repl/index.md
@@ -71,7 +71,7 @@ true
 We can also use application objects in the REPL, but we have to load
 and register the defining modules before we launch the REPL. The easiest
 way to do that is to write a script that imports the necessary modules,
-plus `oso`, and then use the {{% apiDeepLink class="Oso" %}}repl{{% /apiDeepLink %}}
+plus `oso`, and then use the {{% apiDeepLink module="oso" class="Oso" %}}repl{{% /apiDeepLink %}}
 API method to start the REPL:
 
 {{% exampleGet replApi %}}

--- a/docs/content/any/reference/tooling/repl/index.md
+++ b/docs/content/any/reference/tooling/repl/index.md
@@ -71,7 +71,7 @@ true
 We can also use application objects in the REPL, but we have to load
 and register the defining modules before we launch the REPL. The easiest
 way to do that is to write a script that imports the necessary modules,
-plus `oso`, and then use the {{% apiDeepLink "Oso" %}}repl{{% /apiDeepLink %}}
+plus `oso`, and then use the {{% apiDeepLink class="Oso" %}}repl{{% /apiDeepLink %}}
 API method to start the REPL:
 
 {{% exampleGet replApi %}}

--- a/docs/content/any/reference/tooling/repl/index.md
+++ b/docs/content/any/reference/tooling/repl/index.md
@@ -71,7 +71,8 @@ true
 We can also use application objects in the REPL, but we have to load
 and register the defining modules before we launch the REPL. The easiest
 way to do that is to write a script that imports the necessary modules,
-plus `oso`, and then use the `Oso.repl()` API method to start the REPL:
+plus `oso`, and then use the {{% apiDeepLink "Oso" %}}repl{{% /apiDeepLink %}}
+API method to start the REPL:
 
 {{% exampleGet replApi %}}
 

--- a/docs/content/python/guides/data_access/sqlalchemy.md
+++ b/docs/content/python/guides/data_access/sqlalchemy.md
@@ -40,11 +40,13 @@ To get started, we need to:
 
 ### Register models with Oso
 
-`sqlalchemy_oso.register_models()` registers all models that descend from a
+{{% apiDeepLink label="sqlalchemy_oso.register_models" pythonFramework="sqlalchemy" %}}register_models{{% /apiDeepLink %}}
+registers all models that descend from a
 declarative base class as types that are available in the policy.
 
-Alternatively, the `oso.Oso.register_class()` method can be called on each
-SQLAlchemy model that you want to reference in your policy.
+Alternatively, the
+{{% apiDeepLink class="Oso" label="oso.Oso.register_class" %}}register_class{{% /apiDeepLink %}}
+method can be called on each SQLAlchemy model that you want to reference in your policy.
 
 ### Create a SQLAlchemy Session that uses Oso
 

--- a/docs/content/python/guides/data_access/sqlalchemy.md
+++ b/docs/content/python/guides/data_access/sqlalchemy.md
@@ -40,7 +40,7 @@ To get started, we need to:
 
 ### Register models with Oso
 
-{{% apiDeepLink label="sqlalchemy_oso.register_models" pythonFramework="sqlalchemy" %}}register_models{{% /apiDeepLink %}}
+{{% apiDeepLink module="sqlalchemy_oso" label="sqlalchemy_oso.register_models" pythonFramework="sqlalchemy" %}}register_models{{% /apiDeepLink %}}
 registers all models that descend from a
 declarative base class as types that are available in the policy.
 

--- a/docs/content/python/guides/roles/sqlalchemy/examples.md
+++ b/docs/content/python/guides/roles/sqlalchemy/examples.md
@@ -38,8 +38,9 @@ This defines two roles on repository, `"reader"` and `"writer"`.
 This allows us to assign users directly to repositories without
 giving them a role in the entire organization.
 
-Now, we can use `OsoRoles.assign_role` to assign role on
-repositories in addition to organizations.
+Now, we can use
+{{% apiDeepLink "OsoRoles" "OsoRoles.assign_role" "sqlalchemy" %}}assign_role{{% /apiDeepLink %}}
+to assign role on repositories in addition to organizations.
 
 ## Grant access to child resources with implied roles
 

--- a/docs/content/python/guides/roles/sqlalchemy/examples.md
+++ b/docs/content/python/guides/roles/sqlalchemy/examples.md
@@ -39,7 +39,7 @@ This allows us to assign users directly to repositories without
 giving them a role in the entire organization.
 
 Now, we can use
-{{% apiDeepLink "OsoRoles" "OsoRoles.assign_role" "sqlalchemy" %}}assign_role{{% /apiDeepLink %}}
+{{% apiDeepLink class="OsoRoles" pythonFramework="sqlalchemy" %}}assign_role{{% /apiDeepLink %}}
 to assign role on repositories in addition to organizations.
 
 ## Grant access to child resources with implied roles

--- a/docs/content/python/guides/roles/sqlalchemy/examples.md
+++ b/docs/content/python/guides/roles/sqlalchemy/examples.md
@@ -39,7 +39,7 @@ This allows us to assign users directly to repositories without
 giving them a role in the entire organization.
 
 Now, we can use
-{{% apiDeepLink class="OsoRoles" pythonFramework="sqlalchemy" %}}assign_role{{% /apiDeepLink %}}
+{{% apiDeepLink module="sqlalchemy_oso.roles" pythonFramework="sqlalchemy" label="OsoRoles.assign_role" %}}{{% /apiDeepLink %}}
 to assign role on repositories in addition to organizations.
 
 ## Grant access to child resources with implied roles

--- a/docs/layouts/shortcodes/apiDeepLink.html
+++ b/docs/layouts/shortcodes/apiDeepLink.html
@@ -1,19 +1,37 @@
-{{- /* apiDeepLink $class */ -}}
+{{- /* apiDeepLink $class $label $pythonFramework */ -}}
 {{- /* Makes a deep link to the currently selected language's documentation for a given class */ -}}
 {{- /* To link to a specific method of the class, supply it as an inner shortcode or string */ -}}
 {{- $class := (.Get 0) -}}
-{{- if eq $.Page.Language.Lang "node" -}}
-{{- $apiBase := printf "%s%s/%s" $.Site.BaseURL $.Page.Language "reference/api/classes" -}}
-{{- $classLink := printf "%[1]s/%[2]s.%[2]s-1.html" $apiBase (lower $class) -}}
-<code style="display: inline-block; line-height: initial;">
-  {{- if eq (len .Inner) 0 -}}
-  <a href="{{- $classLink -}}">
-    {{- $class -}}
-  </a>
-  {{- else -}}
-  <a href="{{- (printf "%s#%s" $classLink (lower .Inner)) | safeURL -}}">
-    {{- $class -}}.{{- .Inner -}}()
-  </a>
-  {{- end -}}
-</code>
+{{- $label := (.Get 1) -}}
+{{- $pythonFramework := (.Get 2) -}}
+{{- $href := "" -}}
+{{- $genText := "" -}}
+{{- $baseUrl := printf "%s%s" $.Site.BaseURL $.Page.Language -}}
+{{- if eq (len .Inner) 0 -}}
+  {{- $genText = $class -}}
+{{- else -}}
+  {{- $genText = printf "%s.%s()" $class .Inner -}}
 {{- end -}}
+{{- if eq $.Page.Language.Lang "node" -}}
+  {{- $apiBase := printf "%s/%s" $baseUrl "reference/api/classes" -}}
+  {{- $classLink := printf "%[1]s/%[2]s.%[2]s-1.html" $apiBase (lower $class) -}}
+  {{- if eq (len .Inner) 0 -}}
+    {{- $href = $classLink -}}
+  {{- else -}}
+    {{- $href = (printf "%s#%s" $classLink (lower .Inner)) -}}
+  {{- end -}}
+{{- else if eq $.Page.Language.Lang "python" -}}
+  {{- $apiBase := printf "%s/%s" $baseUrl "reference/api" -}}
+  {{- if eq (len $pythonFramework) 0 -}}
+    {{- $href = printf "%s/%s" $apiBase "index.html" -}}
+  {{- else -}}
+    {{- $href = printf "%s/%s.html" $apiBase $pythonFramework -}}
+  {{- end -}}
+{{- else -}}
+  {{ $href = printf "%s/%s" $baseUrl "reference/api/index.html" }}
+{{- end -}}
+<code style="display:inline-block; line-height: initial; margin: 0;">
+  <a href="{{- $href | safeURL -}}">
+    {{- default $genText $label -}}
+  </a>
+</code>

--- a/docs/layouts/shortcodes/apiDeepLink.html
+++ b/docs/layouts/shortcodes/apiDeepLink.html
@@ -1,0 +1,19 @@
+{{- /* apiDeepLink $class */ -}}
+{{- /* Makes a deep link to the currently selected language's documentation for a given class */ -}}
+{{- /* To link to a specific method of the class, supply it as an inner shortcode or string */ -}}
+{{- $class := (.Get 0) -}}
+{{- if eq $.Page.Language.Lang "node" -}}
+{{- $apiBase := printf "%s%s/%s" $.Site.BaseURL $.Page.Language "reference/api/classes" -}}
+{{- $classLink := printf "%[1]s/%[2]s.%[2]s-1.html" $apiBase (lower $class) -}}
+<code style="display: inline-block; line-height: initial;">
+  {{- if eq (len .Inner) 0 -}}
+  <a href="{{- $classLink -}}">
+    {{- $class -}}
+  </a>
+  {{- else -}}
+  <a href="{{- (printf "%s#%s" $classLink (lower .Inner)) | safeURL -}}">
+    {{- $class -}}.{{- .Inner -}}()
+  </a>
+  {{- end -}}
+</code>
+{{- end -}}

--- a/docs/layouts/shortcodes/apiDeepLink.html
+++ b/docs/layouts/shortcodes/apiDeepLink.html
@@ -1,9 +1,9 @@
 {{- /* apiDeepLink $class $label $pythonFramework */ -}}
 {{- /* Makes a deep link to the currently selected language's documentation for a given class */ -}}
 {{- /* To link to a specific method of the class, supply it as an inner shortcode or string */ -}}
-{{- $class := (.Get 0) -}}
-{{- $label := (.Get 1) -}}
-{{- $pythonFramework := (.Get 2) -}}
+{{- $class := (.Get "class") -}}
+{{- $label := (.Get "label") -}}
+{{- $pythonFramework := (.Get "pythonFramework") -}}
 {{- $href := "" -}}
 {{- $genText := "" -}}
 {{- $baseUrl := printf "%s%s" $.Site.BaseURL $.Page.Language -}}

--- a/docs/layouts/shortcodes/apiDeepLink.html
+++ b/docs/layouts/shortcodes/apiDeepLink.html
@@ -1,20 +1,28 @@
-{{- /* apiDeepLink $class $label $pythonFramework */ -}}
-{{- /* Makes a deep link to the currently selected language's documentation for a given class */ -}}
-{{- /* To link to a specific method of the class, supply it as an inner shortcode or string */ -}}
+{{- /* apiDeepLink $class $label $pythonFramework $module */ -}}
+{{- /* Makes a deep link to the currently selected language's documentation. */ -}}
+{{- /* Accepts a module and class as params, and a function as an inner shotcode or string. */ -}}
+{{- /* $module will default to "oso", $label will default to a $class, $class.(.Inner)(), */ -}}
+{{- /* or (.Inner)(), depending on which parameters are provided. */ -}}
 {{- $class := (.Get "class") -}}
 {{- $label := (.Get "label") -}}
 {{- $pythonFramework := (.Get "pythonFramework") -}}
+{{- $module := default "oso" (.Get "module") -}}
 {{- $href := "" -}}
 {{- $genText := "" -}}
 {{- $baseUrl := printf "%s%s" $.Site.BaseURL $.Page.Language -}}
-{{- if eq (len .Inner) 0 -}}
+{{- if ne (len $class) 0 -}}
   {{- $genText = $class -}}
-{{- else -}}
-  {{- $genText = printf "%s.%s()" $class .Inner -}}
+{{- end -}}
+{{- if ne (len .Inner) 0 -}}
+  {{- if eq (len $genText) 0 -}}
+    {{- $genText = printf "%s()" .Inner -}}
+  {{- else -}}
+    {{- $genText = printf "%s.%s()" $genText .Inner -}}
+  {{- end -}}
 {{- end -}}
 {{- if eq $.Page.Language.Lang "node" -}}
   {{- $apiBase := printf "%s/%s" $baseUrl "reference/api/classes" -}}
-  {{- $classLink := printf "%[1]s/%[2]s.%[2]s-1.html" $apiBase (lower $class) -}}
+  {{- $classLink := printf "%s/%s.%s-1.html" $apiBase $module (lower $class) -}}
   {{- if eq (len .Inner) 0 -}}
     {{- $href = $classLink -}}
   {{- else -}}
@@ -27,6 +35,17 @@
   {{- else -}}
     {{- $href = printf "%s/%s.html" $apiBase $pythonFramework -}}
   {{- end -}}
+  {{- $hashLink := $module -}}
+  {{- with $class -}}
+    {{- $hashLink = printf "%s.%s" $hashLink . -}}
+  {{- end -}}
+  {{- with .Inner -}}
+    {{- $hashLink = printf "%s.%s" $hashLink . -}}
+  {{- end -}}
+  {{- if and (eq (len $class) 0) (eq (len .Inner) 0) -}}
+    {{- $hashLink = printf "module-%s" $module -}}
+  {{- end -}}
+  {{- $href = printf "%s#%s" $href $hashLink -}}
 {{- else -}}
   {{ $href = printf "%s/%s" $baseUrl "reference/api/index.html" }}
 {{- end -}}

--- a/docs/spelling/allowed_words.txt
+++ b/docs/spelling/allowed_words.txt
@@ -46,6 +46,7 @@ Postgres
 PyPI
 RBAC
 REPL
+repl
 RESTful
 RubyGems
 Rubying


### PR DESCRIPTION
There are a couple of limitations here:

1) each language api reference has a different url scheme, so we will have to write one of these for each (not that big of a deal, just a little messy)
2) we sometimes use a shortcode to look up the name of a method for a specific language (basically just casing differences). You can't pass a shortcode as a parameter to another shortcode, but you can provide it as an inner shortcode. Just makes the  API a little messy