### PR TITLE
[Java] Don't package junit in the jar

### DIFF
--- a/languages/java/oso/pom.xml
+++ b/languages/java/oso/pom.xml
@@ -60,6 +60,7 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>5.5.2</version>
+      <scope>test</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
     <dependency>


### PR DESCRIPTION
It looks like the `junit` dependency is missing the `<scope>test</scope>` tag which is causing the dependency to get packaged in the resulting jar. 

To double check, I downloaded the latest jar from [maven](https://search.maven.org/artifact/com.osohq/oso/0.12.4/jar) and ran a `jar tvf` on it:

```shell
languages/java/oso on  java_remove_junit_from_jar [!] is 📦 0.12.4 via ☕ v11.0.10 
❯ jar tvf ~/Downloads/oso-0.12.4.jar|grep junit
     0 Sun Sep 08 20:32:52 PDT 2019 org/junit/
     0 Sun Sep 08 20:32:52 PDT 2019 org/junit/jupiter/
     0 Sun Sep 08 20:32:52 PDT 2019 org/junit/jupiter/engine/
  3834 Sun Sep 08 20:32:52 PDT 2019 org/junit/jupiter/engine/Constants.class
     0 Sun Sep 08 20:32:50 PDT 2019 org/junit/jupiter/engine/extension/
  2409 Sun Sep 08 20:32:50 PDT 2019 org/junit/jupiter/engine/extension/TempDirectory$CloseablePath$1.class
...
```

With this change applied, after running `mvn package`:

```shell
languages/java/oso on  java_remove_junit_from_jar is 📦 0.12.4 via ☕ v11.0.10 took 7s 
❯ jar tvf target/oso-0.12.4.jar|grep junit

languages/java/oso on  java_remove_junit_from_jar is 📦 0.12.4 via ☕ v11.0.10 
❯          
```


PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
