### PR TITLE
Make Query an enumerable to avoid running queries on fibers.

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -36,7 +36,7 @@ Before:
 ```ruby
 query = oso.query_rule('allow', actor, action, resource)
 first = query.results.next
-# raises StopIterator if no resutls
+# raises StopIterator if no results
 ```
 
 After:

--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -8,9 +8,9 @@ description: >-
 draft: true
 ---
 
-## `RELEASED_PACKAGE_1` NEW_VERSION
+## `oso-oso 0.13.0` NEW_VERSION
 
-### LANGUAGE (e.g., 'Core' or 'Python' or 'Node.js')
+### Ruby (e.g., 'Core' or 'Python' or 'Node.js')
 
 #### Breaking changes
 
@@ -20,6 +20,34 @@ draft: true
   This release contains breaking changes. Be sure to follow migration steps
   before upgrading.
 {{% /callout %}}
+
+The `Query` object returned by `Polar::Polar#query` is now an `Enumerable`.
+Previously, you would need to access the `results` attribute which
+was an enumerator.
+
+The main impact of this change is that queries are no longer run
+on a Fiber, and therefore any methods using Fiber-local variables
+(e.g. `Thread.current[:var]`) will work fine.
+
+If you are only using `Oso#allowed?` there is no change needed.
+
+Before:
+
+```ruby
+query = oso.query_rule('allow', actor, action, resource)
+first = query.results.next
+# raises StopIterator if no resutls
+```
+
+After:
+
+```ruby
+query = oso.query_rule('allow', actor, action, resource)
+first = query.first
+# first is nil if there are no results
+```
+
+
 
 ##### Breaking change 1
 

--- a/languages/ruby/lib/oso/oso.rb
+++ b/languages/ruby/lib/oso/oso.rb
@@ -17,10 +17,7 @@ module Oso
     # @param resource [Object] Object.
     # @return [Boolean] An access control decision.
     def allowed?(actor:, action:, resource:)
-      query_rule('allow', actor, action, resource).next
-      true
-    rescue StopIteration
-      false
+      not query_rule('allow', actor, action, resource).first.nil?
     end
   end
 end

--- a/languages/ruby/lib/oso/oso.rb
+++ b/languages/ruby/lib/oso/oso.rb
@@ -17,7 +17,7 @@ module Oso
     # @param resource [Object] Object.
     # @return [Boolean] An access control decision.
     def allowed?(actor:, action:, resource:)
-      not query_rule('allow', actor, action, resource).first.nil?
+      !query_rule('allow', actor, action, resource).first.nil?
     end
   end
 end

--- a/languages/ruby/lib/oso/polar/polar.rb
+++ b/languages/ruby/lib/oso/polar/polar.rb
@@ -89,11 +89,7 @@ module Oso
           next_query = ffi_polar.next_inline_query
           break if next_query.nil?
 
-          begin
-            Query.new(next_query, host: host).results.next
-          rescue StopIteration
-            raise InlineQueryFailedError, next_query.source
-          end
+          raise InlineQueryFailedError, next_query.source if Query.new(next_query, host: host).first.nil?
         end
         self
       end
@@ -118,7 +114,7 @@ module Oso
         else
           raise InvalidQueryTypeError
         end
-        Query.new(ffi_query, host: new_host).results
+        Query.new(ffi_query, host: new_host)
       end
 
       # Query for a rule.
@@ -214,7 +210,7 @@ module Oso
         end
 
         begin
-          results = Query.new(ffi_query, host: host).results.to_a
+          results = Query.new(ffi_query, host: host).to_a
         rescue PolarRuntimeError => e
           print_error(e)
           return

--- a/languages/ruby/lib/oso/polar/polar.rb
+++ b/languages/ruby/lib/oso/polar/polar.rb
@@ -81,7 +81,7 @@ module Oso
       # @raise [InlineQueryFailedError] on the first failed inline query.
       # @raise [Error] if any of the FFI calls raise one.
       # @return [self] for chaining.
-      def load_str(str, filename: nil) # rubocop:disable Metrics/MethodLength
+      def load_str(str, filename: nil)
         raise NullByteInPolarFileError if str.chomp("\0").include?("\0")
 
         ffi_polar.load(str, filename: filename)

--- a/languages/ruby/spec/oso/language_parity_spec.rb
+++ b/languages/ruby/spec/oso/language_parity_spec.rb
@@ -64,19 +64,19 @@ rescue Oso::Polar::ParseError::UnrecognizedEOF => e
 end
 raise unless exception_thrown
 
-oso.query_rule('specializers', D.new('hello'), B::C.new('hello')).next
-oso.query_rule('floatLists').next
-oso.query_rule('intDicts').next
-oso.query_rule('comparisons').next
-oso.query_rule('testForall').next
-oso.query_rule('testRest').next
-oso.query_rule('testMatches', A.new('hello')).next
-oso.query_rule('testMethodCalls', A.new('hello'), B::C.new('hello')).next
-oso.query_rule('testOr').next
-oso.query_rule('testUnifyClass', A).next
+raise if oso.query_rule('specializers', D.new('hello'), B::C.new('hello')).first.nil?
+raise if oso.query_rule('floatLists').first.nil?
+raise if oso.query_rule('intDicts').first.nil?
+raise if oso.query_rule('comparisons').first.nil?
+raise if oso.query_rule('testForall').first.nil?
+raise if oso.query_rule('testRest').first.nil?
+raise if oso.query_rule('testMatches', A.new('hello')).first.nil?
+raise if oso.query_rule('testMethodCalls', A.new('hello'), B::C.new('hello')).first.nil?
+raise if oso.query_rule('testOr').first.nil?
+raise if oso.query_rule('testUnifyClass', A).first.nil?
 
 # Test that cut doesn't return anything.
-raise unless oso.query_rule('testCut').to_a.empty?
+raise unless oso.query_rule('testCut').first.nil?
 
 # Test that a constant can be called.
 oso.register_constant Math, name: 'MyMath'
@@ -84,37 +84,35 @@ oso.load_str '?= MyMath.acos(1.0) = 0.0;'
 
 # Test built-in type specializers.
 # rubocop:disable Layout/EmptyLineAfterGuardClause
-oso.query('builtinSpecializers(true, "Boolean")').next
-raise unless oso.query('builtinSpecializers(false, "Boolean")').to_a.empty?
-oso.query('builtinSpecializers(2, "Integer")').next
-oso.query('builtinSpecializers(1, "Integer")').next
-raise unless oso.query('builtinSpecializers(0, "Integer")').to_a.empty?
-raise unless oso.query('builtinSpecializers(-1, "Integer")').to_a.empty?
-oso.query('builtinSpecializers(1.0, "Float")').next
-raise unless oso.query('builtinSpecializers(0.0, "Float")').to_a.empty?
-raise unless oso.query('builtinSpecializers(-1.0, "Float")').to_a.empty?
-oso.query('builtinSpecializers(["foo", "bar", "baz"], "List")').next
-raise unless oso.query('builtinSpecializers(["bar", "foo", "baz"], "List")').to_a.empty?
-oso.query('builtinSpecializers({foo: "foo"}, "Dictionary")').next
-raise unless oso.query('builtinSpecializers({foo: "bar"}, "Dictionary")').to_a.empty?
-oso.query('builtinSpecializers("foo", "String")').next
-raise unless oso.query('builtinSpecializers("bar", "String")').to_a.empty?
+raise if oso.query('builtinSpecializers(true, "Boolean")').first.nil?
+raise unless oso.query('builtinSpecializers(false, "Boolean")').first.nil?
+raise if oso.query('builtinSpecializers(2, "Integer")').first.nil?
+raise if oso.query('builtinSpecializers(1, "Integer")').first.nil?
+raise unless oso.query('builtinSpecializers(0, "Integer")').first.nil?
+raise unless oso.query('builtinSpecializers(-1, "Integer")').first.nil?
+raise if oso.query('builtinSpecializers(1.0, "Float")').first.nil?
+raise unless oso.query('builtinSpecializers(0.0, "Float")').first.nil?
+raise unless oso.query('builtinSpecializers(-1.0, "Float")').first.nil?
+raise if oso.query('builtinSpecializers(["foo", "bar", "baz"], "List")').first.nil?
+raise unless oso.query('builtinSpecializers(["bar", "foo", "baz"], "List")').first.nil?
+raise if oso.query('builtinSpecializers({foo: "foo"}, "Dictionary")').first.nil?
+raise unless oso.query('builtinSpecializers({foo: "bar"}, "Dictionary")').first.nil?
+raise if oso.query('builtinSpecializers("foo", "String")').first.nil?
+raise unless oso.query('builtinSpecializers("bar", "String")').first.nil?
 
-oso.query('builtinSpecializers(1, "IntegerWithFields")').next
-raise unless oso.query('builtinSpecializers(2, "IntegerWithGarbageFields")').to_a.empty?
-raise unless oso.query('builtinSpecializers({}, "DictionaryWithFields")').to_a.empty?
-raise unless oso.query('builtinSpecializers({z: 1}, "DictionaryWithFields")').to_a.empty?
-oso.query('builtinSpecializers({y: 1}, "DictionaryWithFields")').next
+raise if oso.query('builtinSpecializers(1, "IntegerWithFields")').first.nil?
+raise unless oso.query('builtinSpecializers(2, "IntegerWithGarbageFields")').first.nil?
+raise unless oso.query('builtinSpecializers({}, "DictionaryWithFields")').first.nil?
+raise unless oso.query('builtinSpecializers({z: 1}, "DictionaryWithFields")').first.nil?
+raise if oso.query('builtinSpecializers({y: 1}, "DictionaryWithFields")').first.nil?
 
 # test iterables work
-oso.query_rule('testIterables').next
+raise if oso.query_rule('testIterables').first.nil?
 
 # Test deref behaviour
 oso.load_str '?= x = 1 and E.sum([x, 2, x]) = 4 and [3, 2, x].index(1) = 2;'
 
 # Test unspecialized rule ordering
 result = oso.query_rule('testUnspecializedRuleOrder', 'foo', 'bar', Oso::Polar::Variable.new('z'))
-raise unless result.next['z'] == 1
-raise unless result.next['z'] == 2
-raise unless result.next['z'] == 3
+raise unless result.map { |res| res['z'] }.to_a == [1, 2, 3]
 # rubocop:enable Layout/EmptyLineAfterGuardClause

--- a/languages/ruby/spec/oso/language_parity_spec.rb
+++ b/languages/ruby/spec/oso/language_parity_spec.rb
@@ -83,7 +83,6 @@ oso.register_constant Math, name: 'MyMath'
 oso.load_str '?= MyMath.acos(1.0) = 0.0;'
 
 # Test built-in type specializers.
-# rubocop:disable Layout/EmptyLineAfterGuardClause
 raise if oso.query('builtinSpecializers(true, "Boolean")').first.nil?
 raise unless oso.query('builtinSpecializers(false, "Boolean")').first.nil?
 raise if oso.query('builtinSpecializers(2, "Integer")').first.nil?
@@ -115,4 +114,3 @@ oso.load_str '?= x = 1 and E.sum([x, 2, x]) = 4 and [3, 2, x].index(1) = 2;'
 # Test unspecialized rule ordering
 result = oso.query_rule('testUnspecializedRuleOrder', 'foo', 'bar', Oso::Polar::Variable.new('z'))
 raise unless result.map { |res| res['z'] }.to_a == [1, 2, 3]
-# rubocop:enable Layout/EmptyLineAfterGuardClause

--- a/languages/ruby/spec/oso/oso_spec.rb
+++ b/languages/ruby/spec/oso/oso_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
     it 'calls through to the allow rule' do
       subject.load_str('allow(1, 2, 3);')
       result = subject.query_rule('allow', 1, 2, 3)
-      expect(result.next).to eq({})
+      expect(result.first).to eq({})
     end
   end
 end

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -477,9 +477,9 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
                        [one, two, three, four]
                      end
 
-                    def self.tv
-                      Thread.current["foo"]
-                    end
+                     def self.tv
+                       Thread.current['foo']
+                     end
                    end)
         subject.register_class(TestClass)
       end
@@ -489,7 +489,7 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
       end
 
       it 'has access to the thread context' do
-        Thread.current["foo"] = "bar"
+        Thread.current['foo'] = 'bar'
         # you need to use load string here or it might not
         # run on a fiber
         subject.load_str('?= TestClass.tv = "bar";')

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -476,12 +476,23 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
                      def my_method(one, two, three:, four:)
                        [one, two, three, four]
                      end
+
+                    def self.tv
+                      Thread.current["foo"]
+                    end
                    end)
         subject.register_class(TestClass)
       end
 
       it 'accepts positional and keyword args' do
         expect(qvar(subject, 'x = (new TestClass()).my_method(1, 2, four: 4, three: 3)', 'x')).to eq([[1, 2, 3, 4]])
+      end
+
+      it 'has access to the thread context' do
+        Thread.current["foo"] = "bar"
+        # you need to use load string here or it might not
+        # run on a fiber
+        subject.load_str('?= TestClass.tv = "bar";')
       end
     end
 


### PR DESCRIPTION
**For Ruby**


Minimal test case:

```ruby
require 'oso'

oso = Oso.new

class Foo
    def self.tv(name)
        Thread.current[name]
    end
end

oso.register_class(Foo)

Thread.current[:foo] = "bar"
oso.load_str('?= Foo.tv("foo") = "bar";')
```

Before this would fail, because the query runs on a fiber and thread variables are not accessible (without using `Thread.current.thread_variable_set` instead).

PR checklist:

- [x] Added changelog entry.
