### PR TITLE
Java: update maven-javadoc-plugin to 3.3.0

### DIFF
--- a/languages/java/oso/pom.xml
+++ b/languages/java/oso/pom.xml
@@ -120,7 +120,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.3.0</version>
         <configuration>
           <source>8</source>
           <additionalparam>-Xdoclint:none</additionalparam>


### PR DESCRIPTION
Intellij is showing that the `additionalOptions` configuration option for the `maven-javadoc-plugin` isn't supported:

<img width="1107" alt="Screen Shot 2021-06-12 at 17 49 20 PM" src="https://user-images.githubusercontent.com/3231/121792187-97663680-cba6-11eb-9177-39d657a5acee.png">


According to the [documentation](https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#additionalOptions), this option is supported in `3.0.0` and greater, but the `pom.xml` currently only has `2.9.1`. Update to the latest and greatest.

FWIW a diff of `target/site` before and after this change showed no changes.

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
