### PR TITLE
Python config validation code

### DIFF
--- a/languages/python/oso/oso/config.py
+++ b/languages/python/oso/oso/config.py
@@ -1,0 +1,292 @@
+from typing import Any, List, Set, Dict
+from dataclasses import dataclass
+from polar import Variable
+from polar.exceptions import OsoError
+
+
+@dataclass
+class Relationship:
+    child_type: str
+    parent_type: str
+
+
+@dataclass
+class Permission:
+    type: str
+    name: str
+
+
+@dataclass
+class Role:
+    name: str
+    type: str
+    permissions: List[Permission]
+    implied_roles: List[str]
+
+
+@dataclass
+class Resource:
+    type: str
+    name: str
+    actions: Set[str]
+    roles: Set[str]
+
+
+@dataclass
+class Config:
+    resources: Dict[str, Resource]
+    type_to_resource_name: Dict[str, str]
+    permissions: List[Permission]
+    roles: Dict[str, Role]
+    relationships: List[Relationship]
+
+
+def isa_type(arg):
+    assert arg.operator == "Isa"
+    assert len(arg.args) == 2
+    assert arg.args[0] == Variable("_this")
+    pattern = arg.args[1]
+    type = pattern.tag
+    return type
+
+
+def parse_permission(permission, type, config):
+    """Parse a permission string, check if it's valid and return a Permission"""
+    if ":" in permission:
+        resource_name, action = permission.split(":", 1)
+        if resource_name not in config.resources:
+            raise OsoError("Invalid permission namespace.")
+        permission_type = config.resources[resource_name].type
+    else:
+        action = permission
+        permission_type = type
+    perm = Permission(
+        name=action,
+        type=permission_type,
+    )
+    if perm not in config.permissions:
+        raise OsoError(
+            f"Permission {perm.name} doesn't exist for resource {perm.type}."
+        )
+    return perm
+
+
+def parse_role_name(role_name, type, config, other_ok=False):
+    """Parse a role name and return a normalized role name (with namspace).
+
+    :param role_name: un-normalized role name
+    :type role_name: str
+    :param type: type of resource inside which this role was defined
+    :type resource_class: Any
+    :param config: role config
+    :type config: Config
+    :param other_ok: Flag to indicate if a namespace other than `resource_name` is allowed, defaults to False
+    :type other_ok: bool, optional
+    :return: Normalized role name (with namespace)
+    :rtype: str
+    """
+    if type not in config.type_to_resource_name:
+        raise OsoError(f"Unrecognized resource type {type}.")
+    resource_name = config.type_to_resource_name[type]
+    if ":" in role_name:
+        namespace, _ = role_name.split(":", 1)
+        if namespace not in config.resources:
+            raise OsoError(f"Invalid role namespace {namespace}.")
+    else:
+        role_name = f"{resource_name}:{role_name}"
+
+    return role_name
+
+
+def validate_config(oso):
+    config = Config(
+        resources={},
+        type_to_resource_name={},
+        permissions=[],
+        roles={},
+        relationships=[],
+    )
+
+    # role_relationships = oso.query_rule(
+    #     "parent",
+    #     Variable("resource"),
+    #     Variable("parent_resource"),
+    #     accept_expression=True,
+    # )
+    # for result in role_relationships:
+    #     try:
+    #         _constraints = result["bindings"]["resource"]
+    #         parent_constraints = result["bindings"]["parent_resource"]
+    #         assert len(constraints.args) == 2
+    #         type_check = constraints.args[0]
+    #         child_type = isa_type(type_check)
+    #         get_parent = constraints.args[1]
+    #         assert get_parent.operator == "Isa"
+    #         assert len(get_parent.args) == 2
+    #         getter = get_parent.args[0]
+    #         assert getter.operator == "Dot"
+    #         assert len(getter.args) == 2
+    #         assert getter.args[0] == Variable("_this")
+    #         pattern = get_parent.args[1]
+    #         parent_type = pattern.tag
+
+    #         relationship = Relationship(child_type=child_type, parent_type=parent_type)
+    #         config.relationships.append(relationship)
+    #     except AssertionError:
+    #         raise OsoError("Invalid relationship.")
+
+    role_resources = oso.query_rule(
+        "resource",
+        Variable("resource"),
+        Variable("name"),
+        Variable("permissions"),
+        Variable("roles"),
+        accept_expression=True,
+    )
+    role_definitions = []
+    for result in role_resources:
+        resource_def = result["bindings"]["resource"]
+        assert resource_def.operator == "And"
+        assert len(resource_def.args) == 1
+        arg = resource_def.args[0]
+        type = isa_type(arg)
+
+        resource_name = result["bindings"]["name"]
+        permissions = result["bindings"]["permissions"]
+        role_defs = result["bindings"]["roles"]
+
+        if isinstance(permissions, Variable):
+            permissions = []
+
+        # Check for duplicate permissions.
+        for perm in permissions:
+            if permissions.count(perm) > 1:
+                raise OsoError(f"Duplicate action {perm} for resource {type}")
+
+        if isinstance(role_defs, Variable):
+            role_names = []
+        else:
+            role_names = role_defs.keys()
+
+        if len(permissions) == 0 and len(role_names) == 0:
+            raise OsoError("Must define actions or roles for resource.")
+
+        if resource_name in config.resources:
+            raise OsoError(f"Duplicate resource name {resource_name}")
+
+        resource = Resource(
+            type=type,
+            name=resource_name,
+            actions=permissions,
+            roles=role_names,
+        )
+        config.resources[resource.name] = resource
+        config.type_to_resource_name[type] = resource_name
+
+        permissions = [Permission(name=action, type=type) for action in permissions]
+        for permission in permissions:
+            config.permissions.append(permission)
+
+        # Collect up the role definitions to process after we know all the permissions
+        role_definitions.append((type, role_defs))
+
+    for type, role_defs in role_definitions:
+        if isinstance(role_defs, Variable):
+            continue  # No roles defined
+
+        for role_name, role_def in role_defs.items():
+            # preprocess role name
+            role_name = parse_role_name(role_name, type, config)
+            if role_name in config.roles:
+                raise OsoError(f"Duplicate role name {role_name}")
+
+            for key in role_def.keys():
+                if key not in ("permissions", "implies"):
+                    raise OsoError(f"Invalid key in role definition :'{key}'")
+
+            role_permissions = []
+            if "permissions" in role_def:
+                for permission in role_def["permissions"]:
+                    perm = parse_permission(permission, type, config)
+                    role_permissions.append(perm)
+
+            implied_roles = []
+            if "implies" in role_def:
+                implied_roles = [
+                    parse_role_name(role, type, config, other_ok=True)
+                    for role in role_def["implies"]
+                ]
+
+            if len(role_permissions) == 0 and len(implied_roles) == 0:
+                raise OsoError("Must define permissions or implied roles for a role.")
+
+            role = Role(
+                name=role_name,
+                type=type,
+                permissions=role_permissions,
+                implied_roles=implied_roles,
+            )
+            config.roles[role.name] = role
+
+    # Validate config
+    for role_name, role in config.roles.items():
+        for permission in role.permissions:
+            if permission.type != role.type:
+                for _, other_role in config.roles.items():
+                    if other_role.type == permission.type:
+                        raise OsoError(
+                            f"""Permission {permission.name} on {permission.type}
+                            can not go on role {role_name} on {role.type}
+                            because {permission.type} has it's own roles. Use an implication."""
+                        )
+
+                # typ = permission.type
+                # while typ != role.type:
+                #     stepped = False
+                #     for rel in config.relationships:
+                #         if typ == rel.child_typ:
+                #             typ = rel.parent_typ
+                #             stepped = True
+                #             break
+                #     if not stepped:
+                #         raise OsoError(
+                #             f"""Permission {permission.name} on {permission.type}
+                #             can not go on role {role_name} on {role.type}
+                #             because no relationship exists."""
+                #         )
+
+        for implied in role.implied_roles:
+            # Make sure implied role exists
+            if implied not in config.roles:
+                raise OsoError(
+                    f"Role '{implied}' implied by '{role_name}' does not exist."
+                )
+            implied_role = config.roles[implied]
+            # # Make sure implied role is on a valid class
+            # typ = implied_role.type
+            # while typ != role.type:
+            #     stepped = False
+            #     for rel in config.relationships:
+            #         if typ == rel.child_type:
+            #             typ = rel.parent_type
+            #             stepped = True
+            #             break
+            #     if not stepped:
+            #         raise OsoError(
+            #             f"""Role {role_name} on {role.type}
+            #             can not imply role {implied} on {implied_role.type}
+            #             because no relationship exists."""
+            #         )
+            # Make sure implied roles dont have overlapping permissions.
+            # @TODO: Follow implication chair further than just one.
+            permissions = role.permissions
+            for implied_perm in implied_role.permissions:
+                if implied_perm in permissions:
+                    raise OsoError(
+                        f"""Invalid implication. Role {role} has permission {implied_perm.name}
+                        on {implied_perm.type} but implies role {implied}
+                        which also has permission {implied_perm.name} on {implied_perm.type}"""
+                    )
+
+    if len(config.resources) == 0:
+        raise OsoError("Need to define resources to use oso roles.")

--- a/languages/python/oso/oso/config.py
+++ b/languages/python/oso/oso/config.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Set, Dict
+from typing import List, Set, Dict
 from dataclasses import dataclass
 from polar import Variable
 from polar.exceptions import OsoError

--- a/languages/python/oso/oso/oso.py
+++ b/languages/python/oso/oso/oso.py
@@ -46,6 +46,17 @@ class Oso(Polar):
     def enable_roles(self):
         self.load_file(Path(__file__).parent / "roles.polar")
 
+    # @TODO: No good place to automatically call this as it has to be called
+    # after the policy is loaded which might happen before calling enable_roles
+    # and might happen after calling enable_roles. Seperate method for now.
+    def validate_config(self):
+        try:
+            self.load_file(Path(__file__).parent / "validate.polar")
+        except exceptions.InlineQueryFailedError as e:
+            # @TODO: No good way to turn an inline query error into what we want
+            # it to be. Need a better way to pass a failure string out of polar.
+            raise exceptions.OsoError(f"Config Error: {e.message}")
+
     def get_allowed_actions(self, actor, resource, allow_wildcard=False) -> list:
         """Determine the actions ``actor`` is allowed to take on ``resource``.
 

--- a/languages/python/oso/oso/oso.py
+++ b/languages/python/oso/oso/oso.py
@@ -5,6 +5,7 @@ __version__ = "0.12.4"
 import os
 from pathlib import Path
 from polar import Polar, Variable, exceptions
+from .config import validate_config
 
 
 class Oso(Polar):
@@ -45,17 +46,6 @@ class Oso(Polar):
 
     def enable_roles(self):
         self.load_file(Path(__file__).parent / "roles.polar")
-
-    # @TODO: No good place to automatically call this as it has to be called
-    # after the policy is loaded which might happen before calling enable_roles
-    # and might happen after calling enable_roles. Seperate method for now.
-    def validate_config(self):
-        try:
-            self.load_file(Path(__file__).parent / "validate.polar")
-        except exceptions.InlineQueryFailedError as e:
-            # @TODO: No good way to turn an inline query error into what we want
-            # it to be. Need a better way to pass a failure string out of polar.
-            raise exceptions.OsoError(f"Config Error: {e.message}")
 
     def get_allowed_actions(self, actor, resource, allow_wildcard=False) -> list:
         """Determine the actions ``actor`` is allowed to take on ``resource``.
@@ -101,3 +91,6 @@ class Oso(Polar):
                 "Polar tracing enabled. Get help with "
                 + "traces from our engineering team: https://help.osohq.com/trace"
             )
+
+    def validate_config(self):
+        validate_config(self)

--- a/languages/python/oso/oso/validate.polar
+++ b/languages/python/oso/oso/validate.polar
@@ -1,1 +1,0 @@
-?= true = true;

--- a/languages/python/oso/oso/validate.polar
+++ b/languages/python/oso/oso/validate.polar
@@ -1,0 +1,1 @@
+?= true = true;

--- a/languages/python/oso/requirements.txt
+++ b/languages/python/oso/requirements.txt
@@ -1,1 +1,2 @@
 cffi~=1.14
+dataclasses; python_version<"3.7"

--- a/languages/python/oso/tests/test_polar_roles.py
+++ b/languages/python/oso/tests/test_polar_roles.py
@@ -185,7 +185,7 @@ def test_oso_roles_init():
 
 def test_empty_role(init_oso):
     # defining role with no permissions/implications throws an error
-    oso, session = init_oso
+    oso, _ = init_oso
     policy = """
     resource(_type: Org, "org", actions, roles) if
         actions = [

--- a/languages/python/oso/tests/test_polar_roles.py
+++ b/languages/python/oso/tests/test_polar_roles.py
@@ -183,7 +183,6 @@ def test_oso_roles_init():
 # - [x] relationships without resource definition throws an error
 
 
-@pytest.mark.skip("TODO: validation")
 def test_empty_role(init_oso):
     # defining role with no permissions/implications throws an error
     oso, session = init_oso
@@ -202,7 +201,6 @@ def test_empty_role(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_bad_namespace_perm(init_oso):
     # - assigning permission with bad namespace throws an error
     oso, session = init_oso
@@ -274,7 +272,6 @@ def test_resource_with_roles_no_actions(init_oso, sample_data):
     assert oso.is_allowed(steve, "pull", oso_repo)
 
 
-@pytest.mark.skip("TODO: validation")
 def test_duplicate_resource_name(init_oso):
     # - duplicate resource name throws an error
     oso, session = init_oso
@@ -305,7 +302,7 @@ def test_duplicate_resource_name(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
+@pytest.mark.skip("No longer an error")
 def test_nested_dot_relationship(init_oso):
     # - multiple dot lookups throws an error for now
     oso, session = init_oso
@@ -332,7 +329,7 @@ def test_nested_dot_relationship(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
+@pytest.mark.skip("can't detect, not sqlalchemy")
 def test_bad_relationship_lookup(init_oso):
     # - nonexistent attribute lookup throws an error for now
     oso, session = init_oso
@@ -361,7 +358,7 @@ def test_bad_relationship_lookup(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
+@pytest.mark.skip("Can't really test relationship types")
 def test_relationship_without_specializer(init_oso):
     oso, session = init_oso
     policy = """
@@ -380,7 +377,6 @@ def test_relationship_without_specializer(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_relationship_without_resources(init_oso):
     oso, session = init_oso
     policy = """
@@ -394,7 +390,6 @@ def test_relationship_without_resources(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_duplicate_role_name_same_resource(init_oso):
     oso, session = init_oso
     policy = """
@@ -478,7 +473,6 @@ def test_role_namespaces(init_oso, sample_data):
     assert not oso.is_allowed(gabe, "pull", oso_repo)
 
 
-@pytest.mark.skip("TODO: validation")
 def test_resource_actions(init_oso):
     # only define actions, not roles
     oso, session = init_oso
@@ -492,7 +486,6 @@ def test_resource_actions(init_oso):
     oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_duplicate_action(init_oso):
     # - duplicate action
     oso, session = init_oso
@@ -509,7 +502,6 @@ def test_duplicate_action(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_undeclared_permission(init_oso):
     # - assign permission that wasn't declared
     oso, session = init_oso
@@ -530,7 +522,6 @@ def test_undeclared_permission(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_undeclared_role(init_oso):
     # - imply role that wasn't declared
     oso, session = init_oso
@@ -550,7 +541,7 @@ def test_undeclared_role(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
+@pytest.mark.skip("Can't really test relationship types")
 def test_role_implication_without_relationship(init_oso):
     # - imply role without valid relationship
     oso, session = init_oso
@@ -581,7 +572,7 @@ def test_role_implication_without_relationship(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
+@pytest.mark.skip("Can't really test relationship types")
 def test_role_permission_without_relationship(init_oso):
     # - assign permission without valid relationship
     oso, session = init_oso
@@ -607,7 +598,6 @@ def test_role_permission_without_relationship(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_invalid_role_permission(init_oso):
     # assigning permission on related role type errors if role exists for permission resource
     oso, session = init_oso
@@ -645,7 +635,6 @@ def test_invalid_role_permission(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_permission_assignment_to_implied_role(init_oso):
     # assigning the same permission to two roles where one implies the other throws an error
     oso, session = init_oso
@@ -671,7 +660,6 @@ def test_permission_assignment_to_implied_role(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_incorrect_arity_resource(init_oso):
     # - use resource predicate with incorrect arity
     oso, session = init_oso
@@ -686,7 +674,6 @@ def test_incorrect_arity_resource(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_undefined_resource_arguments(init_oso):
     # - use resource predicate without defining actions/roles
     oso, session = init_oso
@@ -698,7 +685,6 @@ def test_undefined_resource_arguments(init_oso):
         oso.validate_config()
 
 
-@pytest.mark.skip("TODO: validation")
 def test_wrong_type_resource_arguments(init_oso):
     # - use resource predicate with field types
     oso, session = init_oso

--- a/languages/python/oso/tests/test_polar_roles.py
+++ b/languages/python/oso/tests/test_polar_roles.py
@@ -199,9 +199,7 @@ def test_empty_role(init_oso):
     oso.load_str(policy)
 
     with pytest.raises(OsoError):
-        # TODO: where are we going to do config validation?
-        # Maybe when user loads their policy file?
-        pass
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -222,9 +220,7 @@ def test_bad_namespace_perm(init_oso):
     oso.load_str(policy)
 
     with pytest.raises(OsoError):
-        # TODO: where are we going to do config validation?
-        # Maybe when user loads their policy file?
-        pass
+        oso.validate_config()
 
 
 def test_resource_with_roles_no_actions(init_oso, sample_data):
@@ -258,6 +254,7 @@ def test_resource_with_roles_no_actions(init_oso, sample_data):
             role in actor.org_roles;
     """
     oso.load_str(policy)
+    oso.validate_config()
 
     # TODO: where are we going to do config validation?
     # Maybe when user loads their policy file?
@@ -305,7 +302,7 @@ def test_duplicate_resource_name(init_oso):
     oso.load_str(policy)
 
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -332,7 +329,7 @@ def test_nested_dot_relationship(init_oso):
     oso.load_str(policy)
 
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -361,7 +358,7 @@ def test_bad_relationship_lookup(init_oso):
     oso.load_str(policy)
 
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -380,7 +377,7 @@ def test_relationship_without_specializer(init_oso):
     oso.load_str(policy)
 
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -394,7 +391,7 @@ def test_relationship_without_resources(init_oso):
     oso.load_str(policy)
 
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -417,7 +414,7 @@ def test_duplicate_role_name_same_resource(init_oso):
         """
     oso.load_str(policy)
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 def test_role_namespaces(init_oso, sample_data):
@@ -457,9 +454,7 @@ def test_role_namespaces(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     oso_repo = sample_data["oso_repo"]
@@ -494,6 +489,7 @@ def test_resource_actions(init_oso):
         ];
     """
     oso.load_str(policy)
+    oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -510,7 +506,7 @@ def test_duplicate_action(init_oso):
     oso.load_str(policy)
 
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -531,7 +527,7 @@ def test_undeclared_permission(init_oso):
     oso.load_str(policy)
 
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -551,7 +547,7 @@ def test_undeclared_role(init_oso):
     """
     oso.load_str(policy)
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -582,7 +578,7 @@ def test_role_implication_without_relationship(init_oso):
     """
     oso.load_str(policy)
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -608,7 +604,7 @@ def test_role_permission_without_relationship(init_oso):
     """
     oso.load_str(policy)
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -646,7 +642,7 @@ def test_invalid_role_permission(init_oso):
 
     oso.load_str(policy)
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -672,7 +668,7 @@ def test_permission_assignment_to_implied_role(init_oso):
 
     oso.load_str(policy)
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -687,7 +683,7 @@ def test_incorrect_arity_resource(init_oso):
     """
     oso.load_str(policy)
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -699,7 +695,7 @@ def test_undefined_resource_arguments(init_oso):
     """
     oso.load_str(policy)
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 @pytest.mark.skip("TODO: validation")
@@ -718,7 +714,7 @@ def test_wrong_type_resource_arguments(init_oso):
     """
     oso.load_str(policy)
     with pytest.raises(OsoError):
-        oso.roles.synchronize_data()
+        oso.validate_config()
 
 
 # TEST CHECK API
@@ -793,8 +789,7 @@ def test_overlapping_permissions(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     oso_repo = sample_data["oso_repo"]
@@ -833,8 +828,7 @@ def test_homogeneous_role_perm(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
@@ -868,8 +862,7 @@ def test_homogeneous_role_perm(init_oso, sample_data):
     # oso.roles.config = None
     oso.enable_roles()
     oso.load_str(new_policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     assert not oso.is_allowed(leina, "invite", osohq)
     assert oso.is_allowed(leina, "list_repos", osohq)
@@ -904,8 +897,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     oso_repo = sample_data["oso_repo"]
@@ -952,8 +944,7 @@ def test_parent_child_role_perm(init_oso, sample_data):
     # oso.roles.config = None
     oso.enable_roles()
     oso.load_str(new_policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     assert not oso.is_allowed(leina, "pull", oso_repo)
     assert oso.is_allowed(leina, "invite", osohq)
@@ -994,10 +985,9 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
+    oso.validate_config()
     # TODO: big red button to reset roles policy?
     # oso.roles.config = None
-    # TODO: validation
-    # oso.roles.synchronize_data()
 
     osohq = sample_data["osohq"]
     oso_bug = sample_data["oso_bug"]
@@ -1051,10 +1041,9 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
     oso.clear_rules()
     oso.enable_roles()
     oso.load_str(new_policy)
+    oso.validate_config()
     # TODO: big red button to reset roles policy?
     # oso.roles.config = None
-    # TODO: validation
-    # oso.roles.synchronize_data()
 
     assert not oso.is_allowed(leina, "edit", oso_bug)
     assert oso.is_allowed(leina, "invite", osohq)
@@ -1081,10 +1070,9 @@ def test_homogeneous_role_implication(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
+    oso.validate_config()
     # TODO: big red button to reset roles policy?
     # oso.roles.config = None
-    # TODO: validation
-    # oso.roles.synchronize_data()
 
     osohq = sample_data["osohq"]
     apple = sample_data["apple"]
@@ -1124,10 +1112,9 @@ def test_homogeneous_role_implication(init_oso, sample_data):
     oso.clear_rules()
     oso.enable_roles()
     oso.load_str(new_policy)
+    oso.validate_config()
     # TODO: big red button to reset roles policy?
     # oso.roles.config = None
-    # TODO: validation
-    # oso.roles.synchronize_data()
 
     # leina can still "invite"
     assert oso.is_allowed(leina, "invite", osohq)
@@ -1171,8 +1158,7 @@ def test_parent_child_role_implication(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     oso_repo = sample_data["oso_repo"]
@@ -1217,10 +1203,9 @@ def test_parent_child_role_implication(init_oso, sample_data):
     oso.clear_rules()
     oso.enable_roles()
     oso.load_str(new_policy)
+    oso.validate_config()
     # TODO: big red button to reset roles policy?
     # oso.roles.config = None
-    # TODO: validation
-    # oso.roles.synchronize_data()
 
     assert not oso.is_allowed(leina, "pull", oso_repo)
     assert oso.is_allowed(leina, "invite", osohq)
@@ -1264,8 +1249,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     oso_bug = sample_data["oso_bug"]
@@ -1319,8 +1303,7 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
     # TODO: big red button to reset roles policy?
     # oso.roles.config = None
     oso.load_str(new_policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     assert not oso.is_allowed(leina, "edit", oso_bug)
     assert oso.is_allowed(leina, "invite", osohq)
@@ -1376,8 +1359,7 @@ def test_chained_role_implication(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     oso_repo = sample_data["oso_repo"]
@@ -1453,8 +1435,7 @@ def test_chained_role_implication(init_oso, sample_data):
     # TODO: big red button to reset roles policy?
     # oso.roles.config = None
     oso.load_str(new_policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     # leina can't edit the issue anymore
     assert not oso.is_allowed(leina, "edit", oso_bug)
@@ -1492,8 +1473,7 @@ def test_assign_role_wrong_resource_type(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     oso_repo = sample_data["oso_repo"]
     leina = sample_data["leina"]
@@ -1520,8 +1500,7 @@ def test_assign_remove_nonexistent_role(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
@@ -1550,8 +1529,7 @@ def test_remove_unassigned_role(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
@@ -1582,8 +1560,7 @@ def test_assign_remove_user_role(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
@@ -1660,8 +1637,7 @@ def test_reassign_user_role(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
@@ -1731,8 +1707,7 @@ def test_authorizing_related_fields(
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     steve = sample_data["steve"]
@@ -1770,8 +1745,7 @@ def test_data_filtering_role_allows_not(init_oso, sample_data, auth_sessionmaker
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     apple = sample_data["apple"]
@@ -1832,8 +1806,7 @@ def test_data_filtering_role_allows_and(
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     apple = sample_data["apple"]
@@ -1901,8 +1874,7 @@ def test_data_filtering_role_allows_explicit_or(
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     apple = sample_data["apple"]
@@ -1961,8 +1933,7 @@ def test_data_filtering_role_allows_implicit_or(
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
@@ -2004,8 +1975,7 @@ def test_data_filtering_user_in_role_not(init_oso, sample_data, auth_sessionmake
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     apple = sample_data["apple"]
@@ -2066,8 +2036,7 @@ def test_data_filtering_user_in_role_and(
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     apple = sample_data["apple"]
@@ -2138,8 +2107,7 @@ def test_data_filtering_user_in_role_explicit_or(
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     apple = sample_data["apple"]
@@ -2201,8 +2169,7 @@ def test_data_filtering_user_in_role_implicit_or(
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
@@ -2250,8 +2217,7 @@ def test_data_filtering_combo(init_oso, sample_data, auth_sessionmaker, User, Or
     """
     # You can't directly `and` the two Roles calls right now but it does work if you do it like ^
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
@@ -2308,8 +2274,7 @@ def test_read_api(init_oso, sample_data, Repo, Org):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     oso_repo = sample_data["oso_repo"]
@@ -2382,8 +2347,7 @@ def test_user_in_role(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
-    # TODO: validation
-    # oso.roles.synchronize_data()
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     oso_repo = sample_data["oso_repo"]
@@ -2531,6 +2495,7 @@ def test_role_allows_with_other_rules(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
+    oso.validate_config()
 
     osohq = sample_data["osohq"]
     leina = sample_data["leina"]
@@ -2602,6 +2567,7 @@ def test_roles_integration(init_oso, sample_data):
         role in actor.org_roles;
     """
     oso.load_str(policy)
+    oso.validate_config()
 
     # Get sample data
     # -------------------
@@ -2717,6 +2683,7 @@ def test_legacy_sam_polar_roles(init_oso, sample_data):
             role in actor.org_roles;
     """
     oso.load_str(policy)
+    oso.validate_config()
 
     leina = sample_data["leina"]
     steve = sample_data["steve"]
@@ -2815,6 +2782,7 @@ def test_perf_polar(init_oso, sample_data):
     # org = repo.org and org matches Org;
     # """
     oso.load_str(p)
+    oso.validate_config()
 
     leina = sample_data["leina"]
     # steve = sample_data["steve"]

--- a/languages/python/oso/tests/test_polar_roles.py
+++ b/languages/python/oso/tests/test_polar_roles.py
@@ -862,8 +862,6 @@ def test_homogeneous_role_perm(init_oso, sample_data):
     """
 
     oso.clear_rules()
-    # TODO: big red button to reset roles policy?
-    # oso.roles.config = None
     oso.enable_roles()
     oso.load_str(new_policy)
     oso.validate_config()
@@ -950,8 +948,6 @@ def test_parent_child_role_perm(init_oso, sample_data):
     """
 
     oso.clear_rules()
-    # TODO: big red button to reset roles policy?
-    # oso.roles.config = None
     oso.enable_roles()
     oso.load_str(new_policy)
     oso.validate_config()
@@ -999,8 +995,6 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
     """
     oso.load_str(policy)
     oso.validate_config()
-    # TODO: big red button to reset roles policy?
-    # oso.roles.config = None
 
     osohq = sample_data["osohq"]
     oso_bug = sample_data["oso_bug"]
@@ -1058,8 +1052,6 @@ def test_grandparent_child_role_perm(init_oso, sample_data):
     oso.enable_roles()
     oso.load_str(new_policy)
     oso.validate_config()
-    # TODO: big red button to reset roles policy?
-    # oso.roles.config = None
 
     assert not oso.is_allowed(leina, "edit", oso_bug)
     assert oso.is_allowed(leina, "invite", osohq)
@@ -1090,8 +1082,6 @@ def test_homogeneous_role_implication(init_oso, sample_data):
     """
     oso.load_str(policy)
     oso.validate_config()
-    # TODO: big red button to reset roles policy?
-    # oso.roles.config = None
 
     osohq = sample_data["osohq"]
     apple = sample_data["apple"]
@@ -1135,8 +1125,6 @@ def test_homogeneous_role_implication(init_oso, sample_data):
     oso.enable_roles()
     oso.load_str(new_policy)
     oso.validate_config()
-    # TODO: big red button to reset roles policy?
-    # oso.roles.config = None
 
     # leina can still "invite"
     assert oso.is_allowed(leina, "invite", osohq)
@@ -1232,8 +1220,6 @@ def test_parent_child_role_implication(init_oso, sample_data):
     oso.enable_roles()
     oso.load_str(new_policy)
     oso.validate_config()
-    # TODO: big red button to reset roles policy?
-    # oso.roles.config = None
 
     assert not oso.is_allowed(leina, "pull", oso_repo)
     assert oso.is_allowed(leina, "invite", osohq)
@@ -1334,8 +1320,6 @@ def test_grandparent_child_role_implication(init_oso, sample_data):
 
     oso.clear_rules()
     oso.enable_roles()
-    # TODO: big red button to reset roles policy?
-    # oso.roles.config = None
     oso.load_str(new_policy)
     oso.validate_config()
 
@@ -1472,8 +1456,6 @@ def test_chained_role_implication(init_oso, sample_data):
 
     oso.clear_rules()
     oso.enable_roles()
-    # TODO: big red button to reset roles policy?
-    # oso.roles.config = None
     oso.load_str(new_policy)
     oso.validate_config()
 


### PR DESCRIPTION
We can't validate as much as we could before.

* Relationship stuff is much harder because we don't restrict the form of those rules the way we had to before.
* Anything checking valid sqlalchemy fields doesn't apply anymore.

This turns back on the tests we can validate.