### PR TITLE
Include roles.polar file in built wheels

### DIFF
--- a/languages/python/oso/setup.py
+++ b/languages/python/oso/setup.py
@@ -67,7 +67,10 @@ setup(
     #
     # If using Python 2.6 or earlier, then these have to be included in
     # MANIFEST.in as well.
-    package_data={"polar": ["py.typed"], "oso": ["py.typed"]},  # Optional
+    package_data={
+        "polar": ["py.typed"],
+        "oso": ["py.typed", "roles.polar"],
+    },  # Optional
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files


### PR DESCRIPTION
Tested by running `python setup.py bdist_wheel` before & after this
change