### PR TITLE
Make read next appear on new roles pages

### DIFF
--- a/docs/content/python/new-roles/intro.md
+++ b/docs/content/python/new-roles/intro.md
@@ -1,3 +1,0 @@
----
-headless: true
----

--- a/docs/themes/oso-tailwind/layouts/_default/single.html
+++ b/docs/themes/oso-tailwind/layouts/_default/single.html
@@ -7,13 +7,17 @@
           <article class="prose max-w-none min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pb-24 lg:pb-16">
             {{ .Content }}
           </article>
-          {{with .PrevInSection }}
-          <a class="flex justify-end" href="{{.RelPermalink}}">
-          <button class="btn btn-blue">
-          Read next: {{.Title}}
-          </button>
-          </a>
-          {{end}}
+          {{ $currentPage := . }}
+          {{ range $pageIdx, $page := .CurrentSection.RegularPages }}
+            {{ if and (eq $currentPage $page) (lt (add $pageIdx 1) (len .CurrentSection.RegularPages)) }}
+              {{ $nextRegPage := index .CurrentSection.RegularPages (add $pageIdx 1) }}
+              <a class="flex justify-end" href="{{$nextRegPage.RelPermalink}}">
+                <button class="btn btn-blue">
+                  Read next: {{$nextRegPage.Title}}
+                </button>
+              </a>
+            {{ end }}
+          {{ end }}
           <hr class="max-w-4xl mx-auto text-center border-gray-100 my-12" />
           <div class="prose max-w-none min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pb-24 lg:pb-16">
             {{- partial "feedback.html" . -}}


### PR DESCRIPTION
I don't really understand why it wasn't working on them, .PrevInSection was returning nil for every page. This is how I assume it works under the hood, so not totally sure