### PR TITLE
Cleaner imports

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -40,3 +40,33 @@ Link to [relevant documentation section]().
 - Bulleted list
 - Of smaller improvements
 - Potentially with doc [links]().
+
+## `sqlalchemy-oso` NEW_VERSION
+
+### Breaking changes
+
+<!-- TODO: remove warning and replace with "None" if no breaking changes. -->
+
+{{% callout "Warning" "orange" %}}
+  This release contains breaking changes. Be sure to follow migration steps
+  before upgrading.
+{{% /callout %}}
+
+#### Breaking change 1
+
+Summary of breaking change.
+
+Link to [migration guide]().
+
+### New features
+
+#### Feature 1
+
+Summary of user-facing changes.
+
+Link to [relevant documentation section]().
+
+### Other bugs & improvements
+
+- Thanks to [@tomashozman](https://github.com/tomashozman) for cleaning up some
+  SQLAlchemy imports ([#997](https://github.com/osohq/oso/pull/997)).

--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -68,5 +68,5 @@ Link to [relevant documentation section]().
 
 ### Other bugs & improvements
 
-- Thanks to [@tomashozman](https://github.com/tomashozman) for cleaning up some
-  SQLAlchemy imports ([#997](https://github.com/osohq/oso/pull/997)).
+- Thanks to [`@tomashozman`](https://github.com/tomashozman) for cleaning up
+  some SQLAlchemy imports ([#997](https://github.com/osohq/oso/pull/997)).

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/roles.py
@@ -4,13 +4,12 @@ from dataclasses import dataclass
 
 from oso import OsoError, Variable
 
-import sqlalchemy
+from sqlalchemy.exc import NoInspectionAvailable
 from sqlalchemy.types import Integer, String
 from sqlalchemy.schema import Column, ForeignKey
-from sqlalchemy import inspect
+from sqlalchemy import inspect, sql
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm.exc import UnmappedClassError
-from sqlalchemy import sql
 from .compat import iterate_model_classes
 
 
@@ -954,7 +953,7 @@ class OsoRoles:
             user_id = getattr(user, user_pk_name)
 
             resource_pk_name, _ = get_pk(resource.__class__)
-        except sqlalchemy.exc.NoInspectionAvailable:
+        except NoInspectionAvailable:
             # User or Resource is not a sqlalchemy object
             return False
 
@@ -1142,7 +1141,7 @@ def _generate_query_filter(oso, role_method, model):
 
         resource_type = model.__name__
         resource_pk_name, _ = get_pk(model)
-    except sqlalchemy.exc.NoInspectionAvailable:
+    except NoInspectionAvailable:
         # User or Resource is not a sqlalchemy object
         return sql.false()
 


### PR DESCRIPTION
I think it's much prettier and cleaner to do it like this, instead of having both objects from SQLAlchemy and SQLAlchemy itself in our namespace. Also better for consistency's sake.