### PR TITLE
Allow custom query timeouts

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -38,9 +38,9 @@ Link to [relevant documentation section]().
 - Thanks to [`@tomashozman`](https://github.com/tomashozman) for cleaning up
   some SQLAlchemy imports ([#997](https://github.com/osohq/oso/pull/997)).
 
-## `RELEASED_PACKAGE_1` NEW_VERSION
+## `oso` NEW_VERSION
 
-### LANGUAGE (e.g., 'Core' or 'Python' or 'Node.js')
+### Core
 
 #### Breaking changes
 
@@ -59,11 +59,9 @@ Link to [migration guide]().
 
 #### New features
 
-##### Feature 1
+##### Custom query timeouts
 
-Summary of user-facing changes.
-
-Link to [relevant documentation section]().
+Added the ability for users to configure query timeouts using a `POLAR_TIMEOUT_MS` environment variable. To disable timeouts (which is useful for debugging), set `POLAR_TIMEOUT_MS` to `0`.
 
 #### Other bugs & improvements
 

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -3756,7 +3756,6 @@ mod tests {
         std::env::set_var("POLAR_TIMEOUT_MS", "0");
         let vm = PolarVirtualMachine::default();
         std::env::remove_var("POLAR_TIMEOUT_MS");
-        assert!(vm.query_timeout_ms == 0);
         assert!(vm.is_query_timeout_disabled())
     }
 

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -863,7 +863,16 @@ impl PolarVirtualMachine {
         (now - start) as u64
     }
 
+    fn is_query_timeout_disabled(&self) -> bool {
+        self.query_timeout_ms == 0
+    }
+
     fn check_timeout(&self) -> PolarResult<()> {
+        if self.is_query_timeout_disabled() {
+            // Useful for debugging
+            return Ok(())
+        }
+
         let elapsed = self.query_duration();
         if elapsed > self.query_timeout_ms {
             return Err(error::RuntimeError::QueryTimeout {
@@ -3748,6 +3757,7 @@ mod tests {
         let vm = PolarVirtualMachine::default();
         std::env::remove_var("POLAR_TIMEOUT_MS");
         assert!(vm.query_timeout_ms == 0);
+        assert!(vm.is_query_timeout_disabled())
     }
 
     #[test]

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -287,7 +287,7 @@ impl PolarVirtualMachine {
         goals: Goals,
         messages: MessageQueue,
     ) -> Self {
-        let timeout_ms = std::env::var("POLAR_TIMEOUT_MS")
+        let query_timeout_ms = std::env::var("POLAR_TIMEOUT_MS")
             .ok()
             .and_then(|timeout_str| timeout_str.parse::<u64>().ok())
             .unwrap_or(DEFAULT_TIMEOUT_MS);
@@ -300,7 +300,7 @@ impl PolarVirtualMachine {
             goals: GoalStack::new_reversed(goals),
             binding_manager: BindingManager::new(),
             query_start_time: None,
-            query_timeout_ms: timeout_ms,
+            query_timeout_ms,
             stack_limit: MAX_STACK_SIZE,
             csp: Bsp::default(),
             choices: vec![],

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -870,7 +870,7 @@ impl PolarVirtualMachine {
     fn check_timeout(&self) -> PolarResult<()> {
         if self.is_query_timeout_disabled() {
             // Useful for debugging
-            return Ok(())
+            return Ok(());
         }
 
         let elapsed = self.query_duration();


### PR DESCRIPTION
This change allows users to configure the query timeout using an environment variable `POLAR_TIMEOUT_MS`. If the timeout is set to `0`, the timeout mechanism is disabled entirely (which is useful for debugging)