### PR TITLE
Dynamically load constants in ruby library

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -68,3 +68,34 @@ Added the ability for users to configure query timeouts using a `POLAR_TIMEOUT_M
 - Bulleted list
 - Of smaller improvements
 - Potentially with doc [links]().
+
+### Ruby (`oso-oso`)
+
+#### Breaking changes
+
+<!-- TODO: remove warning and replace with "None" if no breaking changes. -->
+
+{{% callout "Warning" "orange" %}}
+  This release contains breaking changes. Be sure to follow migration steps
+  before upgrading.
+{{% /callout %}}
+
+##### Breaking change 1
+
+Summary of breaking change.
+
+Link to [migration guide]().
+
+#### New features
+
+#### Feature 1
+
+Summary of user-facing changes.
+
+Link to [relevant documentation section]().
+#### Other bugs & improvements
+
+- Oso's ruby library now behaves better with code reloading in development. You
+  can use `OSO.register_class(Klass)` and calls to `foo matches Klass` will
+  always use the up-to-date version of the `Klass` constant, even if it's been
+  reloaded.

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -18,13 +18,18 @@ module Oso
     # look it up using const_get, which will always return the up-to-date
     # version of the class.
     class PolarClass
-      attr_reader :name
+      attr_reader :name, :anon_class
 
       def initialize(klass)
         @name = klass.name
+        # If the class doesn't have a name, it is anonymous, meaning we should
+        # actually store it directly
+        @anon_class = klass if klass.name.nil?
       end
 
       def get
+        return anon_class if anon_class
+
         Object.const_get(name)
       end
     end
@@ -115,7 +120,7 @@ module Oso
       def cache_instance(instance, id: nil)
         id = ffi_polar.new_id if id.nil?
         # Save the instance as a PolarClass if it is a non-anonymous class
-        instance = PolarClass.new(instance) if instance.is_a?(Class) && !instance.name.nil?
+        instance = PolarClass.new(instance) if instance.is_a?(Class)
         instances[id] = instance
         id
       end

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -100,7 +100,9 @@ module Oso
       def get_instance(id)
         raise UnregisteredInstanceError, id unless instance? id
 
-        instances[id]
+        instance = instances[id]
+        return instance.get if instance.is_a? PolarClass
+        instance
       end
 
       # Cache a Ruby instance in the {#instances} cache, fetching a new id if
@@ -111,6 +113,7 @@ module Oso
       # @return [Integer] the instance ID.
       def cache_instance(instance, id: nil)
         id = ffi_polar.new_id if id.nil?
+        instance = PolarClass.new(instance) if instance.is_a? Class
         instances[id] = instance
         id
       end

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -102,6 +102,7 @@ module Oso
 
         instance = instances[id]
         return instance.get if instance.is_a? PolarClass
+
         instance
       end
 

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -114,7 +114,8 @@ module Oso
       # @return [Integer] the instance ID.
       def cache_instance(instance, id: nil)
         id = ffi_polar.new_id if id.nil?
-        instance = PolarClass.new(instance) if instance.is_a? Class
+        # Save the instance as a PolarClass if it is a non-anonymous class
+        instance = PolarClass.new(instance) if instance.is_a?(Class) && !instance.name.nil?
         instances[id] = instance
         id
       end

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -2,25 +2,24 @@
 
 module Oso
   module Polar
-    # Translate between Polar and the host language (Ruby).
-
+    # Ruby code reloaders (i.e. the one used by rails) swap out the value of
+    # a constant on code changes. Because of this, we can't reliably call
+    # `is_a?` on the constant that was passed to `register_class`.
+    #
+    # Example (where Foo is a class defined in foo.rb):
+    #   > klass = Foo
+    #   > Foo.new.is_a? klass
+    #     => true
+    #   > ... user changes foo.rb ...
+    #   > Foo.new.is_a? klass
+    #     => false
+    #
+    # To solve this, when we need to access the class (e.g. during isa), we
+    # look it up using const_get, which will always return the up-to-date
+    # version of the class.
     class PolarClass
-      # Ruby code reloaders (i.e. the one used by rails) swap out the value of
-      # a constant on code changes. Because of this, we can't reliably call
-      # `is_a?` on the constant that was passed to `register_class`.
-      #
-      # Example (where Foo is a class defined in foo.rb):
-      #   > klass = Foo
-      #   > Foo.new.is_a? klass
-      #     => true
-      #   > ... user changes foo.rb ...
-      #   > Foo.new.is_a? klass
-      #     => false
-      #
-      # To solve this, when we need to access the class (e.g. during isa), we
-      # look it up using const_get, which will always return the up-to-date
-      # version of the class.
       attr_reader :name
+
       def initialize(klass)
         @name = klass.name
       end
@@ -29,6 +28,8 @@ module Oso
         Object.const_get(name)
       end
     end
+
+    # Translate between Polar and the host language (Ruby).
     class Host # rubocop:disable Metrics/ClassLength
       protected
 

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -840,5 +840,14 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
     it 'uses the up-to-date version of the class for lookups' do
       expect(query(subject, 'Foo.class_version = 2')).to eq([{}])
     end
+
+    it 'works with anonymous classes' do
+      subject.register_class(Class.new do
+        def self.test
+          1
+        end
+      end, name: 'AnonymousClass')
+      expect(query(subject, 'AnonymousClass.test = 1')).to eq([{}])
+    end
   end
 end

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -803,7 +803,7 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  context 'Code reloading' do
+  context 'Code reloading' do # rubocop:disable Metrics/BlockLength
     before do
       # Register a class and then simulate it changing due to a code reload
       stub_const('Foo', Class.new do
@@ -838,7 +838,7 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
     end
 
     it 'uses the up-to-date version of the class for lookups' do
-      expect(query(subject, "Foo.class_version = 2")).to eq([{}])
+      expect(query(subject, 'Foo.class_version = 2')).to eq([{}])
     end
   end
 end

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -841,13 +841,23 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
       expect(query(subject, 'Foo.class_version = 2')).to eq([{}])
     end
 
-    it 'works with anonymous classes' do
+    it 'can lookup attributes on anonymous classes' do
       subject.register_class(Class.new do
         def self.test
           1
         end
       end, name: 'AnonymousClass')
       expect(query(subject, 'AnonymousClass.test = 1')).to eq([{}])
+    end
+
+    it 'can match against anonymous classes' do
+      anon_class = Class.new do
+        def self.test
+          1
+        end
+      end
+      subject.register_class(anon_class, name: 'AnonymousClass')
+      expect(query(subject, 'new AnonymousClass() matches AnonymousClass')).to eq([{}])
     end
   end
 end


### PR DESCRIPTION
This fixes issues caused by using Oso with code reloaders (i.e. rails and [zeitwerk](https://github.com/fxn/zeitwerk)), which effectively swap out the values of global constants when files are changed.

One user-space solution is to re-create an Oso instance (with `Oso.new`) every time a file changes, and call `register_class` with each new class constant, but that's kind of a hack. This change lets us take advantage of Ruby's global "constant table" to always use the most up-to-date version of a constant.

Note: it relies on this identity (which is always true AFAICT): `Object.const_get(klass.name) == klass`. That holds even for classes in a nested namespace, e.g. `Foo::Bar::Bat`.

PR checklist:

<!-- Delete if no entry is required. -->
- [x] Added changelog entry.
