### PR TITLE
Add section to Flask docs on working with LocalProxy instances

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -35,6 +35,14 @@ Summary of user-facing changes.
 
 Link to [relevant documentation section]().
 
+## `flask-oso` NEW_VERSION
+
+### Other bugs & improvements
+
+- Thanks to [`@arusahni`](https://github.com/arusahni) for surfacing and
+  documenting a potential gotcha when using `flask-oso` with other Flask
+  libraries that rely on `LocalProxy` objects.
+
 #### Other bugs & improvements
 
 - Bulleted list

--- a/docs/content/python/reference/frameworks/flask.md
+++ b/docs/content/python/reference/frameworks/flask.md
@@ -16,7 +16,7 @@ usage with [Flask](https://flask.palletsprojects.com/).
 The Oso Flask integration is available on [PyPI](https://pypi.org/project/flask-oso/) and can be installed using
 `pip`:
 
-```
+```console
 $ pip install flask-oso
 ```
 
@@ -35,7 +35,7 @@ We just released the next version of our roles feature.
 The `FlaskOso` class is the entrypoint to the integration.
 It must be initialized with the Flask app and Oso:
 
-```
+```python
 from flask import Flask
 from oso import Oso
 
@@ -47,7 +47,7 @@ flask_oso = FlaskOso(app=app, oso=oso)
 Alternatively, to support the Flask factory pattern, the
 `init_app()` method can be used:
 
-```
+```python
 from flask import Flask
 
 from oso import Oso
@@ -71,7 +71,7 @@ This factory function can be a useful place for loading policy files, and
 calling configuration functions on `FlaskOso` like
 `flask_oso.FlaskOso.require_authorization()`:
 
-```
+```python
 def create_app():
     app = Flask("app")
 
@@ -97,7 +97,7 @@ the data access layer, depending upon how you want to express authorization.
 
 Here’s a basic example in a route:
 
-```
+```python
 @app.route("/<int:id>", methods=["GET"])
 def get_expense(id):
     expense = Expense.query.get(id)
@@ -126,7 +126,7 @@ Sometimes a route will not need authorization. To prevent this route from
 causing an authorization error, call
 `flask_oso.FlaskOso.skip_authorization()` during request processing:
 
-```
+```python
 oso = Oso()
 flask_oso = FlaskOso()
 
@@ -161,7 +161,7 @@ authorization. It is the decorator version of
 `flask_oso.FlaskOso.authorize()` before the route body is entered. For
 example:
 
-```
+```python
 from flask_oso import authorize
 
 @authorize(resource="get_user")
@@ -178,7 +178,7 @@ body.
 One common usage of `flask_oso.authorize()` is to perform authorization
 based on the Flask request object:
 
-```
+```python
 from flask import request
 
 @flask_oso.authorize(resource=request)
@@ -190,7 +190,7 @@ def route():
 A policy can then be written controlling authorization based on request
 attributes, like the path:
 
-```
+```polar
 # Allow any actor to make a GET request to "/".
 allow(_actor, action: "GET", resource: Request{path: "/"});
 ```

--- a/docs/content/python/reference/frameworks/flask.md
+++ b/docs/content/python/reference/frameworks/flask.md
@@ -113,6 +113,31 @@ a failed authorization will return a \`\`403 Forbidden\`\` response for the curr
 request.** This can be controlled with
 `set_unauthorized_action()`.
 
+If using specializers in the Polar policy, such as with a `User` class:
+
+```polar
+allow(_actor: User, action: "GET", resource: Request{path: "/"})
+```
+
+... an extra step may need to be taken when using a library or authentication framework (like Flask Login)
+that exposes the current user through `LocalProxy` objects (such as `current_user`).
+
+```python
+from flask_login import current_user
+
+def create_app():
+    app = Flask("app")
+
+    flask_oso.init_app(app)
+    flask_oso.require_authorization(app)
+    # Dereference the current_user LocalProxy
+    flask_oso.set_get_actor(lambda: current_user._get_current_object())
+
+    oso.load_file("authorization.polar")
+    oso.register_class(User)
+    return app
+```
+
 ### Requiring authorization
 
 One downside to calling `flask_oso.FlaskOso.authorize()`

--- a/docs/content/python/reference/frameworks/flask.md
+++ b/docs/content/python/reference/frameworks/flask.md
@@ -113,14 +113,14 @@ a failed authorization will return a \`\`403 Forbidden\`\` response for the curr
 request.** This can be controlled with
 `set_unauthorized_action()`.
 
-If using specializers in the Polar policy, such as with a `User` class:
+#### Working with `LocalProxy` objects
 
-```polar
-allow(_actor: User, action: "GET", resource: Request{path: "/"})
-```
+When using a library that exposes the current user (or similar
+authorization data) through `LocalProxy` objects, such as [Flask-Login][]'s
+`current_user`, you might need to explicitly dereference the proxy
+to pass the underlying object to Oso:
 
-... an extra step may need to be taken when using a library or authentication framework (like Flask Login)
-that exposes the current user through `LocalProxy` objects (such as `current_user`).
+[Flask-Login]: https://flask-login.readthedocs.io/en/0.4.1/#flask_login.current_user
 
 ```python
 from flask_login import current_user
@@ -137,6 +137,9 @@ def create_app():
     oso.register_class(User)
     return app
 ```
+
+By dereferencing the proxy, Oso will use the underlying object when determining
+authorization instead of the proxy object.
 
 ### Requiring authorization
 

--- a/docs/spelling/allowed_words.txt
+++ b/docs/spelling/allowed_words.txt
@@ -85,7 +85,9 @@ customizations
 dataloader
 dataloaders
 declaratively
+dereference
 dereferenced
+dereferencing
 destructure
 destructured
 dev


### PR DESCRIPTION
[As discussed on Slack](https://oso-oss.slack.com/archives/C017KSBTD4M/p1626696970338000), this PR adds a section to the Flask docs on working with `LocalProxy` instances when using specializers in a policy.

I also added syntax names to all fenced code blocks on this page, so highlighting should work.