### PR TITLE
Unify across host/native types

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -27,6 +27,30 @@ Summary of breaking change.
 
 Link to [migration guide]().
 
+##### Feature 1
+
+Summary of user-facing changes.
+
+Link to [relevant documentation section]().
+
+## `oso` NEW_VERSION
+
+### Core
+
+#### Other bugs & improvements
+
+- Native types (`Integer`, `String`, `Dictionary`, etc.) and
+  equivalent host objects created with the `new` operator can now
+  be unified transparently.
+
+### Ruby
+
+#### Other bugs & improvements
+
+- Comparison operations on Ruby objects are now fully supported.
+
+### Rust 
+
 #### New features
 
 ##### Roles in Rust
@@ -34,12 +58,6 @@ Link to [migration guide]().
 The Rust library now has
 [built-in support for Role-Based Access Control (RBAC) policies](/guides/roles),
 which you can turn on with `.enable_roles()`.
-
-##### Feature 1
-
-Summary of user-facing changes.
-
-Link to [relevant documentation section]().
 
 ## `flask-oso` NEW_VERSION
 

--- a/languages/README.md
+++ b/languages/README.md
@@ -64,7 +64,7 @@ Execute a Polar query through the FFI event interface.
 | `ExternalCall`             | x      | x    | x    | x       | x    |
 | `ExternalIsa`              | x      | x    | x    | x       | x    |
 | `ExternalIsSubSpecializer` | x      | x    | x    | x       |      |
-| `ExternalOp`               | x      |      |      | x       |      |
+| `ExternalOp`               | x      | x    |      | x       |      |
 | `ExternalUnify`            | x      | x    |      | x       |      |
 | `MakeExternal`             | x      | x    | x    | x       | x    |
 | `NextExternal`             | x      | x    | x    | x       |      |

--- a/languages/go/interfaces/interfaces.go
+++ b/languages/go/interfaces/interfaces.go
@@ -5,9 +5,9 @@ Interface for values that can be compared.
 */
 type Comparer interface {
 	// Should return `true` when values are equal; `false` when not equal.
-	Equal(other Comparer) bool
+	Equal(other interface{}) bool
 	// Should return `true` when the comparer is less than `other`; `false` when not less than.
-	Lt(other Comparer) bool
+	Lt(other interface{}) bool
 }
 
 /*

--- a/languages/go/internal/host/host.go
+++ b/languages/go/internal/host/host.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/osohq/go-oso/errors"
-	"github.com/osohq/go-oso/interfaces"
 	"github.com/osohq/go-oso/internal/ffi"
 	"github.com/osohq/go-oso/types"
 	. "github.com/osohq/go-oso/types"
@@ -17,15 +16,6 @@ import (
 var CLASSES = make(map[string]reflect.Type)
 
 type None struct{}
-
-func (l None) Equal(r interfaces.Comparer) bool {
-	l, ok := r.(None)
-	return ok
-}
-
-func (l None) Lt(r interfaces.Comparer) bool {
-	panic("unsupported")
-}
 
 type Host struct {
 	ffiPolar     ffi.PolarFfi

--- a/languages/go/internal/host/host.go
+++ b/languages/go/internal/host/host.go
@@ -19,14 +19,13 @@ var CLASSES = make(map[string]reflect.Type)
 type None struct{}
 
 func (l None) Equal(r interfaces.Comparer) bool {
-  l, ok := r.(None)
-  return ok
+	l, ok := r.(None)
+	return ok
 }
 
 func (l None) Lt(r interfaces.Comparer) bool {
-  panic("unsupported")
+	panic("unsupported")
 }
-
 
 type Host struct {
 	ffiPolar     ffi.PolarFfi

--- a/languages/go/internal/host/host.go
+++ b/languages/go/internal/host/host.go
@@ -18,6 +18,16 @@ var CLASSES = make(map[string]reflect.Type)
 
 type None struct{}
 
+func (l None) Equal(r interfaces.Comparer) bool {
+  l, ok := r.(None)
+  return ok
+}
+
+func (l None) Lt(r interfaces.Comparer) bool {
+  panic("unsupported")
+}
+
+
 type Host struct {
 	ffiPolar     ffi.PolarFfi
 	classes      map[string]reflect.Type

--- a/languages/go/internal/host/host.go
+++ b/languages/go/internal/host/host.go
@@ -190,23 +190,6 @@ func (h Host) cacheInstance(instance interface{}, id *uint64) (*uint64, error) {
 	return &instanceID, nil
 }
 
-func (h Host) Unify(leftID uint64, rightID uint64) (bool, error) {
-	left, err1 := h.getInstance(leftID)
-	right, err2 := h.getInstance(rightID)
-	if err1 != nil {
-		return false, err1
-	}
-	if err2 != nil {
-		return false, err2
-	}
-	if leftEq, ok := left.Interface().(interfaces.Comparer); ok {
-		if rightEq, ok := right.Interface().(interfaces.Comparer); ok {
-			return leftEq.Equal(rightEq), nil
-		}
-	}
-	return reflect.DeepEqual(left, right), nil
-}
-
 func (h Host) Isa(value types.Term, classTag string) (bool, error) {
 	instance, err := h.ToGo(value)
 	if err != nil {

--- a/languages/go/query.go
+++ b/languages/go/query.go
@@ -122,8 +122,6 @@ func (q *Query) Next() (*map[string]interface{}, error) {
 			err = q.handleExternalIsSubSpecializer(ev)
 		case QueryEventExternalIsSubclass:
 			err = q.handleExternalIsSubclass(ev)
-		case QueryEventExternalUnify:
-			err = q.handleExternalUnify(ev)
 		case QueryEventExternalOp:
 			err = q.handleExternalOp(ev)
 		case QueryEventNextExternal:
@@ -223,14 +221,6 @@ func (q Query) handleExternalIsSubSpecializer(event types.QueryEventExternalIsSu
 
 func (q Query) handleExternalIsSubclass(event types.QueryEventExternalIsSubclass) error {
 	res, err := q.host.IsSubclass(string(event.LeftClassTag), string(event.RightClassTag))
-	if err != nil {
-		return err
-	}
-	return q.ffiQuery.QuestionResult(event.CallId, res)
-}
-
-func (q Query) handleExternalUnify(event types.QueryEventExternalUnify) error {
-	res, err := q.host.Unify(event.LeftInstanceId, event.RightInstanceId)
 	if err != nil {
 		return err
 	}

--- a/languages/go/query.go
+++ b/languages/go/query.go
@@ -245,32 +245,32 @@ func (q Query) handleExternalOp(event types.QueryEventExternalOp) error {
 	leftCmp, leftOk := left.(interfaces.Comparer)
 	rightCmp, rightOk := right.(interfaces.Comparer)
 
-  if !leftOk || !rightOk {
-    switch event.Operator.OperatorVariant.(type) {
-    case OperatorEq:
-      answer = reflect.DeepEqual(left, right)
-    default:
-      return fmt.Errorf("Unsupported operation: %v", event.Operator.OperatorVariant)
-    }
-  } else {
-    // @TODO: Where are the implementations for these for builtin stuff (numbers mainly)
-    switch event.Operator.OperatorVariant.(type) {
-    case OperatorLt:
-      answer = leftCmp.Lt(rightCmp)
-    case OperatorLeq:
-      answer = leftCmp.Lt(rightCmp) || leftCmp.Equal(rightCmp)
-    case OperatorGt:
-      answer = rightCmp.Lt(leftCmp)
-    case OperatorGeq:
-      answer = !leftCmp.Lt(rightCmp)
-    case OperatorEq:
-      answer = leftCmp.Equal(rightCmp)
-    case OperatorNeq:
-      answer = !leftCmp.Equal(rightCmp)
-    default:
-      return fmt.Errorf("Unsupported operation: %v", event.Operator.OperatorVariant)
-    }
-  }
+	if !leftOk || !rightOk {
+		switch event.Operator.OperatorVariant.(type) {
+		case OperatorEq:
+			answer = reflect.DeepEqual(left, right)
+		default:
+			return fmt.Errorf("Unsupported operation: %v", event.Operator.OperatorVariant)
+		}
+	} else {
+		// @TODO: Where are the implementations for these for builtin stuff (numbers mainly)
+		switch event.Operator.OperatorVariant.(type) {
+		case OperatorLt:
+			answer = leftCmp.Lt(rightCmp)
+		case OperatorLeq:
+			answer = leftCmp.Lt(rightCmp) || leftCmp.Equal(rightCmp)
+		case OperatorGt:
+			answer = rightCmp.Lt(leftCmp)
+		case OperatorGeq:
+			answer = !leftCmp.Lt(rightCmp)
+		case OperatorEq:
+			answer = leftCmp.Equal(rightCmp)
+		case OperatorNeq:
+			answer = !leftCmp.Equal(rightCmp)
+		default:
+			return fmt.Errorf("Unsupported operation: %v", event.Operator.OperatorVariant)
+		}
+	}
 	return q.ffiQuery.QuestionResult(event.CallId, answer)
 }
 

--- a/languages/go/query.go
+++ b/languages/go/query.go
@@ -249,26 +249,38 @@ func (q Query) handleExternalOp(event types.QueryEventExternalOp) error {
 	if err != nil {
 		return err
 	}
+
 	var answer bool
-	leftCmp := left.(interfaces.Comparer)
-	rightCmp := right.(interfaces.Comparer)
-	// @TODO: Where are the implementations for these for builtin stuff (numbers mainly)
-	switch event.Operator.OperatorVariant.(type) {
-	case OperatorLt:
-		answer = leftCmp.Lt(rightCmp)
-	case OperatorLeq:
-		answer = leftCmp.Lt(rightCmp) || leftCmp.Equal(rightCmp)
-	case OperatorGt:
-		answer = rightCmp.Lt(leftCmp)
-	case OperatorGeq:
-		answer = !leftCmp.Lt(rightCmp)
-	case OperatorEq:
-		answer = leftCmp.Equal(rightCmp)
-	case OperatorNeq:
-		answer = !leftCmp.Equal(rightCmp)
-	default:
-		return fmt.Errorf("Unsupported operation: %v", event.Operator.OperatorVariant)
-	}
+
+	leftCmp, leftOk := left.(interfaces.Comparer)
+	rightCmp, rightOk := right.(interfaces.Comparer)
+
+  if !leftOk || !rightOk {
+    switch event.Operator.OperatorVariant.(type) {
+    case OperatorEq:
+      answer = left == right
+    default:
+      return fmt.Errorf("Unsupported operation: %v", event.Operator.OperatorVariant)
+    }
+  } else {
+    // @TODO: Where are the implementations for these for builtin stuff (numbers mainly)
+    switch event.Operator.OperatorVariant.(type) {
+    case OperatorLt:
+      answer = leftCmp.Lt(rightCmp)
+    case OperatorLeq:
+      answer = leftCmp.Lt(rightCmp) || leftCmp.Equal(rightCmp)
+    case OperatorGt:
+      answer = rightCmp.Lt(leftCmp)
+    case OperatorGeq:
+      answer = !leftCmp.Lt(rightCmp)
+    case OperatorEq:
+      answer = leftCmp.Equal(rightCmp)
+    case OperatorNeq:
+      answer = !leftCmp.Equal(rightCmp)
+    default:
+      return fmt.Errorf("Unsupported operation: %v", event.Operator.OperatorVariant)
+    }
+  }
 	return q.ffiQuery.QuestionResult(event.CallId, answer)
 }
 

--- a/languages/go/query.go
+++ b/languages/go/query.go
@@ -248,7 +248,7 @@ func (q Query) handleExternalOp(event types.QueryEventExternalOp) error {
   if !leftOk || !rightOk {
     switch event.Operator.OperatorVariant.(type) {
     case OperatorEq:
-      answer = left == right
+      answer = reflect.DeepEqual(left, right)
     default:
       return fmt.Errorf("Unsupported operation: %v", event.Operator.OperatorVariant)
     }

--- a/languages/go/query.go
+++ b/languages/go/query.go
@@ -240,38 +240,114 @@ func (q Query) handleExternalOp(event types.QueryEventExternalOp) error {
 		return err
 	}
 
-	var answer bool
-
 	leftCmp, leftOk := left.(interfaces.Comparer)
 	rightCmp, rightOk := right.(interfaces.Comparer)
+	op := event.Operator.OperatorVariant
 
-	if !leftOk || !rightOk {
-		switch event.Operator.OperatorVariant.(type) {
-		case OperatorEq:
-			answer = reflect.DeepEqual(left, right)
-		default:
-			return fmt.Errorf("Unsupported operation: %v", event.Operator.OperatorVariant)
+	// this logic is kind of weird!
+	// the reason why we need so many different comparison
+	// routines is that interfaces.Comparer only has methods
+	// to test for == and <, and x > y = !(x < y || x == y)
+	// is only true if x and y are actually ordered -- which
+	// we can't assume. for that reason different subsets of
+	// the 6 usual comparison operators are available in each
+	// case where x or y implements or doesn't implement
+	// interfaces.Comparer.
+
+	if leftOk {
+		if rightOk {
+			return q.handleCmpLR(event, leftCmp, op, rightCmp)
 		}
-	} else {
-		// @TODO: Where are the implementations for these for builtin stuff (numbers mainly)
-		switch event.Operator.OperatorVariant.(type) {
-		case OperatorLt:
-			answer = leftCmp.Lt(rightCmp)
-		case OperatorLeq:
-			answer = leftCmp.Lt(rightCmp) || leftCmp.Equal(rightCmp)
-		case OperatorGt:
-			answer = rightCmp.Lt(leftCmp)
-		case OperatorGeq:
-			answer = !leftCmp.Lt(rightCmp)
-		case OperatorEq:
-			answer = leftCmp.Equal(rightCmp)
-		case OperatorNeq:
-			answer = !leftCmp.Equal(rightCmp)
-		default:
-			return fmt.Errorf("Unsupported operation: %v", event.Operator.OperatorVariant)
-		}
+		return q.handleCmpL(event, leftCmp, op, right)
 	}
-	return q.ffiQuery.QuestionResult(event.CallId, answer)
+	if rightOk {
+		return q.handleCmpR(event, left, op, rightCmp)
+	}
+	return q.handleCmp(event, left, op, right)
+}
+
+func (q Query) answer(ev types.QueryEventExternalOp, b bool) error {
+	return q.ffiQuery.QuestionResult(ev.CallId, b)
+}
+
+func (q Query) handleCmpL(
+	ev types.QueryEventExternalOp,
+	l interfaces.Comparer,
+	op OperatorVariant,
+	r interface{}) error {
+
+	switch op.(type) {
+	case OperatorLt:
+		return q.answer(ev, l.Lt(r))
+	case OperatorLeq:
+		return q.answer(ev, l.Lt(r) || l.Equal(r))
+	case OperatorEq:
+		return q.answer(ev, l.Equal(r))
+	case OperatorNeq:
+		return q.answer(ev, !l.Equal(r))
+	default:
+		return fmt.Errorf("Unsupported operation: %v", op)
+	}
+}
+
+func (q Query) handleCmpR(
+	ev types.QueryEventExternalOp,
+	l interface{},
+	op OperatorVariant,
+	r interfaces.Comparer) error {
+
+	switch op.(type) {
+	case OperatorGt:
+		return q.answer(ev, r.Lt(l))
+	case OperatorGeq:
+		return q.answer(ev, r.Lt(l) || r.Equal(l))
+	case OperatorEq:
+		return q.answer(ev, r.Equal(l))
+	case OperatorNeq:
+		return q.answer(ev, !r.Equal(l))
+	default:
+		return fmt.Errorf("Unsupported operation: %v", op)
+	}
+}
+
+func (q Query) handleCmpLR(
+	ev types.QueryEventExternalOp,
+	l interfaces.Comparer,
+	op OperatorVariant,
+	r interfaces.Comparer) error {
+
+	switch op.(type) {
+	case OperatorLt:
+		return q.answer(ev, l.Lt(r))
+	case OperatorLeq:
+		return q.answer(ev, l.Lt(r) || l.Equal(r))
+	case OperatorGt:
+		return q.answer(ev, r.Lt(l))
+	case OperatorGeq:
+		return q.answer(ev, r.Lt(l) || r.Equal(l))
+	case OperatorEq:
+		return q.answer(ev, l.Equal(r))
+	case OperatorNeq:
+		return q.answer(ev, !l.Equal(r))
+	default:
+		return fmt.Errorf("Unsupported operation: %v", op)
+	}
+}
+
+func (q Query) handleCmp(
+	ev types.QueryEventExternalOp,
+	l interface{},
+	op OperatorVariant,
+	r interface{}) error {
+
+	switch op.(type) {
+	case OperatorEq:
+		return q.answer(ev, reflect.DeepEqual(l, r))
+	case OperatorNeq:
+		return q.answer(ev, !reflect.DeepEqual(l, r))
+	default:
+		return fmt.Errorf("Unsupported operation: %v", op)
+	}
 }
 
 func (q Query) handleNextExternal(event types.QueryEventNextExternal) error {

--- a/languages/go/tests/parity_test.go
+++ b/languages/go/tests/parity_test.go
@@ -174,11 +174,42 @@ func (u ImplementsEq) String() string {
 	return fmt.Sprintf("ImplementsEq { %v }", u.Val)
 }
 
-func (left ImplementsEq) Equal(right interfaces.Comparer) bool {
+func (left ImplementsEq) Equal(right interface{}) bool {
 	return left.Val == right.(ImplementsEq).Val
 }
-func (left ImplementsEq) Lt(right interfaces.Comparer) bool {
+
+func (left ImplementsEq) Lt(right interface{}) bool {
 	panic("unsupported")
+}
+
+type Least struct{}
+
+func (e Least) Equal(x interface{}) bool {
+	_, l := x.(Least)
+	return l
+}
+
+func (e Least) Lt(x interface{}) bool {
+	_, l := x.(Least)
+	return !l
+}
+
+func NewLeast() Least {
+	return Least{}
+}
+
+type NaNLike struct{}
+
+func (n NaNLike) Equal(x interface{}) bool {
+	return false
+}
+
+func (n NaNLike) Lt(x interface{}) bool {
+	return false
+}
+
+func NewNaNLike() NaNLike {
+	return NaNLike{}
 }
 
 type Comparable struct {
@@ -193,14 +224,14 @@ func (u Comparable) String() string {
 	return fmt.Sprintf("Comparable { %v }", u.Val)
 }
 
-func (a Comparable) Equal(b interfaces.Comparer) bool {
+func (a Comparable) Equal(b interface{}) bool {
 	if other, ok := b.(Comparable); ok {
 		return a.Val == other.Val
 	}
 	panic(fmt.Sprintf("cannot compare Comparable with %v", b))
 }
 
-func (a Comparable) Lt(b interfaces.Comparer) bool {
+func (a Comparable) Lt(b interface{}) bool {
 	if other, ok := b.(Comparable); ok {
 		return a.Val < other.Val
 	}
@@ -219,6 +250,8 @@ var CLASSES = map[string]reflect.Type{
 	"Animal":          reflect.TypeOf(Animal{}),
 	"ImplementsEq":    reflect.TypeOf(ImplementsEq{}),
 	"Comparable":      reflect.TypeOf(Comparable{}),
+	"Least":           reflect.TypeOf(Least{}),
+	"NaNLike":         reflect.TypeOf(NaNLike{}),
 }
 
 func setStructFields(instance reflect.Value, args []interface{}) error {
@@ -393,6 +426,8 @@ func (tc TestCase) setupTest(o oso.Oso, t *testing.T) error {
 	var CONSTRUCTORS = map[string]interface{}{
 		"UnitClass":    NewUnitClass,
 		"ValueFactory": NewValueFactory,
+		"Least":        NewLeast,
+		"NaNLike":      NewNaNLike,
 	}
 	for k, v := range CLASSES {
 		c := CONSTRUCTORS[k]

--- a/languages/go/types/polar_types.go
+++ b/languages/go/types/polar_types.go
@@ -1733,18 +1733,6 @@ type QueryEventExternalIsSubclass struct {
 
 func (QueryEventExternalIsSubclass) isQueryEvent() {}
 
-// QueryEventExternalUnify struct
-type QueryEventExternalUnify struct {
-	// CallId
-	CallId uint64 `json:"call_id"`
-	// LeftInstanceId
-	LeftInstanceId uint64 `json:"left_instance_id"`
-	// RightInstanceId
-	RightInstanceId uint64 `json:"right_instance_id"`
-}
-
-func (QueryEventExternalUnify) isQueryEvent() {}
-
 // QueryEventResult struct
 type QueryEventResult struct {
 	// Bindings
@@ -1897,17 +1885,6 @@ func (result *QueryEvent) UnmarshalJSON(b []byte) error {
 		*result = QueryEvent{variant}
 		return nil
 
-	case "ExternalUnify":
-		var variant QueryEventExternalUnify
-		if variantValue != nil {
-			err := json.Unmarshal(*variantValue, &variant)
-			if err != nil {
-				return err
-			}
-		}
-		*result = QueryEvent{variant}
-		return nil
-
 	case "Result":
 		var variant QueryEventResult
 		if variantValue != nil {
@@ -1987,11 +1964,6 @@ func (variant QueryEvent) MarshalJSON() ([]byte, error) {
 	case QueryEventExternalIsSubclass:
 		return json.Marshal(map[string]QueryEventExternalIsSubclass{
 			"ExternalIsSubclass": inner,
-		})
-
-	case QueryEventExternalUnify:
-		return json.Marshal(map[string]QueryEventExternalUnify{
-			"ExternalUnify": inner,
 		})
 
 	case QueryEventResult:

--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -167,6 +167,12 @@ public class Host implements Cloneable {
     return rightClass.isAssignableFrom(leftClass);
   }
 
+  public boolean operator(String op, List<Object> initargs) throws Exceptions.OsoException {
+    Object l = initargs.get(0), r = initargs.get(1);
+    if (op.equals("Eq")) return l == null ? l == r : l.equals(r);
+    throw new Exceptions.UnimplementedOperation(op);
+  }
+
   /** Check if two instances unify. */
   public boolean unify(long leftId, long rightId) throws Exceptions.UnregisteredInstanceError {
     Object left = getInstance(leftId);

--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -167,9 +167,12 @@ public class Host implements Cloneable {
     return rightClass.isAssignableFrom(leftClass);
   }
 
-  public boolean operator(String op, List<Object> initargs) throws Exceptions.OsoException {
-    Object l = initargs.get(0), r = initargs.get(1);
-    if (op.equals("Eq")) return l == null ? l == r : l.equals(r);
+  public boolean operator(String op, List<Object> args) throws Exceptions.OsoException {
+    Object left = args.get(0), right = args.get(1);
+    if (op.equals("Eq")) {
+      if (left == null) return left == right;
+      else return left.equals(right);
+    }
     throw new Exceptions.UnimplementedOperation(op);
   }
 

--- a/languages/java/oso/src/main/java/com/osohq/oso/Host.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Host.java
@@ -173,17 +173,6 @@ public class Host implements Cloneable {
     throw new Exceptions.UnimplementedOperation(op);
   }
 
-  /** Check if two instances unify. */
-  public boolean unify(long leftId, long rightId) throws Exceptions.UnregisteredInstanceError {
-    Object left = getInstance(leftId);
-    Object right = getInstance(rightId);
-    if (left == null) {
-      return right == null;
-    } else {
-      return left.equals(right);
-    }
-  }
-
   /** Convert Java Objects to Polar (JSON) terms. */
   public JSONObject toPolarTerm(Object value) throws Exceptions.OsoException {
     // Build Polar value

--- a/languages/java/oso/src/main/java/com/osohq/oso/Query.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Query.java
@@ -248,13 +248,6 @@ public class Query implements Enumeration<HashMap<String, Object>> {
                   : 0;
           ffiQuery.questionResult(callId, answer);
           break;
-        case "ExternalUnify":
-          long leftId = data.getLong("left_instance_id");
-          long rightId = data.getLong("right_instance_id");
-          callId = data.getLong("call_id");
-          answer = host.unify(leftId, rightId) ? 1 : 0;
-          ffiQuery.questionResult(callId, answer);
-          break;
         case "ExternalOp":
           callId = data.getLong("call_id");
           JSONArray args = data.getJSONArray("args");

--- a/languages/java/oso/src/main/java/com/osohq/oso/Query.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Query.java
@@ -255,6 +255,12 @@ public class Query implements Enumeration<HashMap<String, Object>> {
           answer = host.unify(leftId, rightId) ? 1 : 0;
           ffiQuery.questionResult(callId, answer);
           break;
+        case "ExternalOp":
+          callId = data.getLong("call_id");
+          JSONArray args = data.getJSONArray("args");
+          answer = host.operator(data.getString("operator"), host.polarListToJava(args)) ? 1 : 0;
+          ffiQuery.questionResult(callId, answer);
+          break;
         case "NextExternal":
           callId = data.getLong("call_id");
           JSONObject iterable = data.getJSONObject("iterable");
@@ -276,8 +282,6 @@ public class Query implements Enumeration<HashMap<String, Object>> {
             throw new Exceptions.PolarRuntimeException("Caused by: " + e.getMessage());
           }
           break;
-        case "ExternalOp":
-          throw new Exceptions.UnimplementedOperation("comparison operators");
         default:
           throw new Exceptions.PolarRuntimeException("Unhandled event type: " + kind);
       }

--- a/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
+++ b/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
@@ -416,11 +416,7 @@ public class PolarTest {
 
   @Test
   public void testExternalOp() throws Exception {
-    p.registerClass(Foo.class, "Foo");
-    assertThrows(
-        Exceptions.UnimplementedOperation.class,
-        () -> p.query("new Foo() == new Foo()"),
-        "Expected error.");
+    assertFalse(p.query("new String(\"foo\") == new String(\"foo\")").results().isEmpty());
   }
 
   /**** TEST PARSING ****/

--- a/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
+++ b/languages/java/oso/src/test/java/com/osohq/oso/PolarTest.java
@@ -401,6 +401,11 @@ public class PolarTest {
   }
 
   @Test
+  public void testExternalInternalUnify() throws Exception {
+    assertFalse(p.query("new String(\"foo\") = \"foo\"").results().isEmpty());
+  }
+
+  @Test
   public void testReturnListFromCall() throws Exception {
     p.loadStr("test(c: MyClass) if \"hello\" in c.myList();");
     MyClass c = new MyClass("test", 1);

--- a/languages/js/src/Host.ts
+++ b/languages/js/src/Host.ts
@@ -230,19 +230,6 @@ export class Host {
   }
 
   /**
-   * Check if two instances unify according to the [[`EqualityFn`]].
-   *
-   * @internal
-   */
-  async unify(leftId: number, rightId: number): Promise<boolean> {
-    let left = this.getInstance(leftId);
-    let right = this.getInstance(rightId);
-    left = left instanceof Promise ? await left : left;
-    right = right instanceof Promise ? await right : right;
-    return this.#equalityFn(left, right);
-  }
-
-  /**
    * Turn a JavaScript value into a Polar term that's ready to be sent to the
    * Polar VM.
    *

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -326,6 +326,14 @@ describe('conversions between JS + Polar values', () => {
     expect(result).toStrictEqual([map()]);
   });
 
+  test('unifies equivalent JS and Polar types', async () => {
+    const p = new Polar();
+    var result = await query(p, 'new Integer(1) = 1');
+    expect(result).toStrictEqual([map()]);
+    result = await query(p, 'new String("foo") = "foo"');
+    expect(result).toStrictEqual([map()]);
+  });
+
   test('handles Generator external call results', async () => {
     const actor = new Actor('sam');
     const p = new Polar();

--- a/languages/js/src/Query.ts
+++ b/languages/js/src/Query.ts
@@ -15,7 +15,6 @@ import type {
   ExternalIsa,
   ExternalIsSubspecializer,
   ExternalOp,
-  ExternalUnify,
   MakeExternal,
   NextExternal,
   PolarTerm,
@@ -229,12 +228,6 @@ export class Query {
           case QueryEventKind.ExternalIsa: {
             const { instance, tag, callId } = event.data as ExternalIsa;
             const answer = await this.#host.isa(instance, tag);
-            this.questionResult(answer, callId);
-            break;
-          }
-          case QueryEventKind.ExternalUnify: {
-            const { leftId, rightId, callId } = event.data as ExternalUnify;
-            const answer = await this.#host.unify(leftId, rightId);
             this.questionResult(answer, callId);
             break;
           }

--- a/languages/js/src/helpers.ts
+++ b/languages/js/src/helpers.ts
@@ -65,8 +65,6 @@ export function parseQueryEvent(event: string | obj): QueryEvent {
         return parseExternalIsSubspecializer(event['ExternalIsSubSpecializer']);
       case event['ExternalIsa'] !== undefined:
         return parseExternalIsa(event['ExternalIsa']);
-      case event['ExternalUnify'] !== undefined:
-        return parseExternalUnify(event['ExternalUnify']);
       case event['Debug'] !== undefined:
         return parseDebug(event['Debug']);
       case event['ExternalOp'] !== undefined:
@@ -244,29 +242,6 @@ function parseExternalOp({ call_id: callId, args, operator }: obj): QueryEvent {
       callId,
       operator,
     },
-  };
-}
-
-/**
- * Try to parse a JSON payload received from across the WebAssembly boundary as
- * an [[`ExternalUnify`]].
- *
- * @internal
- */
-function parseExternalUnify({
-  call_id: callId,
-  left_instance_id: leftId,
-  right_instance_id: rightId,
-}: obj): QueryEvent {
-  if (
-    !Number.isSafeInteger(callId) ||
-    !Number.isSafeInteger(leftId) ||
-    !Number.isSafeInteger(rightId)
-  )
-    throw new Error();
-  return {
-    kind: QueryEventKind.ExternalUnify,
-    data: { callId, leftId, rightId },
   };
 }
 

--- a/languages/js/src/types.ts
+++ b/languages/js/src/types.ts
@@ -446,19 +446,6 @@ export interface ExternalOp {
 }
 
 /**
- * The `ExternalUnify` [[`QueryEvent`]] is how Polar determines whether a pair
- * of values unify where at least one of the values is an application instance
- * (and, as such, Polar cannot determine unification internally).
- *
- * @internal
- */
-export interface ExternalUnify {
-  leftId: number;
-  rightId: number;
-  callId: number;
-}
-
-/**
  * The `Debug` [[`QueryEvent`]] is how Polar relays debugging messages to
  * JavaScript from the internal debugger attached to the Polar VM.
  *
@@ -480,7 +467,6 @@ export enum QueryEventKind {
   ExternalIsa,
   ExternalIsSubspecializer,
   ExternalOp,
-  ExternalUnify,
   MakeExternal,
   NextExternal,
   Result,
@@ -499,7 +485,6 @@ export interface QueryEvent {
     | ExternalIsa
     | ExternalIsSubspecializer
     | ExternalOp
-    | ExternalUnify
     | MakeExternal
     | NextExternal
     | Result;

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -76,7 +76,7 @@ class Host:
         cls = self.get_class(name)
         try:
             instance = cls(*args, **kwargs)
-        except TypeError as e:
+        except Exception as e:
             raise PolarRuntimeError(f"Error constructing instance of {name}: {e}")
         return self.cache_instance(instance, id)
 

--- a/languages/python/oso/polar/query.py
+++ b/languages/python/oso/polar/query.py
@@ -54,7 +54,6 @@ class Query:
                 "ExternalOp": self.handle_external_op,
                 "ExternalIsa": self.handle_external_isa,
                 "ExternalIsaWithPath": self.handle_external_isa_with_path,
-                "ExternalUnify": self.handle_external_unify,
                 "ExternalIsSubSpecializer": self.handle_external_is_subspecializer,
                 "ExternalIsSubclass": self.handle_external_is_subclass,
                 "NextExternal": self.handle_next_external,
@@ -140,12 +139,6 @@ class Query:
             # this error in core.
             self.ffi_query.application_error(str(e))
             self.ffi_query.question_result(data["call_id"], False)
-
-    def handle_external_unify(self, data):
-        left_instance_id = data["left_instance_id"]
-        right_instance_id = data["right_instance_id"]
-        answer = self.host.unify(left_instance_id, right_instance_id)
-        self.ffi_query.question_result(data["call_id"], answer)
 
     def handle_external_is_subspecializer(self, data):
         instance_id = data["instance_id"]

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -456,6 +456,12 @@ def test_return_list(polar, query):
     assert query(Predicate(name="allow", args=[User(), "join", "party"]))
 
 
+def test_host_native_unify(polar, query):
+    """Test that unification works across host and native data"""
+    assert query('new Integer(1) = 1')
+    assert query('new String("foo") = "foo"')
+    assert query('new List([1,2,3]) = [1,2,3]')
+
 def test_query(load_file, polar, query):
     """Test that queries work with variable arguments"""
 

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -462,6 +462,7 @@ def test_host_native_unify(polar, query):
     assert query('new String("foo") = "foo"')
     assert query('new List([1,2,3]) = [1,2,3]')
 
+
 def test_query(load_file, polar, query):
     """Test that queries work with variable arguments"""
 
@@ -473,6 +474,7 @@ def test_query(load_file, polar, query):
         {"a": 2},
         {"a": 3},
     ]
+
 
 def test_constructor(polar, qvar):
     """Test that class constructor is called correctly with constructor syntax."""
@@ -519,13 +521,14 @@ def test_constructor(polar, qvar):
     assert instance.bar == 3
     assert instance.baz == 4
 
+
 def test_constructor_error(polar, query):
     """Test that external instance constructor errors cause a PolarRuntimeError"""
     class Foo:
         def __init__(self):
             raise RuntimeError("o no")
     polar.register_class(Foo)
-    with pytest.raises(exceptions.PolarRuntimeError) as e:
+    with pytest.raises(exceptions.PolarRuntimeError):
         query("x = new Foo()")
 
 

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -458,9 +458,9 @@ def test_return_list(polar, query):
 
 def test_host_native_unify(polar, query):
     """Test that unification works across host and native data"""
-    assert query('new Integer(1) = 1')
+    assert query("new Integer(1) = 1")
     assert query('new String("foo") = "foo"')
-    assert query('new List([1,2,3]) = [1,2,3]')
+    assert query("new List([1,2,3]) = [1,2,3]")
 
 
 def test_query(load_file, polar, query):
@@ -524,9 +524,11 @@ def test_constructor(polar, qvar):
 
 def test_constructor_error(polar, query):
     """Test that external instance constructor errors cause a PolarRuntimeError"""
+
     class Foo:
         def __init__(self):
             raise RuntimeError("o no")
+
     polar.register_class(Foo)
     with pytest.raises(exceptions.PolarRuntimeError):
         query("x = new Foo()")

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -468,7 +468,6 @@ def test_query(load_file, polar, query):
         {"a": 3},
     ]
 
-
 def test_constructor(polar, qvar):
     """Test that class constructor is called correctly with constructor syntax."""
 
@@ -513,6 +512,15 @@ def test_constructor(polar, qvar):
     assert instance.b == 2
     assert instance.bar == 3
     assert instance.baz == 4
+
+def test_constructor_error(polar, query):
+    """Test that external instance constructor errors cause a PolarRuntimeError"""
+    class Foo:
+        def __init__(self):
+            raise RuntimeError("o no")
+    polar.register_class(Foo)
+    with pytest.raises(exceptions.PolarRuntimeError) as e:
+        query("x = new Foo()")
 
 
 def test_instance_cache(polar, qeval, query):

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -202,17 +202,6 @@ module Oso
         instance.is_a? cls
       end
 
-      # Check if two instances unify
-      #
-      # @param left_instance_id [Integer]
-      # @param right_instance_id [Integer]
-      # @return [Boolean]
-      def unify?(left_instance_id, right_instance_id)
-        left_instance = get_instance(left_instance_id)
-        right_instance = get_instance(right_instance_id)
-        left_instance == right_instance
-      end
-
       # Turn a Ruby value into a Polar term that's ready to be sent across the
       # FFI boundary.
       #

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -169,9 +169,11 @@ module Oso
         raise PolarRuntimeError, "Unsupported external operation '#{l.class} #{operation} #{r.class}'" if op.nil?
 
         l, r = args
-        l.__send__ op, r
-      rescue StandardError
-        raise PolarRuntimeError, "External operation '#{l.class} #{operation} #{r.class}' failed."
+        begin
+          l.__send__ op, r
+        rescue StandardError
+          raise PolarRuntimeError, "External operation '#{l.class} #{operation} #{r.class}' failed."
+        end
       end
 
       # Check if the left class is more specific than the right class

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -165,14 +165,14 @@ module Oso
       # @raise [PolarRuntimeError] if operation fails or is unsupported.
       # @return [Boolean]
       def operator(operation, args)
+        left, right = args
         op = OPS[operation]
-        raise PolarRuntimeError, "Unsupported external operation '#{l.class} #{operation} #{r.class}'" if op.nil?
+        raise PolarRuntimeError, "Unsupported external operation '#{left.class} #{operation} #{right.class}'" if op.nil?
 
-        l, r = args
         begin
-          l.__send__ op, r
+          left.__send__ op, right
         rescue StandardError
-          raise PolarRuntimeError, "External operation '#{l.class} #{operation} #{r.class}' failed."
+          raise PolarRuntimeError, "External operation '#{left.class} #{operation} #{right.class}' failed."
         end
       end
 

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -149,32 +149,29 @@ module Oso
         raise PolarRuntimeError, "Error constructing instance of #{cls_name}: #{e}"
       end
 
+      OPS = {
+        'Lt' => :<,
+        'Gt' => :>,
+        'Eq' => :==,
+        'Geq' => :>=,
+        'Leq' => :<=,
+        'Neq' => :!=
+      }.freeze
+
       # Compare two values
       #
       # @param op [String] operation to perform.
       # @param args [Array<Object>] left and right args to operation.
       # @raise [PolarRuntimeError] if operation fails or is unsupported.
       # @return [Boolean]
-      def operator(op, args)
+      def operator(operation, args)
+        op = OPS[operation]
+        raise PolarRuntimeError, "Unsupported external operation '#{l.class} #{operation} #{r.class}'" if op.nil?
+
         l, r = args
-        case op
-        when 'Lt'
-          l < r
-        when 'Gt'
-          l > r
-        when 'Eq'
-          l == r
-        when 'Leq'
-          l <= r
-        when 'Geq'
-          l >= r
-        when 'Neq'
-          l != r
-        else
-          raise PolarRuntimeError, "Unsupported external operation '#{l.class} #{op} #{r.class}'"
-        end
-      rescue
-        raise PolarRuntimeError, "External operation '#{l.class} #{op} #{r.class}' failed."
+        l.__send__ op, r
+      rescue StandardError
+        raise PolarRuntimeError, "External operation '#{l.class} #{operation} #{r.class}' failed."
       end
 
       # Check if the left class is more specific than the right class

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -149,6 +149,34 @@ module Oso
         raise PolarRuntimeError, "Error constructing instance of #{cls_name}: #{e}"
       end
 
+      # Compare two values
+      #
+      # @param op [String] operation to perform.
+      # @param args [Array<Object>] left and right args to operation.
+      # @raise [PolarRuntimeError] if operation fails or is unsupported.
+      # @return [Boolean]
+      def operator(op, args)
+        l, r = args
+        case op
+        when 'Lt'
+          l < r
+        when 'Gt'
+          l > r
+        when 'Eq'
+          l == r
+        when 'Leq'
+          l <= r
+        when 'Geq'
+          l >= r
+        when 'Neq'
+          l != r
+        else
+          raise PolarRuntimeError, "Unsupported external operation '#{l.class} #{op} #{r.class}'"
+        end
+      rescue
+        raise PolarRuntimeError, "External operation '#{l.class} #{op} #{r.class}' failed."
+      end
+
       # Check if the left class is more specific than the right class
       # with respect to the given instance.
       #

--- a/languages/ruby/lib/oso/polar/query.rb
+++ b/languages/ruby/lib/oso/polar/query.rb
@@ -162,7 +162,11 @@ module Oso
             command = JSON.dump(host.to_polar(input))
             ffi_query.debug_command(command)
           when 'ExternalOp'
-            raise UnimplementedOperationError, 'comparison operators'
+            op = event.data['operator']
+            args = event.data['args'].map(&host.method(:to_ruby))
+            answer = host.operator(op, args)
+            question_result(answer, call_id: event.data['call_id'])
+            #raise UnimplementedOperationError, 'comparison operators'
           when 'NextExternal'
             call_id = event.data['call_id']
             iterable = event.data['iterable']

--- a/languages/ruby/lib/oso/polar/query.rb
+++ b/languages/ruby/lib/oso/polar/query.rb
@@ -146,11 +146,6 @@ module Oso
             class_tag = event.data['class_tag']
             answer = host.isa?(instance, class_tag: class_tag)
             question_result(answer, call_id: event.data['call_id'])
-          when 'ExternalUnify'
-            left_instance_id = event.data['left_instance_id']
-            right_instance_id = event.data['right_instance_id']
-            answer = host.unify?(left_instance_id, right_instance_id)
-            question_result(answer, call_id: event.data['call_id'])
           when 'Debug'
             puts event.data['message'] if event.data['message']
             print 'debug> '

--- a/languages/ruby/lib/oso/polar/query.rb
+++ b/languages/ruby/lib/oso/polar/query.rb
@@ -161,7 +161,6 @@ module Oso
             args = event.data['args'].map(&host.method(:to_ruby))
             answer = host.operator(op, args)
             question_result(answer, call_id: event.data['call_id'])
-            #raise UnimplementedOperationError, 'comparison operators'
           when 'NextExternal'
             call_id = event.data['call_id']
             iterable = event.data['iterable']

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -533,6 +533,11 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
         expect(query(subject, 'nope()')).to eq([])
       end
 
+      it 'can unify instances with native types' do
+        expect(query(subject, 'new String("foo") = "foo"')).to eq([{}])
+        expect(query(subject, 'new List() = []')).to eq([{}])
+      end
+
       it 'can specialize on dict fields' do
         subject.load_str <<~POLAR
           what_is(_: {genus: "canis"}, r) if r = "canine";

--- a/languages/ruby/spec/oso/polar/polar_spec.rb
+++ b/languages/ruby/spec/oso/polar/polar_spec.rb
@@ -755,12 +755,8 @@ RSpec.describe Oso::Polar::Polar do # rubocop:disable Metrics/BlockLength
     expect(query(subject, 'neg_inf < inf')).to eq([{}])
   end
 
-  it 'fails gracefully on ExternalOp events' do
-    stub_const('Foo', Class.new)
-    subject.register_class(Foo)
-    expect { query(subject, 'new Foo() == new Foo()') }.to raise_error do |e|
-      expect(e).to be_an Oso::Polar::UnimplementedOperationError
-    end
+  it 'handles ExternalOp events' do
+    expect(query(subject, 'new String("foo") == new String("foo")')).to eq [{}]
   end
 
   it 'fails when receiving an expression type' do

--- a/languages/rust/oso/src/builtins.rs
+++ b/languages/rust/oso/src/builtins.rs
@@ -6,29 +6,39 @@ use std::collections::HashMap;
 use crate::{Class, ClassBuilder};
 
 fn boolean() -> ClassBuilder<bool> {
-    ClassBuilder::<bool>::with_default().name("Boolean")
+    ClassBuilder::<bool>::with_default()
+        .with_equality_check()
+        .name("Boolean")
 }
 
 fn integer() -> ClassBuilder<i64> {
-    ClassBuilder::<i64>::with_default().name("Integer")
+    ClassBuilder::<i64>::with_default()
+        .with_equality_check()
+        .name("Integer")
 }
 
 fn float() -> ClassBuilder<f64> {
-    ClassBuilder::<f64>::with_default().name("Float")
+    ClassBuilder::<f64>::with_default()
+        .with_equality_check()
+        .name("Float")
 }
 
 fn list() -> ClassBuilder<Vec<PolarValue>> {
-    ClassBuilder::<Vec<PolarValue>>::with_default().name("List")
+    ClassBuilder::<Vec<PolarValue>>::with_default()
+        .with_equality_check()
+        .name("List")
 }
 
 fn dictionary() -> ClassBuilder<HashMap<String, PolarValue>> {
-    ClassBuilder::<HashMap<String, PolarValue>>::with_default().name("Dictionary")
+    ClassBuilder::<HashMap<String, PolarValue>>::with_default()
+        .with_equality_check()
+        .name("Dictionary")
 }
 
 fn option() -> ClassBuilder<Option<PolarValue>> {
     ClassBuilder::<Option<PolarValue>>::with_default()
-        .name("Option")
         .with_equality_check()
+        .name("Option")
         .add_method("unwrap", |v: &Option<PolarValue>| v.clone().unwrap())
         .add_method("is_none", Option::is_none)
         .add_method("is_some", Option::is_some)
@@ -37,6 +47,7 @@ fn option() -> ClassBuilder<Option<PolarValue>> {
 
 fn string() -> ClassBuilder<String> {
     ClassBuilder::<String>::with_default()
+        .with_equality_check()
         .name("String")
         .add_method("len", |s: &String| s.len() as i64)
         .add_method("is_empty", String::is_empty)

--- a/languages/rust/oso/src/host/mod.rs
+++ b/languages/rust/oso/src/host/mod.rs
@@ -157,14 +157,6 @@ impl Host {
         Ok(())
     }
 
-    pub fn unify(&self, left: u64, right: u64) -> crate::Result<bool> {
-        tracing::trace!("unify {:?}, {:?}", left, right);
-
-        let left = self.get_instance(left).unwrap();
-        let right = self.get_instance(right).unwrap();
-        left.equals(right, &self)
-    }
-
     pub fn isa(&self, value: PolarValue, class_tag: &str) -> crate::Result<bool> {
         let res = match value {
             PolarValue::Instance(instance) => {

--- a/languages/rust/oso/src/host/mod.rs
+++ b/languages/rust/oso/src/host/mod.rs
@@ -13,9 +13,9 @@ mod value;
 
 pub use class::{Class, ClassBuilder, Instance};
 pub use from_polar::{FromPolar, FromPolarList};
+use polar_core::terms::Operator;
 pub use to_polar::{PolarIterator, ToPolar, ToPolarList};
 pub use value::PolarValue;
-use polar_core::terms::Operator;
 
 lazy_static::lazy_static! {
     /// Map of classes that have been globally registered
@@ -179,18 +179,12 @@ impl Host {
         false
     }
 
-    pub fn operator(
-        &self,
-        op: Operator,
-        args: [class::Instance; 2],
-    ) -> crate::Result<bool> {
+    pub fn operator(&self, op: Operator, args: [class::Instance; 2]) -> crate::Result<bool> {
         match op {
-            Operator::Eq =>
-                args[0].equals(&args[1], self),
-            _ =>
-                Err(OsoError::UnimplementedOperation {
-                    operation: String::from("comparison operators"),
-                })
+            Operator::Eq => args[0].equals(&args[1], self),
+            _ => Err(OsoError::UnimplementedOperation {
+                operation: String::from("comparison operators"),
+            }),
         }
         // Operators are not supported
         // TODO (dhatch): Implement.

--- a/languages/rust/oso/src/host/mod.rs
+++ b/languages/rust/oso/src/host/mod.rs
@@ -15,6 +15,7 @@ pub use class::{Class, ClassBuilder, Instance};
 pub use from_polar::{FromPolar, FromPolarList};
 pub use to_polar::{PolarIterator, ToPolar, ToPolarList};
 pub use value::PolarValue;
+use polar_core::terms::Operator;
 
 lazy_static::lazy_static! {
     /// Map of classes that have been globally registered
@@ -188,13 +189,18 @@ impl Host {
 
     pub fn operator(
         &self,
-        _op: polar_core::terms::Operator,
-        _args: [class::Instance; 2],
+        op: Operator,
+        args: [class::Instance; 2],
     ) -> crate::Result<bool> {
+        match op {
+            Operator::Eq =>
+                args[0].equals(&args[1], self),
+            _ =>
+                Err(OsoError::UnimplementedOperation {
+                    operation: String::from("comparison operators"),
+                })
+        }
         // Operators are not supported
         // TODO (dhatch): Implement.
-        Err(OsoError::UnimplementedOperation {
-            operation: String::from("comparison operators"),
-        })
     }
 }

--- a/languages/rust/oso/src/query.rs
+++ b/languages/rust/oso/src/query.rs
@@ -75,11 +75,6 @@ impl Query {
                     instance,
                     class_tag,
                 } => self.handle_external_isa(call_id, instance, class_tag),
-                QueryEvent::ExternalUnify {
-                    call_id,
-                    left_instance_id,
-                    right_instance_id,
-                } => self.handle_external_unify(call_id, left_instance_id, right_instance_id),
                 QueryEvent::ExternalIsSubSpecializer {
                     call_id,
                     instance_id,
@@ -233,17 +228,6 @@ impl Query {
         let res = self
             .host
             .isa(PolarValue::from_term(&instance, &self.host)?, &class_tag.0)?;
-        self.question_result(call_id, res)?;
-        Ok(())
-    }
-
-    fn handle_external_unify(
-        &mut self,
-        call_id: u64,
-        left_instance_id: u64,
-        right_instance_id: u64,
-    ) -> crate::Result<()> {
-        let res = self.host.unify(left_instance_id, right_instance_id)?;
         self.question_result(call_id, res)?;
         Ok(())
     }

--- a/languages/rust/oso/tests/test_polar_rust.rs
+++ b/languages/rust/oso/tests/test_polar_rust.rs
@@ -511,6 +511,19 @@ fn test_results_and_options() {
     assert!(results.is_empty());
 }
 
+// this functionality isn't very useful for rust as long as we
+// only support nullary constructors ...
+#[test]
+fn test_unify_external_internal() {
+    let mut test = OsoTest::new();
+    test.qeval("new List() = []");
+    test.qeval("new Dictionary() = {}");
+    test.qeval("new String() = \"\"");
+    test.qeval("new Integer() = 0");
+    test.qeval("new Float() = 0.0");
+    test.qeval("new Boolean() = false");
+}
+
 // TODO: dhatch see if there is a relevant test to port.
 #[test]
 fn test_unify_externals() {

--- a/polar-core/src/events.rs
+++ b/polar-core/src/events.rs
@@ -80,13 +80,6 @@ pub enum QueryEvent {
         right_class_tag: Symbol,
     },
 
-    /// Unifies two external instances.
-    ExternalUnify {
-        call_id: u64,
-        left_instance_id: u64,
-        right_instance_id: u64,
-    },
-
     Result {
         bindings: Bindings,
         trace: Option<TraceResult>,

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2309,6 +2309,15 @@ impl PolarVirtualMachine {
                 }
             }
 
+            (
+                Value::ExternalInstance(ExternalInstance {
+                    instance_id: left, ..
+                }),
+                Value::ExternalInstance(ExternalInstance {
+                    instance_id: right, ..
+                }),
+            ) if left == right => (),
+
             // If either operand is an external instance, let the host
             // compare them for equality. This handles unification between
             // "equivalent" host and native types transparently.

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -1325,7 +1325,6 @@ impl PolarVirtualMachine {
         })
     }
 
-
     pub fn make_external(&self, constructor: &Term, instance_id: u64) -> QueryEvent {
         QueryEvent::MakeExternal {
             instance_id,
@@ -2260,7 +2259,6 @@ impl PolarVirtualMachine {
                 }
             }
 
-
             // Unify lists by recursively unifying their elements.
             (Value::List(l), Value::List(r)) => self.unify_lists(l, r, |(l, r)| Goal::Unify {
                 left: l.clone(),
@@ -2314,13 +2312,13 @@ impl PolarVirtualMachine {
             // If either operand is an external instance, let the host
             // compare them for equality. This handles unification between
             // "equivalent" host and native types transparently.
-            (Value::ExternalInstance(_),_) | (_, Value::ExternalInstance(_)) => {
+            (Value::ExternalInstance(_), _) | (_, Value::ExternalInstance(_)) => {
                 self.push_goal(Goal::Query {
                     term: Term::new_temporary(Value::Expression(Operation {
-                            operator: Operator:: Eq,
-                            args: vec![left.clone(), right.clone()]
-                        })),
-                    })?
+                        operator: Operator::Eq,
+                        args: vec![left.clone(), right.clone()],
+                    })),
+                })?
             }
 
             // Anything else fails.
@@ -3580,7 +3578,9 @@ mod tests {
                     vm.external_question_result(call_id, class_tag.0 == "a")
                         .unwrap()
                 }
-                QueryEvent::ExternalOp { .. } | QueryEvent::ExternalIsSubSpecializer { .. } | QueryEvent::Result { .. } => (),
+                QueryEvent::ExternalOp { .. }
+                | QueryEvent::ExternalIsSubSpecializer { .. }
+                | QueryEvent::Result { .. } => (),
                 e => panic!("Unexpected event: {:?}", e),
             }
         }
@@ -3664,9 +3664,7 @@ mod tests {
                     operator: Operator::Eq,
                     call_id,
                     ..
-                } => {
-                    vm.external_question_result(call_id, true).unwrap()
-                }
+                } => vm.external_question_result(call_id, true).unwrap(),
 
                 QueryEvent::ExternalIsa { call_id, .. } => {
                     // For this test, anything is anything.
@@ -3747,8 +3745,9 @@ mod tests {
             vm.push_goal(Goal::Noop).unwrap();
             vm.push_goal(Goal::MakeExternal {
                 constructor: Term::new_temporary(Value::Boolean(true)),
-                instance_id: 1
-            }).unwrap();
+                instance_id: 1,
+            })
+            .unwrap();
             let result = vm.run(None);
             match result {
                 Ok(event) => assert!(matches!(event, QueryEvent::MakeExternal { .. })),

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -127,6 +127,14 @@ where
             QueryEvent::Debug { ref message } => {
                 query.debug_command(&debug_handler(message)).unwrap();
             }
+            QueryEvent::ExternalOp {
+                operator: Operator::Eq,
+                call_id,
+                args,
+                ..
+            } => query
+                .question_result(call_id, args[0] == args[1])
+                .unwrap(),
             _ => {}
         }
     }

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -132,9 +132,7 @@ where
                 call_id,
                 args,
                 ..
-            } => query
-                .question_result(call_id, args[0] == args[1])
-                .unwrap(),
+            } => query.question_result(call_id, args[0] == args[1]).unwrap(),
             _ => {}
         }
     }

--- a/test/spec/operators.yml
+++ b/test/spec/operators.yml
@@ -6,6 +6,10 @@ cases:
   - query: ImplementsEq.New(1) = ImplementsEq.New(1)
   - query: ImplementsEq.New(1) == ImplementsEq.New(1)
   - query: not ImplementsEq.New(1) = ImplementsEq.New(2)
+  - query: new Least() = new Least()
+  - query: new Least() == new Least()
+  - query: not new NaNLike() == new NaNLike()
+  - query: new NaNLike() != new NaNLike()
 
   # lt/gt
   - query: Comparable.New(1) < Comparable.New(2)
@@ -18,3 +22,8 @@ cases:
   - query: Comparable.New(2) >= Comparable.New(1)
   - query: Comparable.New(1) >= Comparable.New(1)
   - query: Comparable.New(1) <= Comparable.New(1)
+  - query: new Least() < "anything"
+  - query: "everything" > new Least()
+  - query: not new Least() < new Least()
+  - query: not new NaNLike() <= new Comparable.New(0)
+  - query: not new NaNLike() >= new Comparable.New(0)


### PR DESCRIPTION
This allows unification between host and native data of "equivalent" types, so queries like

```polar
new Integer(1) = 1
```
can succeed.

The specific example above will only work in Python, since different host languages have different rules about applying using the "new" operator built-in types, for example Ruby and Java can't create integers this way. But where creating a new instance of a type is supported by the host language, they should now be transparently unifiable with native data.

This PR also (at least partially) implements comparison operations for all host languages, and improves Python error handling when creating external instances.

PR checklist:

<!-- Delete if no entry is required. -->
- [x] Added changelog entry.
- [x] Add appropriate tests for languages other than Python.
