### PR TITLE
Debugger: break on error

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -29,17 +29,35 @@ Link to [migration guide]().
 
 #### New features
 
-##### Roles in Rust
-
-The Rust library now has
-[built-in support for Role-Based Access Control (RBAC) policies](/guides/roles),
-which you can turn on with `.enable_roles()`.
-
 ##### Feature 1
 
 Summary of user-facing changes.
 
 Link to [relevant documentation section]().
+
+#### Other bugs & improvements
+
+- Bulleted list
+- Of smaller improvements
+- Potentially with doc [links]().
+
+## `oso` NEW_VERSION
+
+### Core
+
+#### Other bugs & improvements
+
+- The debugger can now break on runtime errors.
+
+### Rust
+
+#### New features
+
+##### Roles in Rust
+
+The Rust library now has
+[built-in support for Role-Based Access Control (RBAC) policies](/guides/roles),
+which you can turn on with `.enable_roles()`.
 
 ## `flask-oso` NEW_VERSION
 
@@ -48,9 +66,3 @@ Link to [relevant documentation section]().
 - Thanks to [`@arusahni`](https://github.com/arusahni) for surfacing and
   documenting a potential gotcha when using `flask-oso` with other Flask
   libraries that rely on `LocalProxy` objects.
-
-#### Other bugs & improvements
-
-- Bulleted list
-- Of smaller improvements
-- Potentially with doc [links]().

--- a/polar-core/src/debugger.rs
+++ b/polar-core/src/debugger.rs
@@ -124,7 +124,7 @@ impl Debugger {
             }
             (Step::Error, DebugEvent::Error(error)) => {
                 self.break_msg(vm).map(|message| Goal::Debug {
-                    message: format!("{}\nCAUGHT ERROR: {}\n", message, error.to_string()),
+                    message: format!("{}\nERROR: {}\n", message, error.to_string()),
                 })
             }
             _ => None,

--- a/polar-core/src/debugger.rs
+++ b/polar-core/src/debugger.rs
@@ -27,7 +27,7 @@ impl PolarVirtualMachine {
     pub fn maybe_break(&mut self, event: DebugEvent) -> PolarResult<()> {
         let maybe_goal = self.debugger.maybe_break(event, self);
         if let Some(goal) = maybe_goal {
-            self.push_goal(goal.clone())?;
+            self.push_goal(goal)?;
         }
         Ok(())
     }
@@ -123,7 +123,7 @@ impl Debugger {
                 }
                 (Step::Error, DebugEvent::Error(e)) => match self.break_query(vm) {
                     Some(Goal::Debug { message }) => Some(Goal::Debug {
-                        message: format!("{}\ncaught error: {}\n\n", message, e.to_string()),
+                        message: format!("{}\nERROR: {}\n", message, e.to_string()),
                     }),
                     x => x,
                 },

--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::bindings::{BindingManager, Bsp, FollowerId, VariableState};
 use crate::counter::Counter;
-use crate::error::PolarResult;
+use crate::error::{PolarError, PolarResult};
 use crate::events::QueryEvent;
 use crate::formatting::ToPolarString;
 use crate::kb::Bindings;
@@ -251,5 +251,9 @@ impl Runnable for Inverter {
 
     fn clone_runnable(&self) -> Box<dyn Runnable> {
         Box::new(self.clone())
+    }
+
+    fn handle_error(&mut self, error: PolarError) -> PolarResult<QueryEvent> {
+        self.vm.handle_error(error)
     }
 }

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -48,7 +48,16 @@ impl Query {
     ///    an answer to Runnable A.
     pub fn next_event(&mut self) -> PolarResult<QueryEvent> {
         let mut counter = self.vm.id_counter();
-        match self.top_runnable().run(Some(&mut counter))? {
+        let qe = match self.top_runnable().run(Some(&mut counter)) {
+            Ok(e) => e,
+            Err(e) => self.top_runnable().handle_error(e)?,
+        };
+        self.recv_event(qe)
+    }
+
+    fn recv_event(&mut self, qe: QueryEvent) -> PolarResult<QueryEvent> {
+        match qe {
+            QueryEvent::None => self.next_event(),
             QueryEvent::Run { runnable, call_id } => {
                 self.push_runnable(runnable, call_id);
                 self.next_event()

--- a/polar-core/src/runnable.rs
+++ b/polar-core/src/runnable.rs
@@ -1,5 +1,5 @@
 use crate::counter::Counter;
-use crate::error::{OperationalError, PolarResult};
+use crate::error::{OperationalError, PolarError, PolarResult};
 use crate::events::QueryEvent;
 use crate::terms::Term;
 
@@ -24,6 +24,10 @@ pub trait Runnable {
 
     fn debug_command(&mut self, _command: &str) -> PolarResult<()> {
         Err(OperationalError::InvalidState("Unexpected debug command".to_string()).into())
+    }
+
+    fn handle_error(&mut self, err: PolarError) -> PolarResult<QueryEvent> {
+        Err(err)
     }
 
     // TODO Alternative?: Goal::Run takes a Runnable constructor function.

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1204,7 +1204,7 @@ fn test_debug_break_on_error() -> TestResult {
                     001: foo() if debug() and 1 < "2" and 1 < 2;
                                               ^
 
-                    ERROR: Not supported: 1 < "2"
+                    CAUGHT ERROR: Not supported: 1 < "2"
                     "#
                 );
                 assert_eq!(s, expected);

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1262,7 +1262,6 @@ fn test_debug_break_on_error() -> TestResult {
     Ok(())
 }
 
-
 #[test]
 fn test_debug_temp_var() -> TestResult {
     let p = Polar::new();

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1238,7 +1238,7 @@ fn test_debug_break_on_error() -> TestResult {
                     001: foo() if debug() and 1 < "2" and 1 < 2;
                                               ^
 
-                    CAUGHT ERROR: Not supported: 1 < "2"
+                    ERROR: Not supported: 1 < "2"
                     "#
                 );
                 assert_eq!(s, expected);


### PR DESCRIPTION
Just what it says! Continuing past an error isn't possible, but the stack/bindings at the point where the error is thrown can be examined.

<img width="489" alt="Screen Shot 2021-07-23 at 6 15 47 PM" src="https://user-images.githubusercontent.com/1579800/126846514-6e5b88aa-5f53-44d0-ac7b-02b23ea178b1.png">

PR checklist:

<!-- Delete if no entry is required. -->
- [x] Added changelog entry.
