### PR TITLE
Debugger: update docs

### DIFF
--- a/docs/content/any/reference/tooling/debugger.md
+++ b/docs/content/any/reference/tooling/debugger.md
@@ -426,9 +426,9 @@ debug> line
 001: a() if _x = y and y = z and z = 3 and debug();
                                  ^
 debug> var
-_y_2, _x_1, _z_3
+_y_2, __x_1, _z_3
 debug> var _x z
-_x@_x_1 = 3
+_x@__x_1 = 3
 z@_z_3 = 3
 debug> var foo
 foo = <unbound>

--- a/docs/content/any/reference/tooling/debugger.md
+++ b/docs/content/any/reference/tooling/debugger.md
@@ -56,6 +56,7 @@ s[tep] | into           Step to the next query (will step into rules).
 n[ext] | over           Step to the next query at the same level of the query stack (will not step into rules).
 o[ut]                   Step out of the current query stack level to the next query in the level above.
 g[oal]                  Step to the next goal of the Polar VM.
+e[rror]                 Step to the next error.
 l[ine] [<n>]            Print the current line and <n> lines of context.
 query [<i>]             Print the current query or the query at level <i> in the query stack.
 stack | trace           Print the current query stack.
@@ -237,6 +238,64 @@ True
 True
 ```
 
+#### `g[oal]`
+
+Step the the next goal of the Polar VM. A "goal" is an internal object used to direct
+the state of the Polar interpreter, so this is mainly useful for debugging the VM itself.
+
+```
+query> debug() and 1 + 2 = 3
+QUERY: debug(), BINDINGS: {}
+
+001: debug() and 1 + 2 = 3
+     ^
+
+debug> goal
+PopQuery(debug())
+debug> g
+Query(1 + 2 = _op_5 and _op_5 = 3)
+debug> g
+TraceStackPush
+debug> c
+True
+```
+
+#### `e[rror]`
+
+Continue execution until an error condition is detected. The debugger will
+then pause the Polar VM at that point, allowing the stack and bindings to
+be examined.
+
+
+```
+query> x = 1 and y = "2" and debug() and x < y
+QUERY: debug(), BINDINGS: {}
+
+001: x = 1 and y = "2" and debug() and x < y
+                           ^
+
+debug> error
+QUERY: 1 < "2", BINDINGS: {}
+
+001: x = 1 and y = "2" and debug() and x < y
+                                       ^
+
+ERROR: Not supported: 1 < "2"
+
+debug> stack
+1: x = 1 and y = "2" and debug() and x < y
+  in query at line 1, column 1
+0: x < y
+  in query at line 1, column 35
+
+debug> var x y
+x = 1
+y = "2"
+debug> c
+UnsupportedError
+Not supported: 1 < "2"
+```
+
 ### Context
 
 The Polar file used in the following examples looks like this:
@@ -347,7 +406,7 @@ QUERY: b(_x_8), BINDINGS: {_x_8 = 1}
 The Polar file used in the following examples looks like this:
 
 ```
-a() if x = y and y = z and z = 3 and debug();
+a() if _x = y and y = z and z = 3 and debug();
 ```
 
 #### `var [<var> ...]`
@@ -357,20 +416,20 @@ print the value of those variables. If a provided variable does not exist in
 the current scope, print `<unbound>`.
 
 {{% callout "Note" "green" %}}
-  Due to temporaries used inside the engine, variables may not be available
-  under the names used in the Polar file. `var` with no argument will list
-  variable names in the current scope.
+  Due to temporaries used inside the engine, variables may not be bound
+  under the exact names used in the Polar file. The debugger will automatically
+  map supplied variable names to their temporary equivalents.
 {{% /callout %}}
 
 ```
 debug> line
-001: a() if x = y and y = z and z = 3 and debug();
+001: a() if _x = y and y = z and z = 3 and debug();
                                  ^
 debug> var
-_y_22, _x_21, _z_23
-debug> var _x_21 _z_23
-_x_21 = 3
-_z_23 = 3
+_y_2, _x_1, _z_3
+debug> var _x z
+_x@_x_1 = 3
+z@_z_3 = 3
 debug> var foo
 foo = <unbound>
 ```

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -47,10 +47,9 @@ impl KnowledgeBase {
 
     /// Generate a temporary variable prefix from a variable name.
     pub fn temp_prefix(name: &str) -> String {
-        match name.strip_prefix("_") {
-            None => format!("_{}_", name),
-            Some("") => String::from(name),
-            Some(_) => format!("{}_", name),
+        match name {
+            "_" => String::from(name),
+            _ => format!("_{}_", name),
         }
     }
 

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -423,13 +423,13 @@ mod test {
                n(x: (x)) if [_y] matches [x];"#,
         )?;
         let mut q = p.new_query_from_term(term!(call!("h", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "_this matches _y_34");
+        assert_partial_expression!(next_binding(&mut q)?, "x", "_this matches __y_34");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("i", [sym!("x"), sym!("y")])), false);
         assert_partial_expressions!(next_binding(&mut q)?,
-            "x" => "_this matches y and y matches _z_40",
-            "y" => "x matches _this and _this matches _z_40");
+            "x" => "_this matches y and y matches __z_40",
+            "y" => "x matches _this and _this matches __z_40");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("j", [sym!("x"), sym!("y")])), false);
@@ -450,14 +450,14 @@ mod test {
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("m", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "_y_54 matches _this");
+        assert_partial_expression!(next_binding(&mut q)?, "x", "__y_54 matches _this");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("n", [sym!("x")])), false);
         assert_partial_expression!(
             next_binding(&mut q)?,
             "x",
-            "_this matches _this and _y_58 matches _this"
+            "_this matches _this and __y_58 matches _this"
         );
         assert_query_done!(q);
 
@@ -1525,7 +1525,7 @@ mod test {
         let mut q = p.new_query_from_term(term!(call!("f", [sym!("x")])), false);
         assert_partial_expressions!(
             next_binding(&mut q)?,
-            "x" => "_y_12 in _this.values"
+            "x" => "__y_12 in _this.values"
         );
         assert_query_done!(q);
 
@@ -1559,7 +1559,7 @@ mod test {
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("l", [sym!("x")])), false);
-        assert_partial_expressions!(next_binding(&mut q)?, "x" => "_y_39 in _this");
+        assert_partial_expressions!(next_binding(&mut q)?, "x" => "__y_39 in _this");
         assert_query_done!(q);
 
         let mut q = p.new_query_from_term(term!(call!("m", [sym!("x")])), false);


### PR DESCRIPTION
Updates debugger documentation to cover breaking on errors and goals, and recent changes to the `var` command. Also includes a small change to how temp variable names are assigned, so the debugger can distinguish between temporaries belonging to variables named (for example) `x` and `_x`.