### PR TITLE
Improve circular data handling

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -51,6 +51,7 @@ Link to [relevant documentation section]().
 - The debugger can now break on runtime errors.
 - The `var` command  in the debugger now automatically maps variable
   names to their temporary bindings.
+- The VM can now represent circular data without crashing.
 
 ### Ruby
 

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::error::{PolarResult, RuntimeError};
-use crate::folder::{fold_term, Folder};
+use crate::folder::{fold_list, fold_term, Folder};
 use crate::formatting::ToPolarString;
 use crate::terms::{has_rest_var, Operation, Operator, Symbol, Term, Value};
 
@@ -38,6 +38,55 @@ pub enum VariableState {
     Unbound,
     Bound(Term),
     Partial,
+}
+
+struct Derefer<'a> {
+    binding_manager: &'a BindingManager,
+    seen: HashSet<u64>,
+}
+
+impl<'a> Derefer<'a> {
+    fn new(binding_manager: &'a BindingManager) -> Self {
+        Self {
+            binding_manager,
+            seen: HashSet::new(),
+        }
+    }
+}
+
+impl<'a> Folder for Derefer<'a> {
+    fn fold_list(&mut self, list: Vec<Term>) -> Vec<Term> {
+        let has_rest = has_rest_var(&list);
+        let mut list = fold_list(list, self);
+        if has_rest {
+            let last = list.pop().unwrap();
+            if let Value::List(rest) = last.value() {
+                list.append(&mut rest.clone());
+            } else {
+                list.push(last);
+            }
+        }
+        list
+    }
+
+    fn fold_term(&mut self, t: Term) -> Term {
+        match t.value() {
+            Value::Expression(_) => t,
+            Value::Variable(v) | Value::RestVariable(v) => {
+                let hash = t.hash_value();
+                if self.seen.contains(&hash) {
+                    t
+                } else {
+                    self.seen.insert(hash);
+                    let t = self.binding_manager.lookup(v).unwrap_or(t);
+                    let t = fold_term(t, self);
+                    self.seen.remove(&hash);
+                    t
+                }
+            }
+            _ => fold_term(t, self),
+        }
+    }
 }
 
 /// Represent each binding in a cycle as a unification constraint.
@@ -234,72 +283,9 @@ impl BindingManager {
     }
 
     // *** Binding Inspection ***
-
-    /// If `term` is a variable, return the value bound to that variable.
-    /// If `term` is a list, dereference all items in the list.
-    /// Otherwise, return `term`.
-    pub fn deref(&self, term: &Term) -> Term {
-        match &term.value() {
-            Value::List(list) => {
-                // Deref all elements.
-                let mut derefed: Vec<Term> =
-                    // TODO(gj): reduce recursion here.
-                    list.iter().map(|t| self.deref(t)).collect();
-
-                // If last element was a rest variable, append the list it derefed to.
-                if has_rest_var(list) {
-                    if let Some(last_term) = derefed.pop() {
-                        if let Value::List(terms) = last_term.value() {
-                            derefed.append(&mut terms.clone());
-                        } else {
-                            derefed.push(last_term);
-                        }
-                    }
-                }
-                term.clone_with_value(Value::List(derefed))
-            }
-            Value::Variable(v) => match self.variable_state(v) {
-                VariableState::Bound(value) => value,
-                _ => term.clone(),
-            },
-            Value::RestVariable(v) => match self.variable_state(v) {
-                VariableState::Bound(value) => match value.value() {
-                    Value::List(l) if has_rest_var(l) => self.deref(&value),
-                    _ => value,
-                },
-                _ => term.clone(),
-            },
-            _ => term.clone(),
-        }
-    }
-
     /// Dereference all variables in term, including within nested structures like
     /// lists and dictionaries.
     pub fn deep_deref(&self, term: &Term) -> Term {
-        pub struct Derefer<'a> {
-            binding_manager: &'a BindingManager,
-        }
-
-        impl<'a> Derefer<'a> {
-            pub fn new(binding_manager: &'a BindingManager) -> Self {
-                Self { binding_manager }
-            }
-        }
-
-        impl<'a> Folder for Derefer<'a> {
-            fn fold_term(&mut self, t: Term) -> Term {
-                match t.value() {
-                    Value::Expression(_) => t,
-                    Value::List(_) => fold_term(self.binding_manager.deref(&t), self),
-                    Value::Variable(_) | Value::RestVariable(_) => {
-                        let derefed = self.binding_manager.deref(&t);
-                        fold_term(derefed, self)
-                    }
-                    _ => fold_term(t, self),
-                }
-            }
-        }
-
         Derefer::new(self).fold_term(term.clone())
     }
 
@@ -516,6 +502,13 @@ impl BindingManager {
 
     fn add_binding(&mut self, var: &Symbol, val: Term) {
         self.bindings.push(Binding(var.clone(), val));
+    }
+
+    fn lookup(&self, var: &Symbol) -> Option<Term> {
+        match self.variable_state(var) {
+            VariableState::Bound(val) => Some(val),
+            _ => None,
+        }
     }
 
     /// Look up a variable in the bindings stack and return
@@ -785,37 +778,6 @@ mod test {
         } else {
             panic!("unexpected");
         }
-    }
-
-    #[test]
-    fn deref() {
-        let mut bm = BindingManager::default();
-        let value = term!(1);
-        let x = sym!("x");
-        let y = sym!("y");
-        let term_x = term!(x.clone());
-        let term_y = term!(y.clone());
-
-        // unbound var
-        assert_eq!(bm.deref(&term_x), term_x);
-
-        // unbound var -> unbound var
-        bm.bind(&x, term_y.clone()).unwrap();
-        assert_eq!(bm.deref(&term_x), term_x);
-
-        // value
-        assert_eq!(bm.deref(&value), value.clone());
-
-        // unbound var -> value
-        let mut bm = BindingManager::default();
-        bm.bind(&x, value.clone()).unwrap();
-        assert_eq!(bm.deref(&term_x), value);
-
-        // unbound var -> unbound var -> value
-        let mut bm = BindingManager::default();
-        bm.bind(&x, term_y).unwrap();
-        bm.bind(&y, value.clone()).unwrap();
-        assert_eq!(bm.deref(&term_x), value);
     }
 
     #[test]

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -781,6 +781,37 @@ mod test {
     }
 
     #[test]
+    fn old_deref() {
+        let mut bm = BindingManager::default();
+        let value = term!(1);
+        let x = sym!("x");
+        let y = sym!("y");
+        let term_x = term!(x.clone());
+        let term_y = term!(y.clone());
+
+        // unbound var
+        assert_eq!(bm.deep_deref(&term_x), term_x);
+
+        // unbound var -> unbound var
+        bm.bind(&x, term_y.clone()).unwrap();
+        assert_eq!(bm.deep_deref(&term_x), term_x);
+
+        // value
+        assert_eq!(bm.deep_deref(&value), value.clone());
+
+        // unbound var -> value
+        let mut bm = BindingManager::default();
+        bm.bind(&x, value.clone()).unwrap();
+        assert_eq!(bm.deep_deref(&term_x), value);
+
+        // unbound var -> unbound var -> value
+        let mut bm = BindingManager::default();
+        bm.bind(&x, term_y).unwrap();
+        bm.bind(&y, value.clone()).unwrap();
+        assert_eq!(bm.deep_deref(&term_x), value);
+    }
+
+    #[test]
     fn deep_deref() {
         let mut bm = BindingManager::default();
         let one = term!(1);

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -715,13 +715,6 @@ impl PolarVirtualMachine {
         self.binding_manager.deep_deref(term)
     }
 
-    /// Recursively dereference variables, but do not descend into (most) subterms.
-    /// The exception is for lists, so that we can correctly handle rest variables.
-    /// We also support cycle detection, in which case we return the original term.
-    fn deref(&self, term: &Term) -> Term {
-        self.deep_deref(term)
-    }
-
     /// Generate a fresh set of variables for a rule.
     fn rename_rule_vars(&self, rule: &Rule) -> Rule {
         let kb = &*self.kb.read().unwrap();
@@ -1101,7 +1094,7 @@ impl PolarVirtualMachine {
             Value::Pattern(Pattern::Dictionary(fields)) => {
                 // Produce a constraint like left.field = value
                 let to_unify = |(field, value): (&Symbol, &Term)| -> Term {
-                    let value = self.deref(value);
+                    let value = self.deep_deref(value);
                     let field = right.clone_with_value(value!(field.0.as_ref()));
                     let left = left.clone_with_value(value!(op!(Dot, left.clone(), field)));
                     let unify = op!(Unify, left, value);
@@ -1162,7 +1155,7 @@ impl PolarVirtualMachine {
 
                 // Construct field constraints.
                 let field_constraints = fields.fields.iter().rev().map(|(f, v)| {
-                    let v = self.deref(v);
+                    let v = self.deep_deref(v);
                     let field = right.clone_with_value(value!(f.0.as_ref()));
                     let left = left.clone_with_value(value!(op!(Dot, left.clone(), field)));
                     op!(Unify, left, v)
@@ -1189,7 +1182,7 @@ impl PolarVirtualMachine {
     }
 
     pub fn lookup(&mut self, dict: &Dictionary, field: &Term, value: &Term) -> PolarResult<()> {
-        let field = self.deref(field);
+        let field = self.deep_deref(field);
         match field.value() {
             Value::Variable(_) => {
                 let mut alternatives = vec![];
@@ -1244,7 +1237,7 @@ impl PolarVirtualMachine {
             Symbol,
             Option<Vec<Term>>,
             Option<BTreeMap<Symbol, Term>>,
-        ) = match self.deref(field).value() {
+        ) = match self.deep_deref(field).value() {
             Value::Call(Call { name, args, kwargs }) => (
                 name.clone(),
                 Some(args.iter().map(|arg| self.deep_deref(arg)).collect()),
@@ -1389,18 +1382,16 @@ impl PolarVirtualMachine {
             Value::Expression(_) => {
                 return self.query_for_operation(term);
             }
-            Value::Variable(_a_symbol) => {
-                let val = self.deref(term);
-
-                if val == *term {
+            Value::Variable(sym) => {
+                if let VariableState::Bound(val) = self.variable_state(sym) {
+                    self.push_goal(Goal::Query { term: val })?;
+                } else {
                     // variable was unbound
                     // apply a constraint to variable that it must be truthy
                     self.push_goal(Goal::Unify {
                         left: term.clone(),
                         right: term!(true),
                     })?;
-                } else {
-                    self.push_goal(Goal::Query { term: val })?;
                 }
             }
             Value::Boolean(value) => {
@@ -1553,7 +1544,7 @@ impl PolarVirtualMachine {
                     format!(
                         "debug({})",
                         args.iter()
-                            .map(|arg| self.deref(arg).to_polar())
+                            .map(|arg| self.deep_deref(arg).to_polar())
                             .collect::<Vec<String>>()
                             .join(", ")
                     )
@@ -1564,7 +1555,7 @@ impl PolarVirtualMachine {
                 self.print(
                     &args
                         .iter()
-                        .map(|arg| self.deref(arg).to_polar())
+                        .map(|arg| self.deep_deref(arg).to_polar())
                         .collect::<Vec<String>>()
                         .join(", "),
                 );
@@ -1913,7 +1904,7 @@ impl PolarVirtualMachine {
     ) -> PolarResult<Option<Term>> {
         // If the lookup is a `Value::Call`, then we need to check for partial args
         let (name, args, maybe_kwargs): (Symbol, Vec<Term>, Option<BTreeMap<Symbol, Term>>) =
-            match self.deref(field).value() {
+            match self.deep_deref(field).value() {
                 Value::Call(Call { name, args, kwargs }) => (
                     name.clone(),
                     args.iter().map(|arg| self.deep_deref(arg)).collect(),
@@ -2664,7 +2655,7 @@ impl PolarVirtualMachine {
         right: &Term,
         arg: &Term,
     ) -> PolarResult<QueryEvent> {
-        let arg = self.deref(arg);
+        let arg = self.deep_deref(arg);
         match (arg.value(), left.value(), right.value()) {
             (
                 Value::ExternalInstance(instance),
@@ -3494,7 +3485,7 @@ mod tests {
         }])
         .unwrap();
         let _ = vm.run(None).unwrap();
-        assert_eq!(vm.deref(&term!(x)), one);
+        assert_eq!(vm.deep_deref(&term!(x)), one);
         vm.backtrack().unwrap();
 
         // Left variable bound to value.
@@ -3505,7 +3496,7 @@ mod tests {
         }])
         .unwrap();
         let _ = vm.run(None).unwrap();
-        assert_eq!(vm.deref(&term!(z.clone())), one);
+        assert_eq!(vm.deep_deref(&term!(z.clone())), one);
 
         // Left variable bound to value, unify with something else, backtrack.
         vm.append_goals(vec![Goal::Unify {
@@ -3514,7 +3505,7 @@ mod tests {
         }])
         .unwrap();
         let _ = vm.run(None).unwrap();
-        assert_eq!(vm.deref(&term!(z)), one);
+        assert_eq!(vm.deep_deref(&term!(z)), one);
     }
 
     #[test]
@@ -3731,7 +3722,7 @@ mod tests {
         }
 
         assert_eq!(
-            vm.deref(&term!(Value::Variable(answer))),
+            vm.deep_deref(&term!(Value::Variable(answer))),
             term!(value!(true))
         );
     }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -719,7 +719,7 @@ impl PolarVirtualMachine {
     /// The exception is for lists, so that we can correctly handle rest variables.
     /// We also support cycle detection, in which case we return the original term.
     fn deref(&self, term: &Term) -> Term {
-        self.binding_manager.deref(term)
+        self.deep_deref(term)
     }
 
     /// Generate a fresh set of variables for a rule.

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1578,6 +1578,17 @@ fn test_rest_vars() -> TestResult {
 }
 
 #[test]
+fn test_circular_data() -> TestResult {
+    let mut p = Polar::new();
+    qeval(&mut p, "x = [x]");
+    qeval(&mut p, "y = {y:y}");
+    qruntime!(
+        "x = [x, y] and y = [y, x] and x = y",
+       RuntimeError::StackOverflow { .. });
+    Ok(())
+}
+
+#[test]
 fn test_in_op() -> TestResult {
     let mut p = Polar::new();
     p.load_str("f(x, y) if x in y;")?;

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1584,7 +1584,8 @@ fn test_circular_data() -> TestResult {
     qeval(&mut p, "y = {y:y}");
     qruntime!(
         "x = [x, y] and y = [y, x] and x = y",
-       RuntimeError::StackOverflow { .. });
+        RuntimeError::StackOverflow { .. }
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Right now trying to create circular data in Polar will cause a stack overflow due to unbounded recursion:

<img width="651" alt="Screen Shot 2021-07-27 at 6 48 57 PM" src="https://user-images.githubusercontent.com/1579800/127237538-04966dcf-600c-4f3e-8766-d0418159dd7b.png">

This branch changes the dereferencing code to handle circular data a little more gracefully

<img width="889" alt="Screen Shot 2021-07-27 at 6 55 33 PM" src="https://user-images.githubusercontent.com/1579800/127237969-06c66ef0-093b-4c37-b468-dfa14e4d69f9.png">

which still isn't super useful but probably better than crashing.

To manage this it does at least two slightly iffy things:

- It completely replaces `BindingManager::deref` with a slightly refactored `BindingManager::deep_deref`;
- To detect reference cycles it uses the same hash-set-of-hash-values-so-we-don't-have-to-clone strategy as the simplifier.

Local benchmarks don't seem to show much performance impact from deep-derefing everything, but someone else should test that also. A bigger concern would be if `deref` instead of `deep_deref` is actually necessary for some reason that's not covered by the tests.