### PR TITLE
Make it possible to remove files from knowledge base.

### DIFF
--- a/polar-core/src/folder.rs
+++ b/polar-core/src/folder.rs
@@ -86,11 +86,20 @@ pub trait Folder: Sized {
     }
 }
 
-pub fn fold_rule<T: Folder>(Rule { name, params, body }: Rule, fld: &mut T) -> Rule {
+pub fn fold_rule<T: Folder>(
+    Rule {
+        name,
+        params,
+        body,
+        source_info,
+    }: Rule,
+    fld: &mut T,
+) -> Rule {
     Rule {
         name: fld.fold_name(name),
         params: params.into_iter().map(|p| fld.fold_param(p)).collect(),
         body: fld.fold_term(body),
+        source_info,
     }
 }
 

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -97,7 +97,7 @@ impl KnowledgeBase {
         Ok(src_id)
     }
 
-    pub fn clear_sources(&mut self) {
+    pub fn clear_rules(&mut self) {
         self.rules.clear();
         self.sources = Sources::default();
         self.inline_queries.clear();

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -105,14 +105,23 @@ impl KnowledgeBase {
         self.loaded_files.clear();
     }
 
+    /// Removes a file from the knowledge base by finding the associated
+    /// `Source` and removing all rules for that source, and
+    /// removes the file from loaded files.
+    ///
+    /// Optionally return the source for the file, returning `None`
+    /// if the file was not in the loaded files.
     pub fn remove_file(&mut self, filename: &str) -> Option<String> {
         self.loaded_files
             .get(filename)
             .cloned()
-            .map(|src_id| self.remove_source(Some(filename.to_string()), src_id))
+            .map(|src_id| self.remove_source(src_id))
     }
 
-    pub fn remove_source(&mut self, filename: Option<String>, source_id: u64) -> String {
+    /// Removes a source from the knowledge base by finding the associated
+    /// `Source` and removing all rules for that source. Will
+    /// also remove the loaded files if the source was loaded from a file.
+    pub fn remove_source(&mut self, source_id: u64) -> String {
         // remove from rules
         self.rules.retain(|_, gr| {
             let to_remove: Vec<u64> = gr.rules.iter().filter_map(|(idx, rule)| {
@@ -134,8 +143,7 @@ impl KnowledgeBase {
             .sources
             .remove_source(source_id)
             .expect("source doesn't exist in KB");
-
-        assert_eq!(source.filename, filename);
+        let filename = source.filename;
 
         // remove queries
         self.inline_queries

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -88,7 +88,7 @@ impl KnowledgeBase {
     pub fn add_source(&mut self, source: Source) -> PolarResult<u64> {
         let src_id = self.new_id();
         if let Some(ref filename) = source.filename {
-            self.check_file(&source.src, &filename)?;
+            self.check_file(&source.src, filename)?;
             self.loaded_content
                 .insert(source.src.clone(), filename.to_string());
             self.loaded_files.insert(filename.to_string(), src_id);

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -132,8 +132,7 @@ impl KnowledgeBase {
         // remove from sources
         let source = self
             .sources
-            .sources
-            .remove(&source_id)
+            .remove_source(source_id)
             .expect("source doesn't exist in KB");
 
         assert_eq!(source.filename, filename);

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use crate::error::PolarResult;
+
 pub use super::bindings::Bindings;
 use super::counter::Counter;
 use super::rules::*;
@@ -12,6 +14,12 @@ use super::terms::*;
 #[derive(Default)]
 pub struct KnowledgeBase {
     pub constants: Bindings,
+
+    /// Map from loaded files to the source ID
+    pub loaded_files: HashMap<String, u64>,
+    /// Map from source code loaded to the filename it was loaded as
+    pub loaded_content: HashMap<String, String>,
+
     pub rules: HashMap<Symbol, GenericRule>,
     pub sources: Sources,
     /// For symbols returned from gensym.
@@ -25,6 +33,8 @@ impl KnowledgeBase {
     pub fn new() -> Self {
         Self {
             constants: HashMap::new(),
+            loaded_files: Default::default(),
+            loaded_content: Default::default(),
             rules: HashMap::new(),
             sources: Sources::default(),
             id_counter: Counter::default(),
@@ -73,5 +83,104 @@ impl KnowledgeBase {
     /// Return true if a constant with the given name has been defined.
     pub fn is_constant(&self, name: &Symbol) -> bool {
         self.constants.contains_key(name)
+    }
+
+    pub fn add_source(&mut self, source: Source) -> PolarResult<u64> {
+        let src_id = self.new_id();
+        if let Some(ref filename) = source.filename {
+            self.check_file(&source.src, &filename)?;
+            self.loaded_content
+                .insert(source.src.clone(), filename.to_string());
+            self.loaded_files.insert(filename.to_string(), src_id);
+        }
+        self.sources.add_source(source, src_id);
+        Ok(src_id)
+    }
+
+    pub fn clear_sources(&mut self) {
+        self.rules.clear();
+        self.sources = Sources::default();
+        self.inline_queries.clear();
+        self.loaded_content.clear();
+        self.loaded_files.clear();
+    }
+
+    pub fn remove_file(&mut self, filename: &str) -> Option<String> {
+        self.loaded_files
+            .get(filename)
+            .cloned()
+            .map(|src_id| self.remove_source(Some(filename.to_string()), src_id))
+    }
+
+    pub fn remove_source(&mut self, filename: Option<String>, source_id: u64) -> String {
+        // remove from rules
+        self.rules.retain(|_, gr| {
+            let to_remove: Vec<u64> = gr.rules.iter().filter_map(|(idx, rule)| {
+                if matches!(rule.source_info, SourceInfo::Parser { src_id, ..} if src_id == source_id) {
+                    Some(*idx)
+                } else {
+                    None
+                }
+            }).collect();
+
+            for idx in to_remove {
+                gr.remove_rule(idx);
+            }
+            !gr.rules.is_empty()
+        });
+
+        // remove from sources
+        let source = self
+            .sources
+            .sources
+            .remove(&source_id)
+            .expect("source doesn't exist in KB");
+
+        assert_eq!(source.filename, filename);
+
+        // remove queries
+        self.inline_queries
+            .retain(|q| q.get_source_id() != Some(source_id));
+
+        // remove from files
+        if let Some(filename) = filename {
+            self.loaded_files.remove(&filename);
+            self.loaded_content.retain(|_, f| f != &filename);
+        }
+        source.src
+    }
+
+    fn check_file(&self, src: &str, filename: &str) -> PolarResult<()> {
+        match (
+            self.loaded_content.get(src),
+            self.loaded_files.get(filename).is_some(),
+        ) {
+            (Some(other_file), true) if other_file == filename => {
+                return Err(error::RuntimeError::FileLoading {
+                    msg: format!("File {} has already been loaded.", filename),
+                }
+                .into())
+            }
+            (_, true) => {
+                return Err(error::RuntimeError::FileLoading {
+                    msg: format!(
+                        "A file with the name {}, but different contents has already been loaded.",
+                        filename
+                    ),
+                }
+                .into());
+            }
+            (Some(other_file), _) => {
+                return Err(error::RuntimeError::FileLoading {
+                    msg: format!(
+                        "A file with the same contents as {} named {} has already been loaded.",
+                        filename, other_file
+                    ),
+                }
+                .into());
+            }
+            _ => {}
+        }
+        Ok(())
     }
 }

--- a/polar-core/src/macros.rs
+++ b/polar-core/src/macros.rs
@@ -186,6 +186,7 @@ macro_rules! rule {
             name: sym!($name),
             params,
             body: term!(op!(And, $(term!($body)),+)),
+            source_info: $crate::sources::SourceInfo::Test,
         }}
     };
     ($name:expr, [$($args:tt)*]) => {{
@@ -195,6 +196,7 @@ macro_rules! rule {
             name: sym!($name),
             params,
             body: term!(op!(And)),
+            source_info: $crate::sources::SourceInfo::Test,
         }
     }};
 }

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -614,13 +614,13 @@ RuleHead: (Symbol, Vec<Parameter>) = {
 Define = {"if"};
 
 Rule: Rule = {
-    <head:RuleHead> <start:@L> <end:@R> ";" => {
+    <start_head:@L> <head:RuleHead> <start:@L> <end:@R> ";" => {
         let (name, params) = head;
         let op = Operation{operator: Operator::And, args: vec![]};
         let body = Term::new_from_parser(src_id, start, end, Value::Expression(op));
-        Rule{name, params, body}
+        Rule::new_from_parser(src_id, start_head, start, name, params, body)
     },
-    <head:RuleHead> Define <body:TermExp> ";" => {
+    <start_head:@L> <head:RuleHead> <end_head:@R> Define <body:TermExp> ";" => {
         let (name, params) = head;
         let body = match body.value() {
             Value::Expression(Operation{operator: Operator::And, ..}) => {
@@ -631,7 +631,7 @@ Rule: Rule = {
                 body.clone_with_value(Value::Expression(op))
             }
         };
-        Rule{name, params, body}
+        Rule::new_from_parser(src_id, start_head, end_head, name, params, body)
     }
 }
 

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -166,7 +166,8 @@ impl Polar {
         let mut kb = self.kb.write().unwrap();
         let source_id = kb.add_source(source.clone())?;
 
-        // extract this into a seperate function to we can catch all errors
+        // we extract this into a seperate function
+        // so that any errors returned with `?` are captured
         fn load_source(
             source_id: u64,
             source: &Source,

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -210,7 +210,7 @@ impl Polar {
                 Ok(())
             }
             Err(e) => {
-                kb.remove_source(source.filename, source_id);
+                kb.remove_source(source_id);
                 Err(e)
             }
         }

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -14,7 +14,6 @@ use super::terms::*;
 use super::vm::*;
 use super::warnings::check_singletons;
 
-use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 pub struct Query {
@@ -143,10 +142,6 @@ const ROLES_POLICY: &str = include_str!("roles.polar");
 pub struct Polar {
     pub kb: Arc<RwLock<KnowledgeBase>>,
     messages: MessageQueue,
-    /// Set of filenames already loaded
-    loaded_files: Arc<RwLock<HashSet<String>>>,
-    /// Map from source code loaded to the filename it was loaded as
-    loaded_content: Arc<RwLock<HashMap<String, String>>>,
 }
 
 impl Default for Polar {
@@ -160,94 +155,64 @@ impl Polar {
         Self {
             kb: Arc::new(RwLock::new(KnowledgeBase::new())),
             messages: MessageQueue::new(),
-            loaded_content: Arc::new(RwLock::new(HashMap::new())), // file content -> file name
-            loaded_files: Arc::new(RwLock::new(HashSet::new())),   // set of file names
         }
-    }
-
-    fn check_file(&self, src: &str, filename: &str) -> PolarResult<()> {
-        match (
-            self.loaded_content.read().unwrap().get(src),
-            self.loaded_files.read().unwrap().contains(filename),
-        ) {
-            (Some(other_file), true) if other_file == filename => {
-                return Err(error::RuntimeError::FileLoading {
-                    msg: format!("File {} has already been loaded.", filename),
-                }
-                .into())
-            }
-            (_, true) => {
-                return Err(error::RuntimeError::FileLoading {
-                    msg: format!(
-                        "A file with the name {}, but different contents has already been loaded.",
-                        filename
-                    ),
-                }
-                .into());
-            }
-            (Some(other_file), _) => {
-                return Err(error::RuntimeError::FileLoading {
-                    msg: format!(
-                        "A file with the same contents as {} named {} has already been loaded.",
-                        filename, other_file
-                    ),
-                }
-                .into());
-            }
-            _ => {}
-        }
-        self.loaded_content
-            .write()
-            .unwrap()
-            .insert(src.to_string(), filename.to_string());
-        self.loaded_files
-            .write()
-            .unwrap()
-            .insert(filename.to_string());
-
-        Ok(())
     }
 
     pub fn load(&self, src: &str, filename: Option<String>) -> PolarResult<()> {
-        if let Some(ref filename) = filename {
-            self.check_file(src, filename)?;
-        }
         let source = Source {
             filename,
             src: src.to_owned(),
         };
         let mut kb = self.kb.write().unwrap();
-        let src_id = kb.new_id();
-        let mut lines =
-            parser::parse_lines(src_id, src).map_err(|e| e.set_context(Some(&source), None))?;
-        lines.reverse();
-        kb.sources.add_source(source, src_id);
-        let mut warnings = vec![];
-        while let Some(line) = lines.pop() {
-            match line {
-                parser::Line::Rule(rule) => {
-                    let mut rule_warnings = check_singletons(&rule, &kb)?;
-                    warnings.append(&mut rule_warnings);
-                    let rule = rewrite_rule(rule, &mut kb);
+        let source_id = kb.add_source(source.clone())?;
 
-                    let name = rule.name.clone();
-                    let generic_rule = kb
-                        .rules
-                        .entry(name.clone())
-                        .or_insert_with(|| GenericRule::new(name, vec![]));
-                    generic_rule.add_rule(Arc::new(rule));
-                }
-                parser::Line::Query(term) => {
-                    kb.inline_queries.push(term);
+        // extract this into a seperate function to we can catch all errors
+        fn load_source(
+            source_id: u64,
+            source: &Source,
+            kb: &mut KnowledgeBase,
+        ) -> PolarResult<Vec<String>> {
+            let mut lines = parser::parse_lines(source_id, &source.src)
+                .map_err(|e| e.set_context(Some(source), None))?;
+            lines.reverse();
+            let mut warnings = vec![];
+            while let Some(line) = lines.pop() {
+                match line {
+                    parser::Line::Rule(rule) => {
+                        let mut rule_warnings = check_singletons(&rule, &*kb)?;
+                        warnings.append(&mut rule_warnings);
+                        let rule = rewrite_rule(rule, kb);
+
+                        let name = rule.name.clone();
+                        let generic_rule = kb
+                            .rules
+                            .entry(name.clone())
+                            .or_insert_with(|| GenericRule::new(name, vec![]));
+                        generic_rule.add_rule(Arc::new(rule));
+                    }
+                    parser::Line::Query(term) => {
+                        kb.inline_queries.push(term);
+                    }
                 }
             }
+            Ok(warnings)
         }
-        self.messages.extend(warnings.iter().map(|m| Message {
-            kind: MessageKind::Warning,
-            msg: m.to_owned(),
-        }));
 
-        Ok(())
+        // if any of the lines fail to load, we need to remove the source from
+        // the knowledge base
+        match load_source(source_id, &source, &mut kb) {
+            Ok(warnings) => {
+                self.messages.extend(warnings.iter().map(|m| Message {
+                    kind: MessageKind::Warning,
+                    msg: m.to_owned(),
+                }));
+                Ok(())
+            }
+            Err(e) => {
+                kb.remove_source(source.filename, source_id);
+                Err(e)
+            }
+        }
     }
 
     // Used in integration tests
@@ -255,14 +220,15 @@ impl Polar {
         self.load(src, None)
     }
 
+    pub fn remove_file(&self, filename: &str) -> Option<String> {
+        let mut kb = self.kb.write().unwrap();
+        kb.remove_file(filename)
+    }
+
     /// Clear rules from the knowledge base
     pub fn clear_rules(&self) {
         let mut kb = self.kb.write().unwrap();
-        kb.rules.clear();
-        kb.sources = Sources::default();
-        kb.inline_queries.clear();
-        self.loaded_content.write().unwrap().clear();
-        self.loaded_files.write().unwrap().clear();
+        kb.clear_sources();
     }
 
     pub fn next_inline_query(&self, trace: bool) -> Option<Query> {
@@ -349,10 +315,40 @@ mod tests {
     fn roles_policy_loads_idempotently() {
         let polar = Polar::new();
         assert!(polar.enable_roles().is_ok());
-        assert_eq!(polar.loaded_files.read().unwrap().len(), 1);
-        assert_eq!(polar.loaded_content.read().unwrap().len(), 1);
+        {
+            let kb = polar.kb.read().unwrap();
+            assert_eq!(kb.loaded_files.len(), 1);
+            assert_eq!(kb.loaded_content.len(), 1);
+        }
         assert!(polar.enable_roles().is_ok());
-        assert_eq!(polar.loaded_files.read().unwrap().len(), 1);
-        assert_eq!(polar.loaded_content.read().unwrap().len(), 1);
+        {
+            let kb = polar.kb.read().unwrap();
+            assert_eq!(kb.loaded_files.len(), 1);
+            assert_eq!(kb.loaded_content.len(), 1);
+        }
+    }
+
+    #[test]
+    fn load_remove_files() {
+        let polar = Polar::new();
+        polar
+            .load("f(x) if x = 1;", Some("test.polar".to_string()))
+            .unwrap();
+        polar.remove_file("test.polar");
+        // loading works after removing
+        polar
+            .load("f(x) if x = 1;", Some("test.polar".to_string()))
+            .unwrap();
+        polar.remove_file("test.polar");
+
+        // load a broken file
+        polar
+            .load("f(x) if x", Some("test.polar".to_string()))
+            .unwrap_err();
+
+        // can still load files again
+        polar
+            .load("f(x) if x = 1;", Some("test.polar".to_string()))
+            .unwrap();
     }
 }

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -228,7 +228,7 @@ impl Polar {
     /// Clear rules from the knowledge base
     pub fn clear_rules(&self) {
         let mut kb = self.kb.write().unwrap();
-        kb.clear_sources();
+        kb.clear_rules();
     }
 
     pub fn next_inline_query(&self, trace: bool) -> Option<Query> {

--- a/polar-core/src/rewrites.rs
+++ b/polar-core/src/rewrites.rs
@@ -89,7 +89,15 @@ fn temp_name(o: &Operator) -> &'static str {
 /// conjunction, creating one if necessary.
 impl<'kb> Folder for Rewriter<'kb> {
     /// Rewrite a rule, pushing expressions in the head into the body.
-    fn fold_rule(&mut self, Rule { name, body, params }: Rule) -> Rule {
+    fn fold_rule(
+        &mut self,
+        Rule {
+            name,
+            body,
+            params,
+            source_info,
+        }: Rule,
+    ) -> Rule {
         let mut body = self.fold_term(body);
 
         self.stack.push(vec![]);
@@ -102,7 +110,12 @@ impl<'kb> Folder for Rewriter<'kb> {
                 args: terms.into_iter().chain(rewrites).collect(),
             }));
         }
-        Rule { name, params, body }
+        Rule {
+            name,
+            params,
+            body,
+            source_info,
+        }
     }
 
     /// Rewrite an expression as a temp, and push a rewritten

--- a/polar-core/src/rules.rs
+++ b/polar-core/src/rules.rs
@@ -49,6 +49,15 @@ impl Rule {
         }
     }
 
+    pub fn new_from_test(name: Symbol, params: Vec<Parameter>, body: Term) -> Self {
+        Self {
+            name,
+            params,
+            body,
+            source_info: SourceInfo::Test,
+        }
+    }
+
     /// Creates a new term from the parser
     pub fn new_from_parser(
         src_id: u64,

--- a/polar-core/src/rules.rs
+++ b/polar-core/src/rules.rs
@@ -84,7 +84,7 @@ pub type Rules = Vec<Arc<Rule>>;
 
 type RuleSet = BTreeSet<u64>;
 
-#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[derive(Clone, Default, Debug)]
 struct RuleIndex {
     rules: RuleSet,
     index: HashMap<Option<Value>, RuleIndex>,
@@ -152,7 +152,7 @@ impl RuleIndex {
     }
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone)]
 pub struct GenericRule {
     pub name: Symbol,
     pub rules: HashMap<u64, Arc<Rule>>,

--- a/polar-core/src/rules.rs
+++ b/polar-core/src/rules.rs
@@ -57,6 +57,13 @@ impl RuleIndex {
         }
     }
 
+    pub fn remove_rule(&mut self, rule_id: u64) {
+        self.rules.remove(&rule_id);
+        self.index
+            .iter_mut()
+            .for_each(|(_, index)| index.remove_rule(rule_id));
+    }
+
     #[allow(clippy::comparison_chain)]
     pub fn get_applicable_rules(&self, args: &[Term], i: usize) -> RuleSet {
         if i < args.len() {
@@ -94,10 +101,10 @@ impl RuleIndex {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct GenericRule {
     pub name: Symbol,
-    rules: HashMap<u64, Arc<Rule>>,
+    pub rules: HashMap<u64, Arc<Rule>>,
     index: RuleIndex,
     next_rule_id: u64,
 }
@@ -126,6 +133,11 @@ impl GenericRule {
             "Rule id already used."
         );
         self.index.index_rule(rule_id, &rule.params[..], 0);
+    }
+
+    pub fn remove_rule(&mut self, rule_id: u64) {
+        self.rules.remove(&rule_id);
+        self.index.remove_rule(rule_id);
     }
 
     #[allow(clippy::ptr_arg)]

--- a/polar-core/src/sources.rs
+++ b/polar-core/src/sources.rs
@@ -62,4 +62,8 @@ impl Sources {
     pub fn get_source(&self, src_id: u64) -> Option<Source> {
         self.sources.get(&src_id).cloned()
     }
+
+    pub fn remove_source(&mut self, src_id: u64) -> Option<Source> {
+        self.sources.remove(&src_id)
+    }
 }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -3526,6 +3526,7 @@ mod tests {
                     ))])),
                 ],
             })),
+            source_info: SourceInfo::Test,
         };
 
         let renamed_rule = vm.rename_rule_vars(&rule);

--- a/polar-core/tests/serialize.rs
+++ b/polar-core/tests/serialize.rs
@@ -74,6 +74,7 @@ mod tests {
                 operator: Operator::And,
                 args: vec![dict.clone(), dict.clone(), dict],
             })),
+            source_info: polar_core::sources::SourceInfo::Test,
         };
         eprintln!("{}", rule);
     }

--- a/polar-core/tests/serialize.rs
+++ b/polar-core/tests/serialize.rs
@@ -67,15 +67,14 @@ mod tests {
         };
         let err: PolarError = e.into();
         eprintln!("{}", serde_json::to_string(&err).unwrap());
-        let rule = Rule {
-            name: Symbol::new("foo"),
-            params: vec![],
-            body: Term::new_temporary(Value::Expression(Operation {
+        let rule = Rule::new_from_test(
+            Symbol::new("foo"),
+            vec![],
+            Term::new_temporary(Value::Expression(Operation {
                 operator: Operator::And,
                 args: vec![dict.clone(), dict.clone(), dict],
             })),
-            source_info: polar_core::sources::SourceInfo::Test,
-        };
+        );
         eprintln!("{}", rule);
     }
 }


### PR DESCRIPTION
Core changes needed to support #1028 .

- Make it possible to _remove_ a file (we could consider exposing this functionality, but not in this PR).
- Add sources for rules.

Theoretically, there's a user-facing change which is that previously if a policy failed to load, then all rules loaded up until that point would have been stored. So if you caught that error and tried again you might end up with duplicate rules?!?
