### PR TITLE
Lazily print reprs in log, error, and debugging output

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -58,7 +58,7 @@ Link to [relevant documentation section]().
 
 - Comparison operations on Ruby objects are now fully supported.
 
-### Rust 
+### Rust
 
 #### New features
 
@@ -67,6 +67,16 @@ Link to [relevant documentation section]().
 The Rust library now has
 [built-in support for Role-Based Access Control (RBAC) policies](/guides/roles),
 which you can turn on with `.enable_roles()`.
+
+### Python
+
+#### Other bugs & improvements
+
+- The python library will no longer call `repr` on every object passed into a
+  query. Instead, instance reprs will be calculated when needed (during a log,
+  debug, or error event).
+  - This leads to a performance improvement when you have instances with heavy
+    `repr` calls (e.g. when `repr` requires a round-trip to the database).
 
 ## `flask-oso` NEW_VERSION
 

--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -73,7 +73,7 @@ which you can turn on with `.enable_roles()`.
 #### Other bugs & improvements
 
 - The python library will no longer call `repr` on every object passed into a
-  query. Instead, instance reprs will be calculated when needed (during a log,
+  query. Instead, instances will be stringified only when needed (during a log,
   debug, or error event).
   - This leads to a performance improvement when you have instances with heavy
     `repr` calls (e.g. when `repr` requires a round-trip to the database).

--- a/docs/spelling/allowed_words.txt
+++ b/docs/spelling/allowed_words.txt
@@ -46,7 +46,6 @@ Postgres
 PyPI
 RBAC
 REPL
-repl
 RESTful
 RubyGems
 Rubying
@@ -142,12 +141,14 @@ prefetch
 pseudocode
 quickstart
 registerClass
+repl
 roadmap
 runtime
 specializer
 specializers
 stderr
 stdout
+stringified
 struct
 structs
 subclasses

--- a/languages/python/oso/polar/errors.py
+++ b/languages/python/oso/polar/errors.py
@@ -40,8 +40,10 @@ def get_python_error(err_str, enrich_message=None):
         details = None
 
     if details:
-        details["stack_trace"] = enrich_message(details["stack_trace"])
-        details["msg"] = enrich_message(details["msg"])
+        if "stack_trace" in details:
+            details["stack_trace"] = enrich_message(details["stack_trace"])
+        if "msg" in details:
+            details["msg"] = enrich_message(details["msg"])
 
     if kind == "Parse":
         return _parse_error(subkind, message, details)

--- a/languages/python/oso/polar/errors.py
+++ b/languages/python/oso/polar/errors.py
@@ -22,11 +22,13 @@ from polar.exceptions import (
 )
 
 
-def get_python_error(err_str):
+def get_python_error(err_str, process_message=None):
     """Fetch a Polar error and map it into a Python exception."""
     err = json.loads(err_str)
 
     message = err["formatted"]
+    if process_message:
+        message = process_message(message)
     kind, body = next(iter(err["kind"].items()))
 
     try:
@@ -36,6 +38,10 @@ def get_python_error(err_str):
         # TODO (dhatch): This bug may exist in other libraries.
         subkind = None
         details = None
+
+    if details:
+        details["stack_trace"] = process_message(details["stack_trace"])
+        details["msg"] = process_message(details["msg"])
 
     if kind == "Parse":
         return _parse_error(subkind, message, details)

--- a/languages/python/oso/polar/errors.py
+++ b/languages/python/oso/polar/errors.py
@@ -22,13 +22,13 @@ from polar.exceptions import (
 )
 
 
-def get_python_error(err_str, process_message=None):
+def get_python_error(err_str, enrich_message=None):
     """Fetch a Polar error and map it into a Python exception."""
     err = json.loads(err_str)
 
     message = err["formatted"]
-    if process_message:
-        message = process_message(message)
+    if enrich_message:
+        message = enrich_message(message)
     kind, body = next(iter(err["kind"].items()))
 
     try:
@@ -40,8 +40,8 @@ def get_python_error(err_str, process_message=None):
         details = None
 
     if details:
-        details["stack_trace"] = process_message(details["stack_trace"])
-        details["msg"] = process_message(details["msg"])
+        details["stack_trace"] = enrich_message(details["stack_trace"])
+        details["msg"] = enrich_message(details["msg"])
 
     if kind == "Parse":
         return _parse_error(subkind, message, details)

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -50,23 +50,19 @@ class Polar:
         self.process_messages()
         self.check_result(result)
 
-    def new_query_from_str(self, query_str, enrich_message):
+    def new_query_from_str(self, query_str):
         new_q_ptr = lib.polar_new_query(self.ptr, to_c_str(query_str), 0)
         self.process_messages()
         query = self.check_result(new_q_ptr)
-        query = Query(query)
-        query.set_message_enricher(enrich_message)
-        return query
+        return Query(query)
 
-    def new_query_from_term(self, query_term, enrich_message):
+    def new_query_from_term(self, query_term):
         new_q_ptr = lib.polar_new_query_from_term(
             self.ptr, ffi_serialize(query_term), 0
         )
         self.process_messages()
         query = self.check_result(new_q_ptr)
-        query = Query(query)
-        query.set_message_enricher(enrich_message)
-        return query
+        return Query(query)
 
     def next_inline_query(self):
         q = lib.polar_next_inline_query(self.ptr, 0)

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -157,7 +157,7 @@ class Query:
         self.enrich_message = enrich_message
 
     def check_result(self, result):
-        return check_result(result, lambda msg: self.enrich_message(msg))
+        return check_result(result, self.enrich_message)
 
     def process_messages(self):
         assert self.enrich_message, (

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -88,16 +88,23 @@ class Query:
             value = ffi.NULL
         else:
             value = ffi_serialize(value)
-        check_result(lib.polar_call_result(self.ptr, call_id, value), self._temp_process_message)
+        check_result(
+            lib.polar_call_result(self.ptr, call_id, value), self._temp_process_message
+        )
 
     def question_result(self, call_id, answer):
         answer = 1 if answer else 0
-        check_result(lib.polar_question_result(self.ptr, call_id, answer), self._temp_process_message)
+        check_result(
+            lib.polar_question_result(self.ptr, call_id, answer),
+            self._temp_process_message,
+        )
 
     def application_error(self, message):
         """Pass an error back to polar to get stack trace and other info."""
         message = to_c_str(message)
-        check_result(lib.polar_application_error(self.ptr, message), self._temp_process_message)
+        check_result(
+            lib.polar_application_error(self.ptr, message), self._temp_process_message
+        )
 
     def next_event(self):
         event = lib.polar_next_query_event(self.ptr)

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -88,7 +88,9 @@ class Polar:
         return check_result(result, self.enrich_message)
 
     def process_messages(self):
-        assert self.enrich_message, "No message enricher on this instance of FfiPolar. You must call set_message_enricher before using process_messages."
+        assert (
+            self.enrich_message
+        ), "No message enricher on this instance of FfiPolar. You must call set_message_enricher before using process_messages."
         for msg in process_messages(self.next_message):
             print(self.enrich_message(msg))
 
@@ -157,7 +159,9 @@ class Query:
         return check_result(result, lambda msg: self.enrich_message(msg))
 
     def process_messages(self):
-        assert self.enrich_message, "No message enricher on this instance of FfiQuery. You must call set_message_enricher before using process_messages."
+        assert (
+            self.enrich_message
+        ), "No message enricher on this instance of FfiQuery. You must call set_message_enricher before using process_messages."
         for msg in process_messages(self.next_message):
             print(self.enrich_message(msg))
 

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -88,9 +88,10 @@ class Polar:
         return check_result(result, self.enrich_message)
 
     def process_messages(self):
-        assert (
-            self.enrich_message
-        ), "No message enricher on this instance of FfiPolar. You must call set_message_enricher before using process_messages."
+        assert self.enrich_message, (
+            "No message enricher on this instance of FfiPolar. You must call "
+            "set_message_enricher before using process_messages."
+        )
         for msg in process_messages(self.next_message):
             print(self.enrich_message(msg))
 
@@ -159,9 +160,10 @@ class Query:
         return check_result(result, lambda msg: self.enrich_message(msg))
 
     def process_messages(self):
-        assert (
-            self.enrich_message
-        ), "No message enricher on this instance of FfiQuery. You must call set_message_enricher before using process_messages."
+        assert self.enrich_message, (
+            "No message enricher on this instance of FfiQuery. You must call "
+            "set_message_enricher before using process_messages."
+        )
         for msg in process_messages(self.next_message):
             print(self.enrich_message(msg))
 

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -213,7 +213,7 @@ def ffi_serialize(value):
     return to_c_str(json.dumps(value))
 
 
-def process_messages(next_message_method, postprocess=None):
+def process_messages(next_message_method):
     while True:
         msg_ptr = next_message_method()
         if is_null(msg_ptr):
@@ -224,9 +224,6 @@ def process_messages(next_message_method, postprocess=None):
 
         kind = message["kind"]
         msg = message["msg"]
-
-        if postprocess:
-            msg = postprocess(msg)
 
         if kind == "Print":
             yield msg

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -1,11 +1,14 @@
 import json
 
 from _polar_lib import ffi, lib
+from polar.host import Host
 
 from .errors import get_python_error
 
 
 class Polar:
+    host: Host
+
     def __init__(self):
         self.ptr = lib.polar_new()
 
@@ -14,70 +17,78 @@ class Polar:
 
     def new_id(self):
         """Request a unique ID from the canonical external ID tracker."""
-        return check_result(lib.polar_get_external_id(self.ptr))
+        return self.check_result(lib.polar_get_external_id(self.ptr))
 
     def enable_roles(self):
         """Load the built-in roles policy."""
         result = lib.polar_enable_roles(self.ptr)
-        process_messages(self.next_message)
-        check_result(result)
+        self.process_messages()
+        self.check_result(result)
 
     def validate_roles_config(self, config_data):
         """Validate the user's Oso Roles config."""
         string = ffi_serialize(config_data)
         result = lib.polar_validate_roles_config(self.ptr, string)
-        process_messages(self.next_message)
-        check_result(result)
+        self.process_messages()
+        self.check_result(result)
 
     def load(self, string, filename=None):
         """Load a Polar string, checking that all inline queries succeed."""
         string = to_c_str(string)
         filename = to_c_str(str(filename)) if filename else ffi.NULL
         result = lib.polar_load(self.ptr, string, filename)
-        process_messages(self.next_message)
-        check_result(result)
+        self.process_messages()
+        self.check_result(result)
 
     def clear_rules(self):
         """Clear all rules from the Polar KB"""
         result = lib.polar_clear_rules(self.ptr)
-        process_messages(self.next_message)
-        check_result(result)
+        self.process_messages()
+        self.check_result(result)
 
-    def new_query_from_str(self, query_str):
+    def new_query_from_str(self, query_str, host):
         new_q_ptr = lib.polar_new_query(self.ptr, to_c_str(query_str), 0)
-        process_messages(self.next_message)
-        query = check_result(new_q_ptr)
-        return Query(query)
+        self.process_messages()
+        query = self.check_result(new_q_ptr)
+        return Query(query, host)
 
-    def new_query_from_term(self, query_term):
+    def new_query_from_term(self, query_term, host):
         new_q_ptr = lib.polar_new_query_from_term(
             self.ptr, ffi_serialize(query_term), 0
         )
-        process_messages(self.next_message)
-        query = check_result(new_q_ptr)
-        return Query(query)
+        self.process_messages()
+        query = self.check_result(new_q_ptr)
+        return Query(query, host)
 
     def next_inline_query(self):
         q = lib.polar_next_inline_query(self.ptr, 0)
-        process_messages(self.next_message)
+        self.process_messages()
         if is_null(q):
             return None
-        return Query(q)
+        return Query(q, self.host)
 
     def register_constant(self, value, name):
         name = to_c_str(name)
         value = ffi_serialize(value)
         result = lib.polar_register_constant(self.ptr, name, value)
-        process_messages(self.next_message)
-        check_result(result)
+        self.process_messages()
+        self.check_result(result)
 
     def next_message(self):
         return lib.polar_next_polar_message(self.ptr)
 
+    def check_result(self, result):
+        return check_result(result, lambda msg: self.host.enrich_message(msg))
+
+    def process_messages(self):
+        for msg in process_messages(self.next_message):
+            print(self.host.enrich_message(msg))
+
 
 class Query:
-    def __init__(self, ptr):
+    def __init__(self, ptr, host):
         self.ptr = ptr
+        self.host = host
 
     def __del__(self):
         lib.query_free(self.ptr)
@@ -88,41 +99,34 @@ class Query:
             value = ffi.NULL
         else:
             value = ffi_serialize(value)
-        check_result(
-            lib.polar_call_result(self.ptr, call_id, value), self._temp_process_message
-        )
+        self.check_result(lib.polar_call_result(self.ptr, call_id, value))
 
     def question_result(self, call_id, answer):
         answer = 1 if answer else 0
-        check_result(
-            lib.polar_question_result(self.ptr, call_id, answer),
-            self._temp_process_message,
-        )
+        self.check_result(lib.polar_question_result(self.ptr, call_id, answer))
 
     def application_error(self, message):
         """Pass an error back to polar to get stack trace and other info."""
         message = to_c_str(message)
-        check_result(
-            lib.polar_application_error(self.ptr, message), self._temp_process_message
-        )
+        self.check_result(lib.polar_application_error(self.ptr, message))
 
     def next_event(self):
         event = lib.polar_next_query_event(self.ptr)
-        process_messages(self.next_message, self._temp_process_message)
-        event = check_result(event, self._temp_process_message)
+        self.process_messages()
+        event = self.check_result(event)
         return QueryEvent(event)
 
     def debug_command(self, command):
         result = lib.polar_debug_command(self.ptr, ffi_serialize(command))
-        process_messages(self.next_message, self._temp_process_message)
-        check_result(result, self._temp_process_message)
+        self.process_messages()
+        self.check_result(result)
 
     def next_message(self):
         return lib.polar_next_query_message(self.ptr)
 
     def source(self):
         source = lib.polar_query_source_info(self.ptr)
-        source = check_result(source, self._temp_process_message)
+        source = self.check_result(source)
         return Source(source)
 
     def bind(self, name, value):
@@ -130,8 +134,15 @@ class Query:
         value = ffi_serialize(value)
         result = lib.polar_bind(self.ptr, name, value)
         # TODO(gj): Do we need to process_messages here?
-        process_messages(self.next_message, self._temp_process_message)
-        check_result(result, self._temp_process_message)
+        self.process_messages()
+        self.check_result(result)
+
+    def check_result(self, result):
+        return check_result(result, lambda msg: self.host.enrich_message(msg))
+
+    def process_messages(self):
+        for msg in process_messages(self.next_message):
+            print(self.host.enrich_message(msg))
 
 
 class QueryEvent:
@@ -149,8 +160,8 @@ class Error:
     def __init__(self):
         self.ptr = lib.polar_get_error()
 
-    def get(self, process_message=None):
-        return get_python_error(ffi.string(self.ptr).decode(), process_message)
+    def get(self, enrich_message=None):
+        return get_python_error(ffi.string(self.ptr).decode(), enrich_message)
 
     def __del__(self):
         lib.string_free(self.ptr)
@@ -167,9 +178,9 @@ class Source:
         lib.string_free(self.ptr)
 
 
-def check_result(result, process_error=None):
+def check_result(result, enrich_message=None):
     if result == 0 or is_null(result):
-        raise Error().get(process_error)
+        raise Error().get(enrich_message)
     return result
 
 
@@ -201,6 +212,6 @@ def process_messages(next_message_method, postprocess=None):
             msg = postprocess(msg)
 
         if kind == "Print":
-            print(msg)
+            yield msg
         elif kind == "Warning":
-            print(f"[warning] {msg}")
+            yield f"[warning] {msg}"

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -69,7 +69,7 @@ class Polar:
         self.process_messages()
         if is_null(q):
             return None
-        return Query(q, self.host)
+        return Query(q)
 
     def register_constant(self, value, name):
         name = to_c_str(name)
@@ -88,6 +88,7 @@ class Polar:
         return check_result(result, self.enrich_message)
 
     def process_messages(self):
+        assert self.enrich_message, "No message enricher on this instance of FfiPolar. You must call set_message_enricher before using process_messages."
         for msg in process_messages(self.next_message):
             print(self.enrich_message(msg))
 
@@ -101,7 +102,6 @@ class Query:
 
     def __init__(self, ptr):
         self.ptr = ptr
-        self.enrich_message = lambda msg: msg
 
     def __del__(self):
         lib.query_free(self.ptr)
@@ -157,6 +157,7 @@ class Query:
         return check_result(result, lambda msg: self.enrich_message(msg))
 
     def process_messages(self):
+        assert self.enrich_message, "No message enricher on this instance of FfiQuery. You must call set_message_enricher before using process_messages."
         for msg in process_messages(self.next_message):
             print(self.enrich_message(msg))
 

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -149,7 +149,7 @@ class Host:
         us to avoid sending reprs eagerly when an instance is created in polar.
         """
 
-        def replace_repr(match: re.Match):
+        def replace_repr(match):
             instance_id = int(match[1])
             try:
                 instance = self.get_instance(instance_id)

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -218,7 +218,12 @@ class Host:
             # sqlalchemy_oso.roles.OsoRoles.Roles ONLY
             repr_str = None
             import inspect
-            if inspect.isclass(v) and "OsoRoles" in v.__qualname__ and v.__module__ == "sqlalchemy_oso.roles":
+
+            if (
+                inspect.isclass(v)
+                and "OsoRoles" in v.__qualname__
+                and v.__module__ == "sqlalchemy_oso.roles"
+            ):
                 repr_str = repr(v)
             # END HACK
             val = {

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -148,6 +148,7 @@ class Host:
         Currently only used to enrich messages with instance reprs. This allows
         us to avoid sending reprs eagerly when an instance is created in polar.
         """
+
         def replace_repr(match: re.Match):
             instance_id = int(match[1])
             try:

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -139,6 +139,10 @@ class Host:
                 f"External operation '{type(args[0])} {op} {type(args[1])}' failed."
             )
 
+    def process_message(self, message: str):
+        import re
+        return re.sub(r'\^\{id: ([0-9]+)\}', lambda match: repr(self.get_instance(int(match[1]))), message, flags=re.M)
+
     def to_polar(self, v):
         """Convert a Python object to a Polar term."""
         if type(v) == bool:
@@ -193,7 +197,8 @@ class Host:
             val = {
                 "ExternalInstance": {
                     "instance_id": self.cache_instance(v),
-                    "repr": repr(v),
+                    "repr": None,
+                    # "_internal_allow_methods_with_unbound_arguments": v is OsoRoles
                 }
             }
         term = {"value": val}

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -210,11 +210,21 @@ class Host:
                     }
                 }
         else:
+            # BEGIN HACK:
+            # The polar core uses the .repr property to determine whether or not
+            # to allow Roles.role_allows to be called with unbound variables as
+            # arguments (only for sqlalchemy_oso)
+            # Because of this, we need to continue to send the repr for
+            # sqlalchemy_oso.roles.OsoRoles.Roles ONLY
+            repr_str = None
+            import inspect
+            if inspect.isclass(v) and "OsoRoles" in v.__qualname__ and v.__module__ == "sqlalchemy_oso.roles":
+                repr_str = repr(v)
+            # END HACK
             val = {
                 "ExternalInstance": {
                     "instance_id": self.cache_instance(v),
-                    "repr": None,
-                    # "_internal_allow_methods_with_unbound_arguments": v is OsoRoles
+                    "repr": repr_str,
                 }
             }
         term = {"value": val}

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -140,9 +140,9 @@ class Host:
                 f"External operation '{type(args[0])} {op} {type(args[1])}' failed."
             )
 
-    def process_message(self, message: str):
+    def enrich_message(self, message: str):
         """
-        Process a message from the polar core, such as a log line, debug
+        "Enrich" a message from the polar core, such as a log line, debug
         message, or error trace.
 
         Currently only used to enrich messages with instance reprs. This allows

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -64,6 +64,7 @@ class Polar:
     def __init__(self, classes=CLASSES):
         self.ffi_polar = FfiPolar()
         self.host = Host(self.ffi_polar)
+        self.ffi_polar.host = self.host
         # TODO(gj): rename to _oso_roles_enabled
         self._polar_roles_enabled = False
 
@@ -176,9 +177,9 @@ class Polar:
         host.set_accept_expression(accept_expression)
 
         if isinstance(query, str):
-            query = self.ffi_polar.new_query_from_str(query)
+            query = self.ffi_polar.new_query_from_str(query, host)
         elif isinstance(query, Predicate):
-            query = self.ffi_polar.new_query_from_term(host.to_polar(query))
+            query = self.ffi_polar.new_query_from_term(host.to_polar(query), host)
         else:
             raise InvalidQueryTypeError()
 

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -64,7 +64,7 @@ class Polar:
     def __init__(self, classes=CLASSES):
         self.ffi_polar = FfiPolar()
         self.host = Host(self.ffi_polar)
-        self.ffi_polar.host = self.host
+        self.ffi_polar.set_message_enricher(self.host.enrich_message)
         # TODO(gj): rename to _oso_roles_enabled
         self._polar_roles_enabled = False
 
@@ -177,9 +177,9 @@ class Polar:
         host.set_accept_expression(accept_expression)
 
         if isinstance(query, str):
-            query = self.ffi_polar.new_query_from_str(query, host)
+            query = self.ffi_polar.new_query_from_str(query, host.enrich_message)
         elif isinstance(query, Predicate):
-            query = self.ffi_polar.new_query_from_term(host.to_polar(query), host)
+            query = self.ffi_polar.new_query_from_term(host.to_polar(query), host.enrich_message)
         else:
             raise InvalidQueryTypeError()
 
@@ -214,9 +214,10 @@ class Polar:
 
             host = self.host.copy()
             host.set_accept_expression(True)
+            ffi_query.set_message_enricher(host.enrich_message)
             result = False
             try:
-                query = Query(ffi_query, host=host).run()
+                query = Query(ffi_query).run()
                 for res in query:
                     result = True
                     bindings = res["bindings"]

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -109,7 +109,6 @@ class Polar:
                 query = self.ffi_polar.next_inline_query()
                 if query is None:  # Load is done
                     break
-                query.set_message_enricher(self.host.enrich_message)
                 try:
                     host = self.host.copy()
                     host.set_accept_expression(True)
@@ -152,7 +151,6 @@ class Polar:
             if query is None:  # Load is done
                 break
             else:
-                query.set_message_enricher(self.host.enrich_message)
                 try:
                     next(Query(query, host=self.host.copy()).run())
                 except StopIteration:
@@ -180,10 +178,8 @@ class Polar:
 
         if isinstance(query, str):
             query = self.ffi_polar.new_query_from_str(query)
-            query.set_message_enricher(host.enrich_message)
         elif isinstance(query, Predicate):
             query = self.ffi_polar.new_query_from_term(host.to_polar(query))
-            query.set_message_enricher(host.enrich_message)
         else:
             raise InvalidQueryTypeError()
 
@@ -218,10 +214,9 @@ class Polar:
 
             host = self.host.copy()
             host.set_accept_expression(True)
-            ffi_query.set_message_enricher(host.enrich_message)
             result = False
             try:
-                query = Query(ffi_query).run()
+                query = Query(ffi_query, host=host).run()
                 for res in query:
                     result = True
                     bindings = res["bindings"]

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -109,6 +109,7 @@ class Polar:
                 query = self.ffi_polar.next_inline_query()
                 if query is None:  # Load is done
                     break
+                query.set_message_enricher(self.host.enrich_message)
                 try:
                     host = self.host.copy()
                     host.set_accept_expression(True)
@@ -151,6 +152,7 @@ class Polar:
             if query is None:  # Load is done
                 break
             else:
+                query.set_message_enricher(self.host.enrich_message)
                 try:
                     next(Query(query, host=self.host.copy()).run())
                 except StopIteration:
@@ -177,9 +179,11 @@ class Polar:
         host.set_accept_expression(accept_expression)
 
         if isinstance(query, str):
-            query = self.ffi_polar.new_query_from_str(query, host.enrich_message)
+            query = self.ffi_polar.new_query_from_str(query)
+            query.set_message_enricher(host.enrich_message)
         elif isinstance(query, Predicate):
-            query = self.ffi_polar.new_query_from_term(host.to_polar(query), host.enrich_message)
+            query = self.ffi_polar.new_query_from_term(host.to_polar(query))
+            query.set_message_enricher(host.enrich_message)
         else:
             raise InvalidQueryTypeError()
 

--- a/languages/python/oso/polar/query.py
+++ b/languages/python/oso/polar/query.py
@@ -25,7 +25,6 @@ class Query:
 
     def __init__(self, ffi_query, *, host=None, bindings=None):
         self.ffi_query = ffi_query
-        ffi_query._temp_process_message = lambda m: host.process_message(m)
         self.host = host
         self.calls = {}
         for (k, v) in (bindings or {}).items():
@@ -174,7 +173,7 @@ class Query:
 
     def handle_debug(self, data):
         if data["message"]:
-            print(self.host.process_message(data["message"]))
+            print(self.host.enrich_message(data["message"]))
         try:
             command = input("debug> ").strip(";")
         except EOFError:

--- a/languages/python/oso/polar/query.py
+++ b/languages/python/oso/polar/query.py
@@ -25,6 +25,7 @@ class Query:
 
     def __init__(self, ffi_query, *, host=None, bindings=None):
         self.ffi_query = ffi_query
+        self.ffi_query.set_message_enricher(host.enrich_message)
         self.host = host
         self.calls = {}
         for (k, v) in (bindings or {}).items():

--- a/languages/python/oso/polar/query.py
+++ b/languages/python/oso/polar/query.py
@@ -25,6 +25,7 @@ class Query:
 
     def __init__(self, ffi_query, *, host=None, bindings=None):
         self.ffi_query = ffi_query
+        ffi_query._temp_process_message = lambda m: host.process_message(m)
         self.host = host
         self.calls = {}
         for (k, v) in (bindings or {}).items():
@@ -173,7 +174,7 @@ class Query:
 
     def handle_debug(self, data):
         if data["message"]:
-            print(data["message"])
+            print(self.host.process_message(data["message"]))
         try:
             command = input("debug> ").strip(";")
         except EOFError:

--- a/languages/python/oso/tests/test_polar_roles.py
+++ b/languages/python/oso/tests/test_polar_roles.py
@@ -28,6 +28,7 @@ class Org(Base):  # type: ignore
     def __repr__(self):
         # TODO: remove this slowdown?
         import time
+
         time.sleep(0.002)
         return f"Org({self.name})"
 

--- a/languages/python/oso/tests/test_polar_roles.py
+++ b/languages/python/oso/tests/test_polar_roles.py
@@ -26,10 +26,6 @@ class Org(Base):  # type: ignore
     name = Column(String(), primary_key=True)
 
     def __repr__(self):
-        # TODO: remove this slowdown?
-        import time
-
-        time.sleep(0.002)
         return f"Org({self.name})"
 
 

--- a/languages/python/oso/tests/test_polar_roles.py
+++ b/languages/python/oso/tests/test_polar_roles.py
@@ -26,6 +26,9 @@ class Org(Base):  # type: ignore
     name = Column(String(), primary_key=True)
 
     def __repr__(self):
+        # TODO: remove this slowdown?
+        import time
+        time.sleep(0.002)
         return f"Org({self.name})"
 
 

--- a/languages/python/oso/tests/test_polar_roles.py
+++ b/languages/python/oso/tests/test_polar_roles.py
@@ -2540,6 +2540,7 @@ def test_perf_polar(init_oso, sample_data):
     # parent_org = repo.org and parent_org matches Org;
     # """
     oso.load_str(p)
+    oso.enable_roles()
 
     leina = sample_data["leina"]
     # steve = sample_data["steve"]

--- a/languages/python/oso/tests/test_repr.py
+++ b/languages/python/oso/tests/test_repr.py
@@ -1,0 +1,42 @@
+import os
+import re
+import io
+
+from polar.exceptions import PolarRuntimeError
+import pytest
+
+FOO_REPR = "SPECIAL FOO REPR"
+
+class Foo:
+    def __repr__(self) -> str:
+        return FOO_REPR
+
+
+def test_repr_when_logging(polar, capsys):
+    old_polar_log = os.getenv("POLAR_LOG")
+    os.environ["POLAR_LOG"] = "1"
+    polar.register_class(Foo)
+    polar.load_str("f(_foo: Foo) if 1 = 1;")
+    list(polar.query_rule("f", Foo()))
+    captured = capsys.readouterr()
+    assert f"QUERY: f({FOO_REPR})" in captured.out
+    if not old_polar_log:
+        os.unsetenv("POLAR_LOG")
+
+def test_repr_in_error(polar):
+    polar.register_class(Foo)
+    # This will throw an error because foo.hello is not allowed
+    polar.load_str("f(foo: Foo) if foo.hello;")
+    with pytest.raises(PolarRuntimeError) as excinfo:
+        list(polar.query_rule("f", Foo()))
+    assert f"f({FOO_REPR})" in excinfo.value.stack_trace
+
+
+def test_repr_when_debugging(polar, monkeypatch, capsys):
+    polar.register_class(Foo)
+    polar.load_str("f(_foo: Foo) if debug() and 1 = 1;")
+    monkeypatch.setattr('sys.stdin', io.StringIO('bindings'))
+    list(polar.query_rule("f", Foo()))
+    captured = capsys.readouterr()
+    assert re.search(rf'_foo_[0-9]+ = {FOO_REPR}', captured.out)
+

--- a/languages/python/oso/tests/test_repr.py
+++ b/languages/python/oso/tests/test_repr.py
@@ -7,6 +7,7 @@ import pytest
 
 FOO_REPR = "SPECIAL FOO REPR"
 
+
 class Foo:
     def __repr__(self) -> str:
         return FOO_REPR
@@ -23,6 +24,7 @@ def test_repr_when_logging(polar, capsys):
     if not old_polar_log:
         os.unsetenv("POLAR_LOG")
 
+
 def test_repr_in_error(polar):
     polar.register_class(Foo)
     # This will throw an error because foo.hello is not allowed
@@ -35,8 +37,7 @@ def test_repr_in_error(polar):
 def test_repr_when_debugging(polar, monkeypatch, capsys):
     polar.register_class(Foo)
     polar.load_str("f(_foo: Foo) if debug() and 1 = 1;")
-    monkeypatch.setattr('sys.stdin', io.StringIO('bindings'))
+    monkeypatch.setattr("sys.stdin", io.StringIO("bindings"))
     list(polar.query_rule("f", Foo()))
     captured = capsys.readouterr()
-    assert re.search(rf'_foo_[0-9]+ = {FOO_REPR}', captured.out)
-
+    assert re.search(rf"_foo_[0-9]+ = {FOO_REPR}", captured.out)

--- a/polar-core/src/formatting.rs
+++ b/polar-core/src/formatting.rs
@@ -374,6 +374,9 @@ pub mod to_polar {
             if let Some(ref repr) = self.repr {
                 repr.clone()
             } else {
+                // Print out external instances like ^{id: 123}
+                // NOTE: this format is used by host libraries to enrich output
+                // messages with native representations of the instances.
                 format!("^{{id: {}}}", self.instance_id)
             }
         }


### PR DESCRIPTION
Only python for now. Once I get a review, I can port to ruby and potentially node. Other languages (I think) are unlikely to have slow reprs, so it's less important to do this.

PR checklist:

- [x] Added changelog entry.
