### PR TITLE
Combine timeout tests to reduce flakiness.

### DIFF
--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -3718,18 +3718,15 @@ mod tests {
     }
 
     #[test]
-    fn test_timeout_configuration() {
+    fn test_timeout() {
         let vm = PolarVirtualMachine::default();
         assert!(vm.query_timeout_ms == DEFAULT_TIMEOUT_MS);
 
         std::env::set_var("POLAR_TIMEOUT_MS", "0");
         let vm = PolarVirtualMachine::default();
         std::env::remove_var("POLAR_TIMEOUT_MS");
-        assert!(vm.is_query_timeout_disabled())
-    }
+        assert!(vm.is_query_timeout_disabled());
 
-    #[test]
-    fn test_timeout() {
         std::env::set_var("POLAR_TIMEOUT_MS", "500");
         let mut vm = PolarVirtualMachine::default();
         std::env::remove_var("POLAR_TIMEOUT_MS");


### PR DESCRIPTION
Rust runs all tests in parallel in threads, but environment variables are set at the process level. The `test_timeout` and `test_timeout_configuration` tests could step on each other if they overlap, causing somewhat frequent failures in CI.