### PR TITLE
Rule prototypes

### DIFF
--- a/languages/go/internal/ffi/native/polar.h
+++ b/languages/go/internal/ffi/native/polar.h
@@ -21,6 +21,8 @@ int32_t polar_clear_rules(polar_Polar *polar_ptr);
 
 int32_t polar_register_constant(polar_Polar *polar_ptr, const char *name, const char *value);
 
+int32_t polar_register_mro(polar_Polar *polar_ptr, const char *name, const char *mro);
+
 polar_Query *polar_next_inline_query(polar_Polar *polar_ptr, uint32_t trace);
 
 polar_Query *polar_new_query_from_term(polar_Polar *polar_ptr,

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -863,6 +863,8 @@ describe('Oso Roles', () => {
     const leina = new User('leina', [osohqOwner]);
     const steve = new User('steve', [osohqMember]);
 
+    // TODO: had to change specializers in `parent_child` rules back to
+    // `matches` in the body in order to get tests passing--revisit
     const policy = `
       resource(_type: Org, "org", actions, roles) if
           actions = [

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -900,11 +900,13 @@ describe('Oso Roles', () => {
               "edit"
           ];
 
-      parent_child(parent_org: Org, repo: Repo) if
-          repo.org = parent_org;
+      parent_child(parent_org, repo: Repo) if
+          repo.org = parent_org
+          and parent_org matches Org;
 
-      parent_child(parent_repo: Repo, issue: Issue) if
-          issue.repo = parent_repo;
+      parent_child(parent_repo, issue: Issue) if
+          issue.repo = parent_repo and
+          parent_repo matches Repo;
 
       actor_has_role_for_resource(actor, role_name, role_resource) if
           role in actor.roles and

--- a/languages/python/oso/polar/errors.py
+++ b/languages/python/oso/polar/errors.py
@@ -19,6 +19,7 @@ from polar.exceptions import (
     ParameterError,
     PolarApiError,
     RolesValidationError,
+    ValidationError,
 )
 
 
@@ -55,6 +56,8 @@ def get_python_error(err_str, enrich_message=None):
         # TODO(gj): this is wrong -- method has arity 3.
         return _api_error(message, details)
     elif kind == "RolesValidation":
+        return _roles_validation_error(message, details)
+    elif kind == "Validation":
         return _validation_error(message, details)
 
 
@@ -89,8 +92,12 @@ def _operational_error(subkind, message, details):
         return OperationalError(message, details)
 
 
-def _validation_error(message, details):
+def _roles_validation_error(message, details):
     return RolesValidationError(message, details)
+
+
+def _validation_error(message, details):
+    return ValidationError(message, details)
 
 
 def _api_error(subkind, message, details):

--- a/languages/python/oso/polar/exceptions.py
+++ b/languages/python/oso/polar/exceptions.py
@@ -201,6 +201,10 @@ class RolesValidationError(PolarApiError):
     pass
 
 
+class ValidationError(PolarApiError):
+    pass
+
+
 UNEXPECTED_EXPRESSION_MESSAGE = dedent(
     """\
 Received Expression from Polar VM. The Expression type is only supported when

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -94,6 +94,13 @@ class Polar:
         self.process_messages()
         self.check_result(result)
 
+    def register_mro(self, name, mro):
+        name = to_c_str(name)
+        mro = ffi_serialize(mro)
+        result = lib.polar_register_mro(self.ptr, name, mro)
+        self.process_messages()
+        self.check_result(result)
+
     def next_message(self):
         return lib.polar_next_polar_message(self.ptr)
 

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -1,6 +1,7 @@
 """Communicate with the Polar virtual machine: load rules, make queries, etc."""
 
 from datetime import datetime, timedelta
+import inspect
 import os
 from pathlib import Path
 import sys
@@ -146,6 +147,18 @@ class Polar:
 
     def load_str(self, string, filename=None):
         """Load a Polar string, checking that all inline queries succeed."""
+        # Get MRO of all registered classes
+        # NOTE: not ideal that the MRO gets updated each time load_str is
+        # called, but since we are planning to move to only calling load once
+        # with the include feature, I think it's okay for now.
+        for (cls_name, cls) in self.host.classes.items():
+            mro = [
+                self.host.class_ids.get(c)
+                for c in inspect.getmro(cls)
+                if c in self.host.class_ids
+            ]
+            self.ffi_polar.register_mro(cls_name, mro)
+
         self.ffi_polar.load(string, filename)
 
         # check inline queries
@@ -257,6 +270,9 @@ class Polar:
             self.host.types[cls_name] = types
         if fetcher:
             self.host.fetchers[cls_name] = fetcher
+        self.ffi_polar.register_mro(
+            cls_name, self.host.to_polar(list(inspect.getmro(cls)))
+        )
 
     def register_constant(self, value, name):
         """Register `value` as a Polar constant variable called `name`."""

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -270,9 +270,6 @@ class Polar:
             self.host.types[cls_name] = types
         if fetcher:
             self.host.fetchers[cls_name] = fetcher
-        self.ffi_polar.register_mro(
-            cls_name, self.host.to_polar(list(inspect.getmro(cls)))
-        )
 
     def register_constant(self, value, name):
         """Register `value` as a Polar constant variable called `name`."""

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -13,6 +13,7 @@ from polar import (
     Pattern,
 )
 from polar.partial import TypeConstraint
+from polar.errors import ValidationError
 
 import pytest
 
@@ -948,3 +949,59 @@ def test_lookup_in_head(polar, is_allowed):
 
     assert not is_allowed("leina", "write", r)
     assert is_allowed("leina", "read", r)
+
+
+def test_rule_prototypes_with_subclass_check(polar):
+    class Foo:
+        pass
+
+    class Bar(Foo):
+        pass
+
+    class Baz(Bar):
+        pass
+
+    class Bad:
+        pass
+
+    # NOTE: keep this order of registering classes--confirms that MROs are added at the correct time
+    polar.register_class(Baz)
+    polar.register_class(Bar)
+    polar.register_class(Foo)
+    polar.register_class(Bad)
+
+    p = """
+    type f(_x: Integer);
+    f(1);
+    """
+    polar.load_str(p)
+
+    p = """
+    type f(_x: Foo);
+    type f(_x: Foo, _y: Bar);
+    f(_x: Bar);
+    f(_x: Baz);
+    """
+    polar.load_str(p)
+
+    with pytest.raises(ValidationError) as e:
+        polar.load_str("f(_x: Bad);")
+
+    polar.clear_rules()
+
+    # Test with fields
+    p = """
+    type f(_x: Foo{id: 1});
+    f(_x: Bar{id: 1});
+    f(_x: Baz{id: 1});
+    """
+    polar.load_str(p)
+    with pytest.raises(ValidationError) as e:
+        polar.load_str("f(_x: Baz);")
+
+    # Test invalid rule prototype
+    p = """
+    type f(x: Foo, x.baz);
+    """
+    with pytest.raises(ValidationError) as e:
+        polar.load_str(p)

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -984,7 +984,7 @@ def test_rule_prototypes_with_subclass_check(polar):
     """
     polar.load_str(p)
 
-    with pytest.raises(ValidationError) as e:
+    with pytest.raises(ValidationError):
         polar.load_str("f(_x: Bad);")
 
     polar.clear_rules()
@@ -996,12 +996,12 @@ def test_rule_prototypes_with_subclass_check(polar):
     f(_x: Baz{id: 1});
     """
     polar.load_str(p)
-    with pytest.raises(ValidationError) as e:
+    with pytest.raises(ValidationError):
         polar.load_str("f(_x: Baz);")
 
     # Test invalid rule prototype
     p = """
     type f(x: Foo, x.baz);
     """
-    with pytest.raises(ValidationError) as e:
+    with pytest.raises(ValidationError):
         polar.load_str(p)

--- a/polar-core/src/error.rs
+++ b/polar-core/src/error.rs
@@ -34,6 +34,7 @@ pub enum ErrorKind {
     Operational(OperationalError),
     Parameter(ParameterError),
     RolesValidation(RolesValidationError),
+    Validation(ValidationError),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -125,6 +126,15 @@ impl From<RolesValidationError> for PolarError {
     }
 }
 
+impl From<ValidationError> for PolarError {
+    fn from(err: ValidationError) -> Self {
+        Self {
+            kind: ErrorKind::Validation(err),
+            context: None,
+        }
+    }
+}
+
 pub type PolarResult<T> = std::result::Result<T, PolarError>;
 
 impl std::error::Error for PolarError {}
@@ -137,6 +147,7 @@ impl fmt::Display for PolarError {
             ErrorKind::Operational(e) => write!(f, "{}", e)?,
             ErrorKind::Parameter(e) => write!(f, "{}", e)?,
             ErrorKind::RolesValidation(e) => write!(f, "{}", e)?,
+            ErrorKind::Validation(e) => write!(f, "{}", e)?,
         }
         if let Some(ref context) = self.context {
             write!(f, "{}", context)?;
@@ -374,5 +385,25 @@ pub struct RolesValidationError(pub String);
 impl fmt::Display for RolesValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Oso Roles Validation Error: {}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ValidationError {
+    InvalidRule { rule: String, msg: String },
+    InvalidPrototype { prototype: String, msg: String },
+    // TODO: add SingletonVariable, RolesValidationError and Macro errors here
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::InvalidRule { rule, msg } => {
+                write!(f, "Invalid rule: {} {}", rule, msg)
+            }
+            Self::InvalidPrototype { prototype, msg } => {
+                write!(f, "Invalid prototype: {} {}", prototype, msg)
+            }
+        }
     }
 }

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -105,7 +105,7 @@ impl KnowledgeBase {
     /// Validate that all rules loaded into the knowledge base are valid based on rule prototypes.
     pub fn validate_rules(&self) -> PolarResult<()> {
         for (rule_name, generic_rule) in &self.rules {
-            if let Some(prototypes) = self.rule_prototypes.get(&rule_name) {
+            if let Some(prototypes) = self.rule_prototypes.get(rule_name) {
                 // If a prototype with the same name exists, then the parameters must match for each rule
                 for rule in generic_rule.rules.values() {
                     let mut msg = "Must match one of the following rule prototypes:\n".to_owned();

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -443,10 +443,7 @@ impl KnowledgeBase {
     pub fn add_rule_prototype(&mut self, prototype: Rule) {
         let name = prototype.name.clone();
         // get rule prototypes
-        let prototypes = self
-            .rule_prototypes
-            .entry(name.clone())
-            .or_insert_with(|| vec![]);
+        let prototypes = self.rule_prototypes.entry(name).or_insert_with(Vec::new);
         prototypes.push(prototype);
     }
 

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -324,7 +324,7 @@ impl KnowledgeBase {
                 )
                 | (Value::Variable(_), Some(Value::Pattern(prototype_spec)), rule_value, None) => {
                     match prototype_spec {
-                        // Template specializer is an instance pattern
+                        // Prototype specializer is an instance pattern
                         Pattern::Instance(InstanceLiteral {
                             tag,
                             fields: prototype_fields,
@@ -356,7 +356,7 @@ impl KnowledgeBase {
                                 ))
                             }
                         }
-                        // Template specializer is a dictionary pattern
+                        // Prototype specializer is a dictionary pattern
                         Pattern::Dictionary(prototype_fields) => {
                             if let Value::Dictionary(rule_fields) = rule_value {
                                 if self.param_fields_match(prototype_fields, rule_fields) {
@@ -971,7 +971,7 @@ mod tests {
         // Orange is a subclass of Citrus
         kb.add_mro(sym!("Orange"), vec![3, 2, 1]).unwrap();
 
-        // Template applies if it has the same name as a rule
+        // Prototype applies if it has the same name as a rule
         kb.add_rule_prototype(rule!("f", ["x"; instance!(sym!("Orange"))]));
         kb.add_rule(rule!("f", ["x"; instance!(sym!("Orange"))]));
         kb.add_rule(rule!("f", ["x"; instance!(sym!("Fruit"))]));
@@ -984,7 +984,7 @@ mod tests {
             }
         ));
 
-        // Template does not apply if it doesn't have the same name as a rule
+        // Prototype does not apply if it doesn't have the same name as a rule
         kb.clear_rules();
         kb.add_rule_prototype(rule!("f", ["x"; instance!(sym!("Orange"))]));
         kb.add_rule(rule!("f", ["x"; instance!(sym!("Orange"))]));
@@ -992,7 +992,7 @@ mod tests {
 
         kb.validate_rules().unwrap();
 
-        // Template does apply if it has the same name as a rule even if different arity
+        // Prototype does apply if it has the same name as a rule even if different arity
         kb.clear_rules();
         kb.add_rule_prototype(rule!("f", ["x"; instance!(sym!("Orange")), value!(1)]));
         kb.add_rule(rule!("f", ["x"; instance!(sym!("Orange"))]));

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -1,26 +1,42 @@
 use std::collections::HashMap;
 
-use crate::error::PolarResult;
+use crate::error::ParameterError;
+use crate::error::{PolarError, PolarResult};
 
 pub use super::bindings::Bindings;
 use super::counter::Counter;
 use super::rules::*;
 use super::sources::*;
 use super::terms::*;
+use std::sync::Arc;
 
-/// A map of bindings: variable name → value. The VM uses a stack internally,
-/// but can translate to and from this type.
+enum RuleParamMatch {
+    True,
+    False(String),
+}
+
+impl RuleParamMatch {
+    #[cfg(test)]
+    fn is_true(&self) -> bool {
+        matches!(self, RuleParamMatch::True)
+    }
+}
 
 #[derive(Default)]
 pub struct KnowledgeBase {
+    /// A map of bindings: variable name → value. The VM uses a stack internally,
+    /// but can translate to and from this type.
     pub constants: Bindings,
+    /// Map of class name -> MRO list where the MRO list is a list of class instance IDs
+    mro: HashMap<Symbol, Vec<u64>>,
 
     /// Map from loaded files to the source ID
     pub loaded_files: HashMap<String, u64>,
     /// Map from source code loaded to the filename it was loaded as
     pub loaded_content: HashMap<String, String>,
 
-    pub rules: HashMap<Symbol, GenericRule>,
+    rules: HashMap<Symbol, GenericRule>,
+    rule_prototypes: HashMap<Symbol, Vec<Rule>>,
     pub sources: Sources,
     /// For symbols returned from gensym.
     gensym_counter: Counter,
@@ -33,9 +49,11 @@ impl KnowledgeBase {
     pub fn new() -> Self {
         Self {
             constants: HashMap::new(),
+            mro: HashMap::new(),
             loaded_files: Default::default(),
             loaded_content: Default::default(),
             rules: HashMap::new(),
+            rule_prototypes: HashMap::new(),
             sources: Sources::default(),
             id_counter: Counter::default(),
             gensym_counter: Counter::default(),
@@ -75,9 +93,377 @@ impl KnowledgeBase {
         self.rules.insert(rule.name.clone(), rule);
     }
 
+    pub fn add_rule(&mut self, rule: Rule) {
+        let name = rule.name.clone();
+        let generic_rule = self
+            .rules
+            .entry(name.clone())
+            .or_insert_with(|| GenericRule::new(name, vec![]));
+        generic_rule.add_rule(Arc::new(rule));
+    }
+
+    /// Validate that all rules loaded into the knowledge base are valid based on rule prototypes.
+    pub fn validate_rules(&self) -> PolarResult<()> {
+        for (rule_name, generic_rule) in &self.rules {
+            if let Some(prototypes) = self.rule_prototypes.get(&rule_name) {
+                // If a prototype with the same name exists, then the parameters must match for each rule
+                for rule in generic_rule.rules.values() {
+                    let mut msg = "Must match one of the following rule prototypes:\n".to_owned();
+
+                    let found_match = prototypes
+                        .iter()
+                        .map(|prototype| {
+                            self.rule_params_match(rule.as_ref(), prototype)
+                                .map(|result| (result, prototype))
+                        })
+                        .collect::<PolarResult<Vec<(RuleParamMatch, &Rule)>>>()
+                        .map(|results| {
+                            results.iter().any(|(result, prototype)| match result {
+                                RuleParamMatch::True => true,
+                                RuleParamMatch::False(message) => {
+                                    msg.push_str(&format!(
+                                        "\n{}\n\tFailed to match because: {}\n",
+                                        prototype.to_polar(),
+                                        message
+                                    ));
+                                    false
+                                }
+                            })
+                        })?;
+                    if !found_match {
+                        return Err(self.set_error_context(
+                            &rule.body,
+                            error::ValidationError::InvalidRule {
+                                rule: rule.to_polar(),
+                                msg,
+                            },
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Determine whether the fields of a rule parameter specializer match the fields of a prototype parameter specializer.
+    /// Rule fields match if they are a superset of prototype fields and all field values are equal.
+    // TODO: once field-level specializers are working this should be updated so
+    // that it recursively checks all fields match, rather than checking for
+    // equality
+    fn param_fields_match(&self, prototype_fields: &Dictionary, rule_fields: &Dictionary) -> bool {
+        return prototype_fields
+            .fields
+            .iter()
+            .map(|(k, prototype_value)| {
+                rule_fields
+                    .fields
+                    .get(k)
+                    .map(|rule_value| rule_value == prototype_value)
+                    .unwrap_or_else(|| false)
+            })
+            .all(|v| v);
+    }
+
+    /// Check that a rule parameter that has a pattern specializer matches a prototype parameter that has a pattern specializer.
+    fn check_pattern_param(
+        &self,
+        index: usize,
+        rule_pattern: &Pattern,
+        prototype_pattern: &Pattern,
+    ) -> PolarResult<RuleParamMatch> {
+        Ok(match (prototype_pattern, rule_pattern) {
+            (Pattern::Instance(prototype_instance), Pattern::Instance(rule_instance)) => {
+                // if tags match, all prototype fields must match those in rule fields, otherwise false
+                if prototype_instance.tag == rule_instance.tag {
+                    if self.param_fields_match(
+                        &prototype_instance.fields,
+                        &rule_instance.fields,
+                    ) {
+                        RuleParamMatch::True
+                    } else {
+                        RuleParamMatch::False(format!("Rule specializer {} on parameter {} did not match prototype specializer {} because the specializer fields did not match.", rule_instance.to_polar(), index, prototype_instance.to_polar()))
+                    }
+                // If tags don't match, then rule specializer must be a subclass of prototype specializer
+                } else if let Some(Value::ExternalInstance(ExternalInstance {
+                    instance_id,
+                    ..
+                })) = self
+                    .constants
+                    .get(&prototype_instance.tag)
+                    .map(|t| t.value())
+                {
+                    if let Some(rule_mro) = self.mro.get(&rule_instance.tag) {
+                        if !rule_mro.contains(instance_id) {
+                            RuleParamMatch::False(format!("Rule specializer {} on parameter {} must be a subclass of prototype specializer {}", rule_instance.tag,index, prototype_instance.tag))
+
+                        } else if !self.param_fields_match(
+                                &prototype_instance.fields,
+                                &rule_instance.fields,
+                            )
+                        {
+                            RuleParamMatch::False(format!("Rule specializer {} on parameter {} did not match prototype specializer {} because the specializer fields did not match.", rule_instance.to_polar(), index, prototype_instance.to_polar()))
+                        } else {
+                            RuleParamMatch::True
+                        }
+                    } else {
+                        return Err(error::OperationalError::InvalidState(format!(
+                                "All registered classes must have a registered MRO. Class {} does not have a registered MRO.",
+                                &rule_instance.tag
+                            )).into());
+                    }
+                } else {
+                    unreachable!("Unregistered specializer classes should be caught before this point.");
+                }
+            }
+            (Pattern::Dictionary(prototype_fields), Pattern::Dictionary(rule_fields))
+            | (
+                Pattern::Dictionary(prototype_fields),
+                Pattern::Instance(InstanceLiteral {
+                    tag: _,
+                    fields: rule_fields,
+                }),
+            ) => {
+                if self.param_fields_match(prototype_fields, rule_fields) {
+                    RuleParamMatch::True
+                } else {
+                    RuleParamMatch::False(format!("Specializer mismatch on parameter {}. Rule specializer fields {:#?} do not match prototype specializer fields {:#?}.", index, rule_fields, prototype_fields))
+                }
+            }
+            (
+                Pattern::Instance(InstanceLiteral {
+                    tag,
+                    fields: prototype_fields,
+                }),
+                Pattern::Dictionary(rule_fields),
+            ) if tag == &sym!("Dictionary") => {
+                if self.param_fields_match(prototype_fields, rule_fields) {
+                    RuleParamMatch::True
+                } else {
+                    RuleParamMatch::False(format!("Specializer mismatch on parameter {}. Rule specializer fields {:#?} do not match prototype specializer fields {:#?}.", index, rule_fields, prototype_fields))
+                }
+            }
+            (_, _) => {
+                RuleParamMatch::False(format!("Mismatch on parameter {}. Rule parameter {:#?} does not match prototype parameter {:#?}.", index, prototype_pattern, rule_pattern))
+            }
+        })
+    }
+
+    /// Check that a rule parameter that is a value matches a prototype parameter that is a value
+    fn check_value_param(
+        &self,
+        index: usize,
+        rule_value: &Value,
+        prototype_value: &Value,
+    ) -> PolarResult<RuleParamMatch> {
+        Ok(match (prototype_value, rule_value) {
+            (Value::List(prototype_list), Value::List(rule_list)) => {
+                if prototype_list.iter().all(|t| rule_list.contains(t)) {
+                    RuleParamMatch::True
+                } else {
+                    RuleParamMatch::False(format!(
+                        "Invalid parameter {}. Rule prototype expected list {:#?}, got list {:#?}.",
+                        index, prototype_list, rule_list
+                    ))
+                }
+            }
+            (Value::Dictionary(prototype_fields), Value::Dictionary(rule_fields)) => {
+                if self.param_fields_match(prototype_fields, rule_fields) {
+                    RuleParamMatch::True
+                } else {
+                    RuleParamMatch::False(format!("Invalid parameter {}. Rule prototype expected Dictionary with fields {:#?}, got Dictionary with fields {:#?}", index, prototype_fields, rule_fields
+                        ))
+                }
+            }
+            (_, _) => {
+                if prototype_value == rule_value {
+                    RuleParamMatch::True
+                } else {
+                    RuleParamMatch::False(format!(
+                        "Invalid parameter {}. Rule value {} != prototype value {}",
+                        index, rule_value, prototype_value
+                    ))
+                }
+            }
+        })
+    }
+    /// Check a single rule parameter against a prototype parameter.
+    fn check_param(
+        &self,
+        index: usize,
+        rule_param: &Parameter,
+        prototype_param: &Parameter,
+    ) -> PolarResult<RuleParamMatch> {
+        Ok(
+            match (
+                prototype_param.parameter.value(),
+                prototype_param.specializer.as_ref().map(Term::value),
+                rule_param.parameter.value(),
+                rule_param.specializer.as_ref().map(Term::value),
+            ) {
+                // Rule and prototype both have pattern specializers
+                (
+                    Value::Variable(_),
+                    Some(Value::Pattern(prototype_spec)),
+                    Value::Variable(_),
+                    Some(Value::Pattern(rule_spec)),
+                ) => self.check_pattern_param(index, rule_spec, prototype_spec)?,
+                // Prototype has specializer but rule doesn't
+                (Value::Variable(_), Some(prototype_spec), Value::Variable(_), None) => {
+                    RuleParamMatch::False(format!(
+                        "Invalid rule parameter {}. Rule prototype expected {}",
+                        index,
+                        prototype_spec.to_polar()
+                    ))
+                }
+                // Rule has value or value specializer, prototype has pattern specializer
+                (
+                    Value::Variable(_),
+                    Some(Value::Pattern(prototype_spec)),
+                    Value::Variable(_),
+                    Some(rule_value),
+                )
+                | (Value::Variable(_), Some(Value::Pattern(prototype_spec)), rule_value, None) => {
+                    match prototype_spec {
+                        // Template specializer is an instance pattern
+                        Pattern::Instance(InstanceLiteral {
+                            tag,
+                            fields: prototype_fields,
+                        }) => {
+                            if match rule_value {
+                                Value::String(_) => tag == &sym!("String"),
+                                Value::Number(Numeric::Integer(_)) => tag == &sym!("Integer"),
+                                Value::Number(Numeric::Float(_)) => tag == &sym!("Float"),
+                                Value::Boolean(_) => tag == &sym!("Boolean"),
+                                Value::List(_) => tag == &sym!("List"),
+                                Value::Dictionary(rule_fields) => {
+                                    tag == &sym!("Dictionary")
+                                        && self.param_fields_match(prototype_fields, rule_fields)
+                                }
+                                _ => {
+                                    unreachable!(
+                                        "Value variant {} cannot be a specializer",
+                                        rule_value
+                                    )
+                                }
+                            } {
+                                RuleParamMatch::True
+                            } else {
+                                RuleParamMatch::False(format!(
+                                    "Invalid parameter {}. Rule prototype expected {}, got {}. ",
+                                    index,
+                                    tag.to_polar(),
+                                    rule_value.to_polar()
+                                ))
+                            }
+                        }
+                        // Template specializer is a dictionary pattern
+                        Pattern::Dictionary(prototype_fields) => {
+                            if let Value::Dictionary(rule_fields) = rule_value {
+                                if self.param_fields_match(prototype_fields, rule_fields) {
+                                    RuleParamMatch::True
+                                } else {
+                                    RuleParamMatch::False(format!("Invalid parameter {}. Rule prototype expected Dictionary with fields {}, got dictionary with fields {}.", index, prototype_fields.to_polar(), rule_fields.to_polar()))
+                                }
+                            } else {
+                                RuleParamMatch::False(format!("Invalid parameter {}. Rule prototype expected Dictionary, got {}.", index, rule_value.to_polar()))
+                            }
+                        }
+                    }
+                }
+
+                // Prototype has no specializer
+                (Value::Variable(_), None, _, _) => RuleParamMatch::True,
+                // Rule has value or value specializer, prototype has value specializer |
+                // rule has value, prototype has value
+                (
+                    Value::Variable(_),
+                    Some(prototype_value),
+                    Value::Variable(_),
+                    Some(rule_value),
+                )
+                | (Value::Variable(_), Some(prototype_value), rule_value, None)
+                | (prototype_value, None, rule_value, None) => {
+                    self.check_value_param(index, rule_value, prototype_value)?
+                }
+                _ => RuleParamMatch::False(format!(
+                    "Invalid parameter {}. Rule parameter {} does not match prototype parameter {}",
+                    index,
+                    rule_param.to_polar(),
+                    prototype_param.to_polar()
+                )),
+            },
+        )
+    }
+
+    /// Determine whether a rule matches a rule prototype based on its parameters.
+    fn rule_params_match(&self, rule: &Rule, prototype: &Rule) -> PolarResult<RuleParamMatch> {
+        if rule.params.len() != prototype.params.len() {
+            return Ok(RuleParamMatch::False(format!(
+                "Different number of parameters. Rule has {} parameter(s) but prototype has {}.",
+                rule.params.len(),
+                prototype.params.len()
+            )));
+        }
+        let mut failure_message = "".to_owned();
+        rule.params
+            .iter()
+            .zip(prototype.params.iter())
+            .enumerate()
+            .map(|(i, (rule_param, prototype_param))| {
+                self.check_param(i + 1, rule_param, prototype_param)
+            })
+            .collect::<PolarResult<Vec<RuleParamMatch>>>()
+            .map(|results| {
+                results.iter().all(|r| {
+                    if let RuleParamMatch::False(msg) = r {
+                        failure_message = msg.to_owned();
+                        false
+                    } else {
+                        true
+                    }
+                })
+            })
+            .map(|matched| {
+                if matched {
+                    RuleParamMatch::True
+                } else {
+                    RuleParamMatch::False(failure_message)
+                }
+            })
+    }
+
+    pub fn get_rules(&self) -> &HashMap<Symbol, GenericRule> {
+        &self.rules
+    }
+
+    pub fn get_generic_rule(&self, name: &Symbol) -> Option<&GenericRule> {
+        self.rules.get(name)
+    }
+
+    pub fn add_rule_prototype(&mut self, prototype: Rule) {
+        let name = prototype.name.clone();
+        // get rule prototypes
+        let prototypes = self
+            .rule_prototypes
+            .entry(name.clone())
+            .or_insert_with(|| vec![]);
+        prototypes.push(prototype);
+    }
+
     /// Define a constant variable.
     pub fn constant(&mut self, name: Symbol, value: Term) {
         self.constants.insert(name, value);
+    }
+
+    /// Add the Method Resolution Order (MRO) list for a registered class.
+    /// The `mro` argument is a list of the `instance_id` associated with a registered class.
+    pub fn add_mro(&mut self, name: Symbol, mro: Vec<u64>) -> PolarResult<()> {
+        // Confirm name is a registered class
+        self.constants.get(&name).ok_or_else(|| {
+            ParameterError(format!("Cannot add MRO for unregistered class {}", name))
+        })?;
+        self.mro.insert(name, mro);
+        Ok(())
     }
 
     /// Return true if a constant with the given name has been defined.
@@ -99,6 +485,7 @@ impl KnowledgeBase {
 
     pub fn clear_rules(&mut self) {
         self.rules.clear();
+        self.rule_prototypes.clear();
         self.sources = Sources::default();
         self.inline_queries.clear();
         self.loaded_content.clear();
@@ -189,5 +576,442 @@ impl KnowledgeBase {
             _ => {}
         }
         Ok(())
+    }
+
+    pub fn set_error_context(&self, term: &Term, error: impl Into<PolarError>) -> PolarError {
+        let source = term
+            .get_source_id()
+            .and_then(|id| self.sources.get_source(id));
+        let error: PolarError = error.into();
+        error.set_context(source.as_ref(), Some(term))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::*;
+    #[test]
+    fn test_rule_params_match() {
+        let mut kb = KnowledgeBase::new();
+        kb.constant(
+            sym!("Fruit"),
+            term!(Value::ExternalInstance(ExternalInstance {
+                instance_id: 1,
+                constructor: None,
+                repr: None
+            })),
+        );
+        kb.constant(
+            sym!("Citrus"),
+            term!(Value::ExternalInstance(ExternalInstance {
+                instance_id: 2,
+                constructor: None,
+                repr: None
+            })),
+        );
+        kb.constant(
+            sym!("Orange"),
+            term!(Value::ExternalInstance(ExternalInstance {
+                instance_id: 3,
+                constructor: None,
+                repr: None
+            })),
+        );
+        kb.add_mro(sym!("Fruit"), vec![1]).unwrap();
+        // Citrus is a subclass of Fruit
+        kb.add_mro(sym!("Citrus"), vec![2, 1]).unwrap();
+        // Orange is a subclass of Citrus
+        kb.add_mro(sym!("Orange"), vec![3, 2, 1]).unwrap();
+
+        // BOTH PATTERN SPEC
+        // rule: f(x: Foo), prototype: f(x: Foo) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; instance!(sym!("Fruit"))]),
+                &rule!("f", ["x"; instance!(sym!("Fruit"))])
+            )
+            .unwrap()
+            .is_true());
+
+        // rule: f(x: Foo), prototype: f(x: Bar) => FAIL if Foo is not subclass of Bar
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; instance!(sym!("Fruit"))]),
+                &rule!("f", ["x"; instance!(sym!("Citrus"))])
+            )
+            .unwrap()
+            .is_true());
+
+        // rule: f(x: Foo), prototype: f(x: Bar) => PASS if Foo is subclass of Bar
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; instance!(sym!("Citrus"))]),
+                &rule!("f", ["x"; instance!(sym!("Fruit"))])
+            )
+            .unwrap()
+            .is_true());
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; instance!(sym!("Orange"))]),
+                &rule!("f", ["x"; instance!(sym!("Fruit"))])
+            )
+            .unwrap()
+            .is_true());
+
+        // rule: f(x: Foo), prototype: f(x: {id: 1}) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; instance!(sym!("Foo"))]),
+                &rule!("f", ["x"; btreemap! {sym!("id") => term!(1)}])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: Foo{id: 1}), prototype: f(x: {id: 1}) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!(
+                    "f",
+                    ["x"; instance!(sym!("Foo"), btreemap! {sym!("id") => term!(1)})]
+                ),
+                &rule!("f", ["x"; btreemap! {sym!("id") => term!(1)}])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: {id: 1}), prototype: f(x: Foo{id: 1}) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; btreemap! {sym!("id") => term!(1)}]),
+                &rule!(
+                    "f",
+                    ["x"; instance!(sym!("Foo"), btreemap! {sym!("id") => term!(1)})]
+                )
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: {id: 1}), prototype: f(x: {id: 1}) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; btreemap! {sym!("id") => term!(1)}]),
+                &rule!("f", ["x"; btreemap! {sym!("id") => term!(1)}])
+            )
+            .unwrap()
+            .is_true());
+
+        // RULE VALUE SPEC, TEMPLATE PATTERN SPEC
+        // rule: f(x: 6), prototype: f(x: Integer) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!(6)]),
+                &rule!("f", ["x"; instance!(sym!("Integer"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: 6), prototype: f(x: Foo) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!(6)]),
+                &rule!("f", ["x"; instance!(sym!("Foo"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: 6.0), prototype: f(x: Float) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!(6.0)]),
+                &rule!("f", ["x"; instance!(sym!("Float"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: 6.0), prototype: f(x: Foo) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!(6.0)]),
+                &rule!("f", ["x"; instance!(sym!("Foo"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: "hi"), prototype: f(x: String) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!("hi")]),
+                &rule!("f", ["x"; instance!(sym!("String"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: "hi"), prototype: f(x: Foo) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!("hi")]),
+                &rule!("f", ["x"; instance!(sym!("Foo"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: true), prototype: f(x: Boolean) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!(true)]),
+                &rule!("f", ["x"; instance!(sym!("Boolean"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: true), prototype: f(x: Foo) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!(true)]),
+                &rule!("f", ["x"; instance!(sym!("Foo"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: [1, 2]), prototype: f(x: List) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!([1, 2])]),
+                &rule!("f", ["x"; instance!(sym!("List"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: [1, 2]), prototype: f(x: Foo) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!([1, 2])]),
+                &rule!("f", ["x"; instance!(sym!("Foo"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: {id: 1}), prototype: f(x: Dictionary) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; btreemap! {sym!("id") => term!(1)}]),
+                &rule!("f", ["x"; instance!(sym!("Dictionary"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: {id: 1}), prototype: f(x: Foo) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; btreemap! {sym!("id") => term!(1)}]),
+                &rule!("f", ["x"; instance!(sym!("Foo"))])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: {id: 1}), prototype: f(x: Dictionary{id: 1}) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; btreemap! {sym!("id") => term!(1)}]),
+                &rule!(
+                    "f",
+                    ["x"; instance!(sym!("Dictionary"), btreemap! {sym!("id") => term!(1)})]
+                )
+            )
+            .unwrap()
+            .is_true());
+
+        // RULE PATTERN SPEC, TEMPLATE VALUE SPEC
+        // always => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; btreemap!(sym!("1") => term!(1))]),
+                &rule!("f", ["x"; value!(1)])
+            )
+            .unwrap()
+            .is_true());
+
+        // BOTH VALUE SPEC
+        // Integer, String, Boolean: must be equal
+        // rule: f(x: 1), prototype: f(x: 1) => PASS
+        assert!(kb
+            .rule_params_match(&rule!("f", ["x"; value!(1)]), &rule!("f", ["x"; value!(1)]))
+            .unwrap()
+            .is_true());
+        // rule: f(x: 1), prototype: f(x: 2) => FAIL
+        assert!(!kb
+            .rule_params_match(&rule!("f", ["x"; value!(1)]), &rule!("f", ["x"; value!(2)]))
+            .unwrap()
+            .is_true());
+        // rule: f(x: 1.0), prototype: f(x: 1.0) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!(1.0)]),
+                &rule!("f", ["x"; value!(1.0)])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: 1.0), prototype: f(x: 2.0) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!(1.0)]),
+                &rule!("f", ["x"; value!(2.0)])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: "hi"), prototype: f(x: "hi") => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!("hi")]),
+                &rule!("f", ["x"; value!("hi")])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: "hi"), prototype: f(x: "hello") => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!("hi")]),
+                &rule!("f", ["x"; value!("hello")])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: true), prototype: f(x: true) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!(true)]),
+                &rule!("f", ["x"; value!(true)])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: true), prototype: f(x: false) => PASS
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!(true)]),
+                &rule!("f", ["x"; value!(false)])
+            )
+            .unwrap()
+            .is_true());
+        // List: rule must be more specific than (superset of) prototype
+        // rule: f(x: [1,2,3]), prototype: f(x: [1,2]) => PASS
+        // TODO: I'm not sure this logic actually makes sense--it feels like
+        // they should have to be an exact match
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!([1, 2, 3])]),
+                &rule!("f", ["x"; value!([1, 2])])
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: [1,2]), prototype: f(x: [1,2,3]) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; value!([1, 2])]),
+                &rule!("f", ["x"; value!([1, 2, 3])])
+            )
+            .unwrap()
+            .is_true());
+        // Dict: rule must be more specific than (superset of) prototype
+        // rule: f(x: {"id": 1, "name": "Dave"}), prototype: f(x: {"id": 1}) => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!(
+                    "f",
+                    ["x"; btreemap! {sym!("id") => term!(1), sym!("name") => term!(sym!("Dave"))}]
+                ),
+                &rule!("f", ["x"; btreemap! {sym!("id") => term!(1)}]),
+            )
+            .unwrap()
+            .is_true());
+        // rule: f(x: {"id": 1}), prototype: f(x: {"id": 1, "name": "Dave"}) => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", ["x"; btreemap! {sym!("id") => term!(1)}]),
+                &rule!(
+                    "f",
+                    ["x"; btreemap! {sym!("id") => term!(1), sym!("name") => term!(sym!("Dave"))}]
+                )
+            )
+            .unwrap()
+            .is_true());
+
+        // RULE None SPEC TEMPLATE Some SPEC
+        // always => FAIL
+        assert!(!kb
+            .rule_params_match(
+                &rule!("f", [sym!("x")]),
+                &rule!("f", ["x"; instance!(sym!("Foo"))])
+            )
+            .unwrap()
+            .is_true());
+
+        // RULE Some SPEC TEMPLATE None SPEC
+        // always => PASS
+        assert!(kb
+            .rule_params_match(
+                &rule!("f", ["x"; instance!(sym!("Foo"))]),
+                &rule!("f", [sym!("x")]),
+            )
+            .unwrap()
+            .is_true());
+    }
+
+    #[test]
+    fn test_validate_rules() {
+        let mut kb = KnowledgeBase::new();
+        kb.constant(
+            sym!("Fruit"),
+            term!(Value::ExternalInstance(ExternalInstance {
+                instance_id: 1,
+                constructor: None,
+                repr: None
+            })),
+        );
+        kb.constant(
+            sym!("Citrus"),
+            term!(Value::ExternalInstance(ExternalInstance {
+                instance_id: 2,
+                constructor: None,
+                repr: None
+            })),
+        );
+        kb.constant(
+            sym!("Orange"),
+            term!(Value::ExternalInstance(ExternalInstance {
+                instance_id: 3,
+                constructor: None,
+                repr: None
+            })),
+        );
+        kb.add_mro(sym!("Fruit"), vec![1]).unwrap();
+        // Citrus is a subclass of Fruit
+        kb.add_mro(sym!("Citrus"), vec![2, 1]).unwrap();
+        // Orange is a subclass of Citrus
+        kb.add_mro(sym!("Orange"), vec![3, 2, 1]).unwrap();
+
+        // Template applies if it has the same name as a rule
+        kb.add_rule_prototype(rule!("f", ["x"; instance!(sym!("Orange"))]));
+        kb.add_rule(rule!("f", ["x"; instance!(sym!("Orange"))]));
+        kb.add_rule(rule!("f", ["x"; instance!(sym!("Fruit"))]));
+
+        assert!(matches!(
+            kb.validate_rules().err().unwrap(),
+            PolarError {
+                kind: ErrorKind::Validation(ValidationError::InvalidRule { .. }),
+                ..
+            }
+        ));
+
+        // Template does not apply if it doesn't have the same name as a rule
+        kb.clear_rules();
+        kb.add_rule_prototype(rule!("f", ["x"; instance!(sym!("Orange"))]));
+        kb.add_rule(rule!("f", ["x"; instance!(sym!("Orange"))]));
+        kb.add_rule(rule!("g", ["x"; instance!(sym!("Fruit"))]));
+
+        kb.validate_rules().unwrap();
+
+        // Template does apply if it has the same name as a rule even if different arity
+        kb.clear_rules();
+        kb.add_rule_prototype(rule!("f", ["x"; instance!(sym!("Orange")), value!(1)]));
+        kb.add_rule(rule!("f", ["x"; instance!(sym!("Orange"))]));
+
+        assert!(matches!(
+            kb.validate_rules().err().unwrap(),
+            PolarError {
+                kind: ErrorKind::Validation(ValidationError::InvalidRule { .. }),
+                ..
+            }
+        ));
+        // Multiple templates can exist for the same name but only one needs to match
+        kb.clear_rules();
+        kb.add_rule_prototype(rule!("f", ["x"; instance!(sym!("Orange"))]));
+        kb.add_rule_prototype(rule!("f", ["x"; instance!(sym!("Orange")), value!(1)]));
+        kb.add_rule_prototype(rule!("f", ["x"; instance!(sym!("Fruit"))]));
+        kb.add_rule(rule!("f", ["x"; instance!(sym!("Fruit"))]));
     }
 }

--- a/polar-core/src/lexer.rs
+++ b/polar-core/src/lexer.rs
@@ -89,6 +89,7 @@ pub enum Token {
     Or,        // or
     Not,       // not
     Matches,   // matches
+    Type,      // type
 }
 
 impl ToString for Token {
@@ -138,6 +139,7 @@ impl ToString for Token {
             Token::Or => "or".to_owned(),           // or
             Token::Not => "not".to_owned(),         // not
             Token::Matches => "matches".to_owned(), // matches
+            Token::Type => "type".to_owned(),       // type
         }
     }
 }
@@ -245,6 +247,8 @@ impl<'input> Lexer<'input> {
             Some(Ok((start, Token::Not, last + 1)))
         } else if &self.buf == "matches" {
             Some(Ok((start, Token::Matches, last + 1)))
+        } else if &self.buf == "type" {
+            Some(Ok((start, Token::Type, last + 1)))
         } else if &self.buf == "mod" {
             Some(Ok((start, Token::Mod, last + 1)))
         } else if &self.buf == "rem" {

--- a/polar-core/src/parser.rs
+++ b/polar-core/src/parser.rs
@@ -21,6 +21,7 @@ use super::terms::*;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Line {
     Rule(Rule),
+    RuleTemplate(Rule),
     Query(Term),
 }
 
@@ -211,6 +212,19 @@ mod tests {
         let line = parse_lines(f);
 
         assert_eq!(line[0], Line::Query(term!(call!("f", [1]))));
+
+        let prototype = r#"type f(x: String);"#;
+        let line = parse_lines(prototype);
+        assert_eq!(
+            line[0],
+            Line::RuleTemplate(rule!("f", ["x"; value!(instance!("String"))]))
+        );
+    }
+
+    #[test]
+    fn test_rule_prototype_error() {
+        let prototype = r#"type f(x: String) if x = "bad";"#;
+        super::parse_lines(0, prototype).expect_err("parse error");
     }
 
     #[test]

--- a/polar-core/src/parser.rs
+++ b/polar-core/src/parser.rs
@@ -21,7 +21,7 @@ use super::terms::*;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Line {
     Rule(Rule),
-    RuleTemplate(Rule),
+    RulePrototype(Rule),
     Query(Term),
 }
 
@@ -217,7 +217,7 @@ mod tests {
         let line = parse_lines(prototype);
         assert_eq!(
             line[0],
-            Line::RuleTemplate(rule!("f", ["x"; value!(instance!("String"))]))
+            Line::RulePrototype(rule!("f", ["x"; value!(instance!("String"))]))
         );
     }
 

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -62,6 +62,7 @@ extern {
         "or" => lexer::Token::Or,           // or
         "not" => lexer::Token::Not,         // not
         "matches" => lexer::Token::Matches, // matches
+        "type" => lexer::Token::Type        // type
     }
 }
 
@@ -254,7 +255,7 @@ LogExp: Term = {
     <ExpectLogical<Exp1<"Term">>>
 }
 
-// `ValueOrLogic` is used to do some simple parse-time 
+// `ValueOrLogic` is used to do some simple parse-time
 // checks for correctly formed expressions. For example,
 // `x in y` is a logical expression, so it does
 // not make sense to compare the result with a value.
@@ -635,10 +636,20 @@ Rule: Rule = {
     }
 }
 
+RuleTemplate: Rule = {
+    "type" <start_head:@L> <head:RuleHead> <start:@L> <end:@R> ";" => {
+        let (name, params) = head;
+        let op = Operation{operator: Operator::And, args: vec![]};
+        let body = Term::new_from_parser(src_id, start, end, Value::Expression(op));
+        Rule::new_from_parser(src_id, start_head, start, name, params, body)
+    }
+}
+
 pub(crate) Rules: Vec<Rule> = <Rule*>;
 
 Line: Line = {
     <Rule> => Line::Rule(<>),
+    <RuleTemplate> => Line::RuleTemplate(<>),
     "?=" <TermExp> ";" => Line::Query(<>),
 }
 

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -636,7 +636,7 @@ Rule: Rule = {
     }
 }
 
-RuleTemplate: Rule = {
+RulePrototype: Rule = {
     "type" <start_head:@L> <head:RuleHead> <start:@L> <end:@R> ";" => {
         let (name, params) = head;
         let op = Operation{operator: Operator::And, args: vec![]};
@@ -649,7 +649,7 @@ pub(crate) Rules: Vec<Rule> = <Rule*>;
 
 Line: Line = {
     <Rule> => Line::Rule(<>),
-    <RuleTemplate> => Line::RuleTemplate(<>),
+    <RulePrototype> => Line::RulePrototype(<>),
     "?=" <TermExp> ";" => Line::Query(<>),
 }
 

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -6,7 +6,6 @@ use super::messages::*;
 use super::parser;
 use super::rewrites::*;
 use super::roles_validation::{validate_roles_config, VALIDATE_ROLES_CONFIG_RESOURCES};
-use super::rules::*;
 use super::runnable::Runnable;
 use super::sources::*;
 use super::terms::*;
@@ -182,19 +181,37 @@ impl Polar {
                         let mut rule_warnings = check_singletons(&rule, &*kb)?;
                         warnings.append(&mut rule_warnings);
                         let rule = rewrite_rule(rule, kb);
-
-                        let name = rule.name.clone();
-                        let generic_rule = kb
-                            .rules
-                            .entry(name.clone())
-                            .or_insert_with(|| GenericRule::new(name, vec![]));
-                        generic_rule.add_rule(Arc::new(rule));
+                        kb.add_rule(rule);
                     }
                     parser::Line::Query(term) => {
                         kb.inline_queries.push(term);
                     }
+                    parser::Line::RuleTemplate(prototype) => {
+                        // make sure prototype doesn't have anything that needs to be rewritten in the head
+                        let prototype = rewrite_rule(prototype, kb);
+                        if !matches!(
+                            prototype.body.value(),
+                            Value::Expression(
+                                Operation {
+                                    operator: Operator::And,
+                                    args
+                                }
+                            ) if args.is_empty()
+                        ) {
+                            return Err(kb.set_error_context(
+                                &prototype.body,
+                                error::ValidationError::InvalidPrototype {
+                                    prototype: prototype.to_polar(),
+                                    msg: "\nPrototypes cannot contain dot lookups.".to_owned(),
+                                },
+                            ));
+                        }
+                        kb.add_rule_prototype(prototype);
+                    }
                 }
             }
+            // check rules are valid against rule prototypes
+            kb.validate_rules()?;
             Ok(warnings)
         }
 
@@ -273,6 +290,10 @@ impl Polar {
         self.kb.write().unwrap().constant(name, value)
     }
 
+    pub fn register_mro(&self, name: Symbol, mro: Vec<u64>) -> PolarResult<()> {
+        self.kb.write().unwrap().add_mro(name, mro)
+    }
+
     pub fn next_message(&self) -> Option<Message> {
         self.messages.next()
     }
@@ -296,7 +317,7 @@ impl Polar {
     }
 
     pub fn validate_roles_config(&self, results: Vec<Vec<ResultEvent>>) -> PolarResult<()> {
-        validate_roles_config(&self.kb.read().unwrap().rules, results)
+        validate_roles_config(self.kb.read().unwrap().get_rules(), results)
     }
 
     pub fn build_filter_plan(

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -186,7 +186,7 @@ impl Polar {
                     parser::Line::Query(term) => {
                         kb.inline_queries.push(term);
                     }
-                    parser::Line::RuleTemplate(prototype) => {
+                    parser::Line::RulePrototype(prototype) => {
                         // make sure prototype doesn't have anything that needs to be rewritten in the head
                         let prototype = rewrite_rule(prototype, kb);
                         if !matches!(

--- a/polar-core/src/rules.rs
+++ b/polar-core/src/rules.rs
@@ -225,7 +225,7 @@ mod tests {
         polar.load_str(r#"f(1, 3, {c: "z"});"#).unwrap();
 
         let kb = polar.kb.read().unwrap();
-        let generic_rule = kb.rules.get(&sym!("f")).unwrap();
+        let generic_rule = kb.get_generic_rule(&sym!("f")).unwrap();
         let index = &generic_rule.index;
         assert!(index.rules.is_empty());
 

--- a/polar-core/src/terms.rs
+++ b/polar-core/src/terms.rs
@@ -3,6 +3,7 @@ pub use super::{error, formatting::ToPolarString};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashSet};
+use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -207,6 +208,12 @@ impl Value {
                 args.iter().all(|t| t.is_ground())
             }
         }
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -1478,7 +1478,7 @@ impl PolarVirtualMachine {
     /// Create a choice over the applicable rules.
     fn query_for_predicate(&mut self, predicate: Call) -> PolarResult<()> {
         assert!(predicate.kwargs.is_none());
-        let goals = match self.kb.read().unwrap().rules.get(&predicate.name) {
+        let goals = match self.kb.read().unwrap().get_generic_rule(&predicate.name) {
             None => vec![Goal::Backtrack],
             Some(generic_rule) => {
                 assert_eq!(generic_rule.name, predicate.name);
@@ -2838,9 +2838,7 @@ impl PolarVirtualMachine {
         term: &Term,
         error: impl Into<error::PolarError>,
     ) -> error::PolarError {
-        let source = self.source(term);
-        let error: error::PolarError = error.into();
-        error.set_context(source.as_ref(), Some(term))
+        self.kb.read().unwrap().set_error_context(term, error)
     }
 
     fn type_error(&self, term: &Term, msg: String) -> error::PolarError {
@@ -3094,7 +3092,7 @@ mod tests {
         let rule = GenericRule::new(sym!("f"), vec![Arc::new(f1), Arc::new(f2)]);
 
         let mut kb = KnowledgeBase::new();
-        kb.rules.insert(rule.name.clone(), rule);
+        kb.add_generic_rule(rule);
 
         let goal = query!(op!(And));
 

--- a/polar-wasm-api/src/errors.rs
+++ b/polar-wasm-api/src/errors.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::JsValue;
 
 use polar_core::error::{
     ErrorKind, FormattedPolarError, OperationalError, ParameterError, ParseError, PolarError,
-    RolesValidationError, RuntimeError,
+    RolesValidationError, RuntimeError, ValidationError,
 };
 
 pub struct Error {
@@ -23,6 +23,7 @@ fn kind(err: &PolarError) -> String {
     use OperationalError::*;
     use ParseError::*;
     use RuntimeError::*;
+    use ValidationError::*;
     match err.kind {
         Parse(IntegerOverflow { .. }) => "ParseError::IntegerOverflow",
         Parse(InvalidTokenCharacter { .. }) => "ParseError::InvalidTokenCharacter",
@@ -50,6 +51,8 @@ fn kind(err: &PolarError) -> String {
         Operational(InvalidState(..)) => "OperationalError::InvalidState",
         Parameter(ParameterError(..)) => "ParameterError::ParameterError",
         RolesValidation(RolesValidationError(..)) => "RolesValidationError::RolesValidationError",
+        Validation(InvalidRule { .. }) => "ValidationError::InvalidRule",
+        Validation(InvalidPrototype { .. }) => "ValidationError::InvalidPrototype",
     }
     .to_owned()
 }


### PR DESCRIPTION
Rule prototypes provide a way to constrain how certain rules must be defined. 

A rule prototype looks like this:
```python
type f(_a: Foo, _b: Bar);
```
It consists of the keyword `type` followed by what looks like a normal Polar rule head.
With the above rule prototype defined, any rule named `f` would have to match the prototype in order to be valid.

A rule matches a prototype if it has the same **arity** (number of parameters) as the prototype, and if each parameter matches the corresponding prototype parameter. This logic is defined in `validate_rules` in `kb.rs`.

A rule parameter matches a prototype parameter according to `isa` or `matches` logic. This logic is defined in `rule_params_match` in `kb.rs`.

Multiple prototypes can be defined for a given rule name.

When a rule fails to match any defined prototype, the user receives an error message that looks like:

```
polar.exceptions.ValidationError: Invalid rule: f(_x: Bad{}); Must match one of the following rule prototypes:
E           
E           f(_x: Integer{});
E               Failed to match because: Rule specializer Bad on parameter 1 must be a subclass of prototype specializer Integer
E           
E           f(_x: Foo{});
E               Failed to match because: Rule specializer Bad on parameter 1 must be a subclass of prototype specializer Foo
E           
E           f(_x: Foo{}, _y: Bar{});
E               Failed to match because: Different number of parameters. Rule has 1 parameter(s) but prototype has 2.
E            at line 1, column 11
E               Get help with Oso from our engineers: https://help.osohq.com/error/ValidationError
```

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
- [x] Standardize naming of rule prototypes
- [x] Test `validate_rules`