### PR TITLE
Improve grounding performance for dot operations

### DIFF
--- a/languages/python/oso/polar/exceptions.py
+++ b/languages/python/oso/polar/exceptions.py
@@ -16,7 +16,7 @@ class OsoError(Exception):
     @classmethod
     def add_get_help(cls, message):
         return (
-            message
+            str(message)
             + f"\n\tGet help with Oso from our engineers: https://help.osohq.com/error/{cls.__name__}"
         )
 

--- a/languages/python/oso/setup.py
+++ b/languages/python/oso/setup.py
@@ -39,7 +39,7 @@ def get_version(rel_path):
 setup(
     name="oso",
     version=get_version("oso/oso.py"),
-    description="oso is an open source policy engine for authorization that’s embedded in your application",
+    description="oso is an open source policy engine for authorization that's embedded in your application",
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Oso Security, Inc.",

--- a/polar-core/benches/benchmarks/partial.rs
+++ b/polar-core/benches/benchmarks/partial.rs
@@ -61,7 +61,7 @@ pub fn partial_and(c: &mut Criterion) {
 /// a partial that calls 5 rules and does 5 field comparisons.
 pub fn partial_rule_depth(c: &mut Criterion) {
     let mut group = c.benchmark_group("partial_rule_depth");
-    for n in &[1, 5, 10, 20, 40] {
+    for n in &[1, 5, 10, 20, 40, 80, 100] {
         group.bench_function(BenchmarkId::from_parameter(format!("{}", n)), |b| {
             b.iter_batched_ref(
                 || {

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -1878,7 +1878,8 @@ impl PolarVirtualMachine {
 
                 // Translate `.(object, field, value)` → `value = .(object, field)`.
                 let dot2 = op!(Dot, object.clone(), field.clone());
-                self.add_constraint(&op!(Unify, value.clone(), dot2.into_term()).into_term())?;
+                let value = self.deep_deref(value);
+                self.add_constraint(&op!(Unify, value, dot2.into_term()).into_term())?;
             }
             _ => {
                 return Err(self.type_error(


### PR DESCRIPTION
Makes `partial_and` and `partial_rule_filter` benchmarks faster than previously. This fix works by rewriting dot operations (only) as:

```
_value_3 = 2 and _value_1.a = _value_2 and _value_2.b = _value_3
```

compared to the previous rewriting of

```
_value_1.a = _value_2 and _value_2.b = _value_3 and _value_3 = 2
```

This improves performance for partials because grounding is no longer required for a dot operation like `x.foo = 2`. Instead, the constraint added is `x.foo = 2` (compared with adding `x.foo = _value_1` and then grounding later when `_value_1 = 2` is processed). This is a special case, but seems worth it in my opinion because these types of operations are probably the most common.

- [ ] Rewrite code is pretty challenging to work with, I think it may be worth a bit of a cleanup while I'm looking at it.
- [ ] Also needs a test