### PR TITLE
Minor docs styling fixes

### DIFF
--- a/docs/themes/oso-tailwind/assets/css/site.css
+++ b/docs/themes/oso-tailwind/assets/css/site.css
@@ -167,3 +167,18 @@
     width: 1rem;
     height: 1rem;
 }
+
+/* Make anchor links behave properly with a fixed header */
+.prose h1::before,
+.prose h2::before,
+.prose h3::before,
+.prose h4::before,
+.prose h5::before,
+.prose h6::before {
+  display: block;
+  content: " ";
+  margin-top: -130px;
+  height: 130px;
+  visibility: hidden;
+  pointer-events: none;
+}

--- a/docs/themes/oso-tailwind/assets/css/styles.css
+++ b/docs/themes/oso-tailwind/assets/css/styles.css
@@ -179,17 +179,3 @@ pre code {
   pointer-events: none;
   background-color: rgb(167, 243, 208);
 }
-
-.prose h1::before,
-.prose h2::before,
-.prose h3::before,
-.prose h4::before,
-.prose h5::before,
-.prose h6::before {
-  display: block;
-  content: " ";
-  margin-top: -130px;
-  height: 130px;
-  visibility: hidden;
-  pointer-events: none;
-}

--- a/docs/themes/oso-tailwind/assets/css/styles.css
+++ b/docs/themes/oso-tailwind/assets/css/styles.css
@@ -31,7 +31,7 @@ button > * {
     }
 
     .tooltip .tooltip-text {
-        @apply 
+        @apply
             invisible
             p-2 mt-16
             absolute z-50 inline-block
@@ -178,4 +178,18 @@ pre code {
   pointer: default;
   pointer-events: none;
   background-color: rgb(167, 243, 208);
+}
+
+.prose h1::before,
+.prose h2::before,
+.prose h3::before,
+.prose h4::before,
+.prose h5::before,
+.prose h6::before {
+  display: block;
+  content: " ";
+  margin-top: -130px;
+  height: 130px;
+  visibility: hidden;
+  pointer-events: none;
 }

--- a/docs/themes/oso-tailwind/layouts/_default/list.html
+++ b/docs/themes/oso-tailwind/layouts/_default/list.html
@@ -42,7 +42,7 @@
       <h2 class="text-xl font-semibold text-primary-dark pb-4">
         Choose your language:
       </h2>
-      <div class="grid mx-6 pb-4 grid-cols-3 gap-8 content-evenly">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8 content-evenly">
         {{ partial "language-chooser.html" . }}
       </div>
     </div>

--- a/docs/themes/oso-tailwind/layouts/_default/single.html
+++ b/docs/themes/oso-tailwind/layouts/_default/single.html
@@ -35,7 +35,7 @@
       <h2 class="text-xl font-semibold text-primary-dark pb-4">
         Choose your language:
       </h2>
-      <div class="grid mx-6 grid-cols-3  gap-8 content-evenly">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8 content-evenly">
         {{ partial "language-chooser.html" .  }}
       </div>
     </div>

--- a/docs/themes/oso-tailwind/layouts/partials/header.html
+++ b/docs/themes/oso-tailwind/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <nav id="header"
-    class="static pin-t lg:sticky lg:z-50  top-0 pin-t h-8 w-full max-w-8xl mx-auto bg-primary flex flex-none items-center">
+    class="static pin-t hidden md:flex lg:sticky lg:z-50  top-0 pin-t h-8 w-full max-w-8xl mx-auto bg-primary flex-none items-center">
     <div id="header-page-title" class="flex-grow">
         <p class="text-white font-base text-sm  text-center truncate">
             Want to get started? Jump into <a class="underline" href="https://join-slack.osohq.com">our Slack</a> and an

--- a/docs/themes/oso-tailwind/layouts/partials/sidebar.html
+++ b/docs/themes/oso-tailwind/layouts/partials/sidebar.html
@@ -11,11 +11,11 @@
 <div id="sidebar-content"
     class="fixed z-40 inset-0 flex-none h-full bg-primary-dark bg-opacity-25 w-full lg:bg-white lg:static lg:h-auto lg:overflow-y-visible lg:pt-0 lg:w-72 hidden lg:block">
     <aside id="nav-wrapper"
-        class="h-full overflow-y-auto  overscroll-y-contain scrolling-touch lg:h-auto lg:block lg:relative lg:sticky lg:bg-transparent overflow-hidden lg:top-20 bg-white w-1/2 lg:w-full">
+        class="h-full overflow-y-auto  overscroll-y-contain scrolling-touch lg:h-auto lg:block lg:relative lg:sticky lg:bg-transparent overflow-hidden lg:top-20 bg-white w-3/4 lg:w-full">
         <nav id="sidebar-inner"
-            class="overflow-y-auto overscroll-y-contain font-medium text-base sm:px-3 xl:px-5 lg:text-sm pb-10 lg:pt-6 lg:pb-14 sticky?lg:h-(screen-20)">
+            class="overflow-y-auto overscroll-y-contain font-medium text-base sm:px-3 xl:px-5 lg:text-sm pb-10 pt-5 lg:pt-6 lg:pb-14 sticky?lg:h-(screen-20)">
             <div
-                class="h-full overflow-y-auto scrolling-touch lg:h-auto lg:block lg:relative lg:sticky lg:bg-transparent overflow-hidden bg-white mr-24 lg:mr-0 sticky?lg:h-(screen-20)">
+                class="h-full overflow-y-auto scrolling-touch lg:h-auto lg:block lg:relative lg:sticky lg:bg-transparent overflow-hidden bg-white mr-1 lg:mr-0 sticky?lg:h-(screen-20)">
                 <div class="search-button-div">
                     <button class="search-button" onclick="searchButtonClick(event)">
                         <div class="search-inner-button">
@@ -59,7 +59,7 @@
     {{ else }}
     hidden
     {{ end }}
-    {{ if eq $level 0 }}font-bold py-2{{else}}font-normal{{end}} 
+    {{ if eq $level 0 }}font-bold py-2{{else}}font-normal{{end}}
     {{ if $isCurrent}}active text-primary{{else}} text-black{{ end }}
 ">
     <a class="flex items-center px-3 hover:text-gray-900 transition-colors duration-200 mb-2" href="{{.RelPermalink}}">
@@ -100,7 +100,7 @@
         {{ else }}
         hidden
         {{ end }}
-        {{end}} 
+        {{end}}
         {{ if eq $level 0 }} font-bold {{ else }} font-normal {{ end}}
         text-black pl-2">
     <a class=" flex items-center px-3 transition-colors duration-200 mb-2" href="{{ .RelPermalink}}">


### PR DESCRIPTION
- Fix anchor linking in docs (we use a fixed header so the headers are covered when you click on a link like `#getting-started`)
- Fix the display of the language picker on mobile
- Fix the modal menu on mobile

Before:
<img width="200" alt="Screen Shot 2021-08-17 at 4 29 45 PM" src="https://user-images.githubusercontent.com/3156043/129799679-8ec3d23c-9fac-49ad-b410-7f6fc34b9711.png">  <img width="200" alt="Screen Shot 2021-08-17 at 4 29 45 PM" src="https://user-images.githubusercontent.com/3156043/129799777-bc0937d3-37f0-45db-a48a-2d4fc9580c75.PNG">

After:
<img width="200" alt="Screen Shot 2021-08-17 at 4 32 44 PM" src="https://user-images.githubusercontent.com/3156043/129799927-00e2b0ff-cb78-44e1-ad0a-a9238c280413.png">  <img width="200" alt="Screen Shot 2021-08-17 at 4 29 14 PM" src="https://user-images.githubusercontent.com/3156043/129799947-883c5ba3-b1cb-4faa-8a27-e03d540557e1.png">
