### PR TITLE
fields can be reserved words

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -48,6 +48,7 @@ Link to [relevant documentation section]().
 #### Other bugs & improvements
 
 - The debugger can now break on rule matches.
-- Reserved words can be used as field and method names in dictionaries and objects.
+- Polar reserved words (eg. `type`, `if`, `debug`) can be used as field and method names in
+  dictionaries and objects.
 
 #### TODO: enforcement changelog, if we decide to release it

--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -48,7 +48,7 @@ Link to [relevant documentation section]().
 #### Other bugs & improvements
 
 - The debugger can now break on rule matches.
-- Polar reserved words (eg. `type`, `if`, `debug`) can be used as field and method names in
+- Polar reserved words (e.g. `type`, `if`, `debug`) can be used as field and method names in
   dictionaries and objects.
 
 #### TODO: enforcement changelog, if we decide to release it

--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -48,5 +48,6 @@ Link to [relevant documentation section]().
 #### Other bugs & improvements
 
 - The debugger can now break on rule matches.
+- Reserved words can be used as field and method names in dictionaries and objects.
 
 #### TODO: enforcement changelog, if we decide to release it

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -66,6 +66,22 @@ extern {
     }
 }
 
+ResWord: String = {
+  "type" => "type".to_owned(),
+  "cut" => "cut".to_owned(),
+  "debug" => "debug".to_owned(),
+  "print" => "print".to_owned(),
+  "in" => "in".to_owned(),
+  "forall" => "forall".to_owned(),
+  "if" => "if".to_owned(),
+  "and" => "and".to_owned(),
+  "or" => "or".to_owned(),
+  "not" => "not".to_owned(),
+  "new" => "new".to_owned(),
+  "matches" => "matches".to_owned(),
+}
+
+
 
 // ****** Values ******* //
 
@@ -98,6 +114,11 @@ Boolean: Value = <b:"Boolean"> => {
 
 Name: Symbol = <s:"Symbol"> => s;
 
+ResName: Symbol = {
+  <Name>,
+  <w:ResWord> => Symbol(w),
+}
+
 Variable: Value  = <n:Name> => {
     Value::Variable(n)
 };
@@ -126,6 +147,30 @@ Call: Value = {
     }
 };
 
+DotCall: Value = {
+  <Call>,
+  // No args.
+  <w:ResWord> "("  ")" => {
+      let args = vec![];
+      let kwargs = None;
+      let name = Symbol(w);
+      Value::Call(Call{name, args, kwargs})
+  },
+  // Positional args only.
+  <w:ResWord> "(" <mut args:(<ValExp> ",")*> <arg:ValExp> ")" => {
+      args.push(arg);
+      let kwargs = None;
+      let name = Symbol(w);
+      Value::Call(Call{name, args, kwargs})
+  },
+  // Positional args + kwargs.
+  <w:ResWord> "(" <mut args:(<ValExp> ",")*> <fields:(<Fields<ValExp>>)>")" => {
+      let kwargs = Some(fields);
+      let name = Symbol(w);
+      Value::Call(Call{name, args, kwargs})
+  },
+}
+
 New: Value = {
     "new" <call:Spanned<Call>> => {
         let args = vec![call];
@@ -135,7 +180,8 @@ New: Value = {
 };
 
 Field<T>: (Symbol, Term) = {
-    <name:Name> ":" <value:T> => (name, value)
+    <name:Name> ":" <value:T> => (name, value),
+    <w:ResWord> ":" <value:T> => (Symbol(w), value),
 }
 
 Fields<T>: BTreeMap<Symbol, Term> = {
@@ -308,7 +354,8 @@ Exp10<T>: ValueOrLogical = {
 }
 
 CallTerm: Value = {
-    <Call>,
+    <DotCall>,
+    <w:ResWord> => Value::String(w),
     <s:"Symbol"> => Value::String(s.0),
     // These provide ways to get keys that aren't
     // expressable as `foo.bar`
@@ -371,6 +418,7 @@ Op7: Operator = {
     "mod" => Operator::Mod,
     "rem" => Operator::Rem,
 }
+
 MulExp<T>: Value = {
     <exp7:ExpectValue<Exp7<T>>> <operator:Op7> <exp8:ExpectValue<Exp8<T>>> => {
         let args = vec![exp7, exp8];

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -114,11 +114,6 @@ Boolean: Value = <b:"Boolean"> => {
 
 Name: Symbol = <s:"Symbol"> => s;
 
-ResName: Symbol = {
-  <Name>,
-  <w:ResWord> => Symbol(w),
-}
-
 Variable: Value  = <n:Name> => {
     Value::Variable(n)
 };

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1671,11 +1671,23 @@ fn test_matches() {
 }
 
 #[test]
-fn test_keyword_bug() {
-    qparse!("g(a) if a.new(b);", ParseError::ReservedWord { .. });
-    qparse!("f(a) if a.in(b);", ParseError::ReservedWord { .. });
+fn test_keyword_call() {
     qparse!("cut(a) if a;", ParseError::ReservedWord { .. });
     qparse!("debug(a) if a;", ParseError::ReservedWord { .. });
+    qparse!(
+        "foo(debug) if debug = 1;",
+        ParseError::UnrecognizedToken { .. }
+    );
+}
+
+#[test]
+fn test_keyword_dot() -> TestResult {
+    // field accesses of reserved words are allowed
+    let mut p = Polar::new();
+    p.load_str("f(a, b) if a.in(b);")?;
+    p.load_str("g(a, b) if a.new(b);")?;
+    qeval(&mut p, "x = {debug: 1} and x.debug = 1");
+    Ok(())
 }
 
 /// Test that rule heads work correctly when unification or specializers are used.

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1686,7 +1686,10 @@ fn test_keyword_dot() -> TestResult {
     let mut p = Polar::new();
     p.load_str("f(a, b) if a.in(b);")?;
     p.load_str("g(a, b) if a.new(b);")?;
-    qeval(&mut p, "x = {debug: 1} and x.debug = 1");
+    qeval(
+        &mut p,
+        "x = {debug: 1, new: 2, type: 3} and x.debug + x.new = x.type",
+    );
     Ok(())
 }
 


### PR DESCRIPTION
allowed: `x = {debug: 1, type: 2, new: 3} and x.new = x.debug + x.type`
not allowed:  `new(x);` `foo(debug);`

PR checklist:

<!-- Delete if no entry is required. -->
- [x] Added changelog entry.
