### PR TITLE
Explicitly call out that rust requires 'POLAR_LOG=now'

### DIFF
--- a/docs/content/any/reference/tooling/tracing.md
+++ b/docs/content/any/reference/tooling/tracing.md
@@ -11,7 +11,14 @@ Polar tracing shows logs of how a query is evaluated.
 
 ## Enabling Tracing
 
+
+{{% ifLang not="rust" %}}
 Debug mode is enabled by setting an environment variable: `POLAR_LOG=1`.
+{{% /ifLang %}}
+
+{{% ifLang "rust" %}}
+Debug mode is enabled by setting an environment variable: `POLAR_LOG=now`.
+{{% /ifLang %}}
 
 It will print out `[debug]` messages during query evaluation that show how the query is executed.
 Notable things include:


### PR DESCRIPTION
There's a weird bug that's easy to get snagged on if you're using the rust library: #824 

As a temporary fix, this updates the rust docs to explicitly recommend that you use `POLAR_LOG=now`, which skips all of the messaging queue stuff.

At a quick glance I'm not sure why messages aren't coming through to stdout in rust. There appears to be code to that effect, but something is just not working with it.