### PR TITLE
Backticks for both parts of the pre-0.20 parentheses expression example

### DIFF
--- a/polar-core/src/warnings.rs
+++ b/polar-core/src/warnings.rs
@@ -155,7 +155,7 @@ impl<'kb> AndOrPrecendenceCheck<'kb> {
             .iter()
             .map(|(source, or_term)| {
                 let mut msg = "Expression without parentheses could be ambiguous. \n\
-                    Prior to 0.20, x and y or z would parse as `x and (y or z)`. \n\
+                    Prior to 0.20, `x and y or z` would parse as `x and (y or z)`. \n\
                     This was changed in 0.20 to match other languages. \n\
                 \n\n"
                     .to_string();


### PR DESCRIPTION
The Expression error message was missing backticks on the first part of the example as noticed by @gj. 
After the fix, the message reads

```
Error: Expression without parentheses could be ambiguous.
Prior to 0.20, `x and y or z` would parse as `x and (y or z)`.
This was changed in 0.20 to match other languages.
```