### PR TITLE
Use the less fancy way of displaying rules.

### DIFF
--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -2689,28 +2689,7 @@ impl PolarVirtualMachine {
     }
 
     pub fn rule_source(&self, rule: &Rule) -> String {
-        let head = format!(
-            "{}({})",
-            rule.name,
-            rule.params.iter().fold(String::new(), |mut acc, p| {
-                if !acc.is_empty() {
-                    acc += ", ";
-                }
-                acc += &self.term_source(&p.parameter, false);
-                if let Some(spec) = &p.specializer {
-                    acc += ": ";
-                    acc += &self.term_source(spec, false);
-                }
-                acc
-            })
-        );
-        match rule.body.value() {
-            Value::Expression(Operation {
-                operator: Operator::And,
-                args,
-            }) if !args.is_empty() => head + " if " + &self.term_source(&rule.body, false) + ";",
-            _ => head + ";",
-        }
+        rule.to_polar()
     }
 
     fn set_error_context(


### PR DESCRIPTION
(It broke in a horrible way with shorthand syntax).

Preview:

```
[debug]         BACKTRACK
[debug]           QUERY: has_role(_actor_10, "counter", _integer_11), BINDINGS: {_actor_10 = "steve", _integer_11 = _integer_11 = _resource_6 and _resource_6 = num and _integer_11 matches Integer{}}
[debug]             APPLICABLE_RULES:
[debug]               has_role(actor: Actor{}, "counter", integer: Integer{}) if has_role(actor, "owner", integer);
[debug]             RULE: has_role(actor: Actor{}, "counter", integer: Integer{}) if has_role(actor, "owner", integer);
```

Before:

```
[debug]         BACKTRACK
[debug]           QUERY: has_role(_actor_10, "counter", _integer_11), BINDINGS: {_integer_11 = _integer_11 = _resource_6 and _resource_6 = num and _integer_11 matches Integer{}, _actor_10 = "steve"}
[debug]             APPLICABLE_RULES:
[debug]               has_role("counter": "counter", "counter", "counter": resource Integer {
[debug]                 roles = ["owner", "counter"];
[debug]                 permissions = ["read", "write"];
[debug]
[debug]                 "read" if "counter";
[debug]                 "write" if "owner";
[debug]
[debug]                 "counter" if "owner";
[debug]             }) if "owner";
[debug]             RULE: has_role("counter": "counter", "counter", "counter": resource Integer {
[debug]                 roles = ["owner", "counter"];
[debug]                 permissions = ["read", "write"];
[debug]
[debug]                 "read" if "counter";
[debug]                 "write" if "owner";
[debug]
[debug]                 "counter" if "owner";
[debug]             }) if "owner";
[debug]             MATCHES: _actor_42 matches Actor{}, BINDINGS: {_actor_42 = "steve"}
[debug]             MATCHES: _integer_43 matches Integer{}, BINDINGS: {_integer_43 = _integer_11 = _resource_6 and _resource_6 = num and _integer_11 matches Integer{} and _integer_11 = _integer_43}
[debug]             BACKTRACK
```