### PR TITLE
Accept plain objects in js type decls

### DIFF
--- a/languages/js/src/Host.ts
+++ b/languages/js/src/Host.ts
@@ -159,13 +159,18 @@ export class Host {
         existing,
       });
     }
+
+    // TODO(gw) maybe we only want to support plain objects?
+    let fields = types || {};
+    if (!(fields instanceof Map)) fields = new Map(Object.entries(fields));
+
     const userType = new UserType({
       name: clsName,
       cls: cls,
       buildQuery: buildQuery || this.buildQuery,
       execQuery: execQuery || this.execQuery,
       combineQuery: combineQuery || this.combineQuery,
-      fields: types || new Map(),
+      fields: fields,
       id: id || this.cacheInstance(cls, undefined),
     });
     this.types.set(cls, userType);

--- a/languages/js/src/Host.ts
+++ b/languages/js/src/Host.ts
@@ -166,11 +166,11 @@ export class Host {
 
     const userType = new UserType({
       name: clsName,
-      cls: cls,
+      cls,
+      fields,
       buildQuery: buildQuery || this.buildQuery,
       execQuery: execQuery || this.execQuery,
       combineQuery: combineQuery || this.combineQuery,
-      fields: fields,
       id: id || this.cacheInstance(cls, undefined),
     });
     this.types.set(cls, userType);

--- a/languages/js/src/Polar.ts
+++ b/languages/js/src/Polar.ts
@@ -254,6 +254,14 @@ export class Polar {
 
   /**
    * Register a JavaScript class for use in Polar policies.
+   *
+   * @param cls The class to register.
+   * @param params An optional object with extra parameters.
+   *
+   * Accepted extra parameters are:
+   * - name: Explicit name to use for the class in Polar.
+   * - types: A map or object of string keys to type values, used for data filtering.
+   * - {build,combine,exec}Query: Query generating/executing callbacks for data filtering.
    */
   registerClass<T>(cls: Class<T>, params?: any): void {
     const clsName = this.#host.cacheClass(cls, params);

--- a/languages/js/src/dataFiltering.test.ts
+++ b/languages/js/src/dataFiltering.test.ts
@@ -132,34 +132,34 @@ async function fixtures() {
     combineQuery: combineQuery,
   });
 
-  const barType = new Map();
-  barType.set('id', String);
-  barType.set('isCool', Boolean);
-  barType.set('isStillCool', Boolean);
-  barType.set('foos', new Relation('many', 'Foo', 'id', 'barId'));
   oso.registerClass(Bar, {
-    types: barType,
     buildQuery: fromRepo(bars, 'bar'),
+    types: {
+      id: String,
+      isCool: Boolean,
+      isStillCool: Boolean,
+      foos: new Relation('many', 'Foo', 'id', 'barId'),
+    },
   });
 
-  const fooType = new Map();
-  fooType.set('id', String);
-  fooType.set('barId', String);
-  fooType.set('isFooey', Boolean);
-  fooType.set('bar', new Relation('one', 'Bar', 'barId', 'id'));
-  fooType.set('numbers', new Relation('many', 'Num', 'id', 'fooId'));
   oso.registerClass(Foo, {
-    types: fooType,
     buildQuery: fromRepo(foos, 'foo'),
+    types: {
+      id: String,
+      barId: String,
+      isFooey: Boolean,
+      bar: new Relation('one', 'Bar', 'barId', 'id'),
+      numbers: new Relation('many', 'Num', 'id', 'fooId'),
+    },
   });
 
-  const numType = new Map();
-  numType.set('number', Number);
-  numType.set('fooId', String);
-  numType.set('foo', new Relation('one', 'Foo', 'fooId', 'id'));
   oso.registerClass(Num, {
-    types: numType,
     buildQuery: fromRepo(nums, 'num'),
+    types: {
+      number: Number,
+      fooId: String,
+      foo: new Relation('one', 'Foo', 'fooId', 'id'),
+    },
   });
 
   const checkAuthz = async (


### PR DESCRIPTION
Instead of requiring `Map` objects. For example:
```javascript
oso.registerClass(Foo, {
  types: { id: Number }
});
```
PR checklist:
