### PR TITLE
Docs Tweaks

### DIFF
--- a/docs/layouts/shortcodes/literalInclude.html
+++ b/docs/layouts/shortcodes/literalInclude.html
@@ -244,6 +244,15 @@
         {{ end }}
       {{ end }}
 
+      {{/* Strip any remaining lines containing the 'docs:' magic string. */}}
+      {{ $withoutDocsTags := slice }}
+      {{ range $index, $line := $contentLines }}
+        {{ if not (in $line "docs:") }}
+          {{ $withoutDocsTags = $withoutDocsTags | append $line }}
+        {{ end }}
+      {{ end }}
+      {{ $contentLines = $withoutDocsTags }}
+
       {{ $content = delimit $contentLines "\n" }}
     {{ end }}
   {{ end }}

--- a/docs/layouts/shortcodes/literalInclude.html
+++ b/docs/layouts/shortcodes/literalInclude.html
@@ -65,6 +65,7 @@
 {{ $lastLine := 0 }}
 {{ $linenos := $.Params.linenos | default false }}
 {{ $ellipsis := $.Params.ellipsis | default "..." }}
+{{ $hl_lines := $.Params.hl_lines | default "" }}
 
 {{/* Turn "1,3-5,11-17" into a slice of maps consisting of a single key-value
      pair where the key is the starting line and the value is the length of the
@@ -281,7 +282,7 @@
     {{ $gitHubRef = (printf "%s/blob/main/%s#L%d-L%d" $gitHub $pathTrim $gFirstLine $gLastLine) }}
 {{ end }}
 
-<div class="code" id="{{ $id | urlize }}">
+<div class="code" id="{{ $file | urlize}}" data-hl_lines="{{ $hl_lines }}">
   <div class="filename rounded-t-md bg-gray-200 text-gray-700 text-sm py-2">
     {{- with $syntax -}}
       <span class="px-2{{ if eq . "go" }} block w-10{{end}}">

--- a/docs/layouts/shortcodes/literalInclude.html
+++ b/docs/layouts/shortcodes/literalInclude.html
@@ -43,6 +43,7 @@
       segments will be separated by an ellipsis to indicate elided code.
   - gitHub: specify GitHub link to generate a link to example. E.g
     ``https://github.com/osohq/gitclub/``
+  - ellipsis: override the default marker for elided code ("...").
 */}}
 
 {{ $dynPath := $.Params.dynPath }}
@@ -63,6 +64,7 @@
 {{ $firstLine := 0 }}
 {{ $lastLine := 0 }}
 {{ $linenos := $.Params.linenos | default false }}
+{{ $ellipsis := $.Params.ellipsis | default "..." }}
 
 {{/* Turn "1,3-5,11-17" into a slice of maps consisting of a single key-value
      pair where the key is the starting line and the value is the length of the
@@ -205,7 +207,7 @@
               {{ with first $count (after (sub (int $start) 1) $bounded) }}
                 {{ $temp = $temp | append . }}
                 {{ if ne $index $last }}
-                  {{ $temp = $temp | append "" "..." "" }}
+                  {{ $temp = $temp | append "" $ellipsis "" }}
                 {{ end }}
               {{ end }}
             {{ end }}

--- a/docs/themes/oso-tailwind/assets/css/postcss.config.js
+++ b/docs/themes/oso-tailwind/assets/css/postcss.config.js
@@ -6,7 +6,7 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
     './hugo_stats.json',
     './themes/oso-webpack/search-result.handlebars'
   ],
-  whitelist: ['polar-code-in-here'],
+  whitelist: ['polar-code-in-here', 'highlight-me-pls'],
   extractors: [
     {
       extensions: ['json'],

--- a/docs/themes/oso-tailwind/assets/css/styles.css
+++ b/docs/themes/oso-tailwind/assets/css/styles.css
@@ -184,3 +184,7 @@ pre code {
   pointer-events: none;
   background-color: rgb(167, 243, 208);
 }
+
+.highlight-me-pls {
+  background-color: #333;
+}

--- a/docs/themes/oso-tailwind/assets/css/styles.css
+++ b/docs/themes/oso-tailwind/assets/css/styles.css
@@ -84,7 +84,12 @@ button > * {
       @apply bg-primary-800 !important
     }
 
-    .code pre {
+    .code > pre {
+      @apply rounded-t-md
+    }
+
+    .code > .filename + pre,
+    .code > .filename + .highlight > pre {
       @apply rounded-t-none mt-0
     }
 }

--- a/docs/themes/oso-tailwind/layouts/shortcodes/code.html
+++ b/docs/themes/oso-tailwind/layouts/shortcodes/code.html
@@ -2,11 +2,12 @@
 {{ $file := .Get "file" }}
 {{ $codeLang := "" }}
 {{ $suffix := findRE "(\\.[^.]+)$" $file 1 }}
+{{ $hl_lines := $.Params.hl_lines | default "" }}
 {{ with  $suffix }}
 {{ $codeLang = (index . 0 | strings.TrimPrefix ".") }}
 {{ end }}
 {{ with .Get "codeLang" }}{{ $codeLang = . }}{{ end }}
-<div class="code" id="{{ $file | urlize}}">
+<div class="code" id="{{ $file | urlize}}" data-hl_lines="{{ $hl_lines }}">
 {{- with $file -}}
 <div class="filename rounded-md bg-gray-200 text-gray-700 text-sm py-2">
 {{- with $codeLang -}}<span class="px-2">{{- partialCached "fontawesome.html" $codeLang $codeLang -}}</span>{{- end -}}{{- . -}}

--- a/docs/themes/oso-webpack/index.js
+++ b/docs/themes/oso-webpack/index.js
@@ -157,16 +157,31 @@ import('monaco-editor-core').then(monaco => {
 
   monaco.editor.setTheme('polarTheme');
 
-  window.addEventListener('load', () => {
-    let polarCode = document.getElementsByClassName('language-polar');
-    for (let i = 0; i < polarCode.length; i++) {
-      let el = polarCode[i];
-      monaco.editor
-        .colorize(el.innerText, 'polar', { theme: 'polarTheme' })
-        .then(colored => {
-          el.innerHTML = colored;
-          el.parentNode.classList.add('polar-code-in-here');
-        });
+  function highlightPolarCode(el) {
+    let { hl_lines: numbers } = el.parentNode.parentNode.dataset;
+    if (typeof numbers !== 'string' || numbers.length === 0) return;
+    numbers = numbers.replace(/ /g, '').split(',').flatMap(parseRange);
+    const lines = Array.from(el.children).filter(child => child.matches('span'));
+    for (const number of numbers) {
+      lines[number].classList.add('highlight-me-pls');
+    }
+  }
+
+  function parseRange(maybeRange) {
+    const range = maybeRange.split('-');
+    const start = Number.parseInt(range[0], 10) - 1;
+    if (range.length === 1) return [start];
+    const end = Number.parseInt(range[1], 10);
+    return Array(end - start).fill(null).map((_, i) => start + i);
+  }
+
+  window.addEventListener('load', async () => {
+    const els = document.getElementsByClassName('language-polar');
+    for (const el of els) {
+      const colorized = await monaco.editor.colorize(el.innerText, 'polar', { theme: 'polarTheme' });
+      el.innerHTML = colorized;
+      el.parentNode.classList.add('polar-code-in-here');
+      highlightPolarCode(el);
     }
   });
 });


### PR DESCRIPTION
- Made it so that [code blocks w/o a filename have rounded corners on top](https://github.com/osohq/oso/commit/4e9989b424036213f810840a275cf91048e6470b), matching the rounded corners on the bottom.
- [Allow specifying a custom ellipsis in literalInclude](https://github.com/osohq/oso/commit/42df80f7d62aa21e26d5cd88861609e1779d2f16) so you can customize the indentation, comment style, etc.
- Allow highlighting (in yellow) lines of Polar code (we could already do this for all non-Polar languages) in the [`{{% code %}}` and `{{% literalInclude %}}` shortcodes](https://github.com/osohq/oso/commit/b25bb13006cbe898bbf383cf5974096fff27bd6e)
- [Skip over lines containing `docs:` in the `literalInclude` shortcode](https://github.com/osohq/oso/commit/ac78c23a946ab88b8849c04be7151da70fc96d01) so you can have overlapping `docs:` delimiters (e.g., to identify a range of code that you want to display) without the random `docs:` comments showing up in a code snippet.