### PR TITLE
Test RBAC guides against HEAD

### DIFF
--- a/docs/examples/Makefile
+++ b/docs/examples/Makefile
@@ -9,6 +9,9 @@ RUBY_DIR := $(OSO_ROOT)/languages/ruby
 # Needed for tests
 JAVA_PACKAGE_JAR_PATH := $(JAVA_DIR)/oso/target/oso-0.20.1.jar
 
+# Note: if you are using bundler in a sub-makefile (in a docs test for example),
+# you need to add `unexport BUNDLE_GEMFILE` to that makefile. Otherwise this
+# setting will take precedence over the working directory.
 export BUNDLE_GEMFILE := $(RUBY_DIR)/Gemfile
 
 submodules: .make.submodules.installed

--- a/docs/examples/rbac/go/Makefile
+++ b/docs/examples/rbac/go/Makefile
@@ -1,4 +1,5 @@
 .PHONY: test
 
 test:
+	make -C ../../../../languages/go
 	go test

--- a/docs/examples/rbac/go/Makefile
+++ b/docs/examples/rbac/go/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test
 
 test:
-	make -C ../../../../languages/go
+	make -C ../../../../languages/go copy_lib
 	go test

--- a/docs/examples/rbac/go/app.go
+++ b/docs/examples/rbac/go/app.go
@@ -46,7 +46,9 @@ o.RegisterClass(reflect.TypeOf(Repository{}), nil)
 o.RegisterClass(reflect.TypeOf(User{}), NewUser)
 // docs: end-register
 
-o.LoadFiles([]string{"main.polar"})
+if err := o.LoadFiles([]string{"main.polar"}); err != nil {
+	panic(err)
+}
 // docs: end-setup
 
 return o

--- a/docs/examples/rbac/go/app.go
+++ b/docs/examples/rbac/go/app.go
@@ -46,9 +46,7 @@ o.RegisterClass(reflect.TypeOf(Repository{}), nil)
 o.RegisterClass(reflect.TypeOf(User{}), NewUser)
 // docs: end-register
 
-if err := o.LoadFiles([]string{"main.polar"}); err != nil {
-	panic(err)
-}
+o.LoadFiles([]string{"main.polar"})
 // docs: end-setup
 
 return o

--- a/docs/examples/rbac/go/go.mod
+++ b/docs/examples/rbac/go/go.mod
@@ -3,3 +3,5 @@ module github.com/osohq/oso
 go 1.13
 
 require github.com/osohq/go-oso v0.20.1-beta
+
+replace github.com/osohq/go-oso => ../../../../languages/go

--- a/docs/examples/rbac/nodejs/Makefile
+++ b/docs/examples/rbac/nodejs/Makefile
@@ -5,4 +5,6 @@ test: node_modules
 
 node_modules: package.json
 	yarn
+	cd ../../../../languages/js; yarn link
+	yarn link oso
 	@touch $@

--- a/docs/examples/rbac/ruby/Makefile
+++ b/docs/examples/rbac/ruby/Makefile
@@ -1,3 +1,5 @@
+unexport BUNDLE_GEMFILE
+
 .PHONY: test install
 
 test: install

--- a/docs/examples/rbac/ruby/Makefile
+++ b/docs/examples/rbac/ruby/Makefile
@@ -1,3 +1,5 @@
+# By unexporting BUNDLE_GEMFILE here, we prevent bundler from using the
+# Gemfile defined in `docs/examples/Makefile`.
 unexport BUNDLE_GEMFILE
 
 .PHONY: test install


### PR DESCRIPTION
The java, ruby, and python RBAC guides already seem to be using a local version of Oso. This updates the Go and Node RBAC guides to also run their tests against an installation at a relative path.