### PR TITLE
Throw an error if the attribute is truly undefined

### DIFF
--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -833,6 +833,7 @@ describe('iterators', () => {
       await qvar(p, 'x = new BarIterator([1, 2, 3]).sum()', 'x', true)
     ).toBe(6);
   });
+
 });
 
 test('handles expressions', async () => {
@@ -947,10 +948,10 @@ describe('Oso Roles', () => {
   });
 
   test('rule types correctly check subclasses', async () => {
-    class Foo {}
-    class Bar extends Foo {}
-    class Baz extends Bar {}
-    class Bad {}
+    class Foo { }
+    class Bar extends Foo { }
+    class Baz extends Bar { }
+    class Bad { }
 
     // NOTE: keep this order of registering classes--confirms that MROs are added at the correct time
     const p = new Polar();
@@ -991,4 +992,14 @@ describe('Oso Roles', () => {
     const policy5 = policy4 + 'type f(x: Foo, x.baz);';
     await expect(p.loadStr(policy5)).rejects.toThrow('Invalid rule type');
   });
+});
+
+test('can specialize on a dict with undefineds', async () => {
+  const p = new Polar();
+  p.registerClass(User);
+  await p.loadStr('f(_: {x: 1});');
+  const result1 = await query(p, pred('f', { x: 1 }));
+  expect(result1).toStrictEqual([map()]);
+  const result2 = await query(p, pred('f', {}));
+  expect(result2).toStrictEqual([]);
 });

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -997,7 +997,7 @@ test('can specialize on a dict with undefineds', async () => {
   const p = new Polar();
   await p.loadStr('f(_: {x: 1});');
 
-  const noAttr = { };
+  const noAttr = {};
   const hasAttr = { x: 1 };
 
   const result1 = await query(p, pred('f', hasAttr));

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -997,8 +997,18 @@ test('can specialize on a dict with undefineds', async () => {
   const p = new Polar();
   p.registerClass(User);
   await p.loadStr('f(_: {x: 1});');
-  const result1 = await query(p, pred('f', { x: 1 }));
+
+  const noAttr = { };
+  const hasAttr = { x: 1 };
+
+  const result1 = await query(p, pred('f', hasAttr));
   expect(result1).toStrictEqual([map()]);
-  const result2 = await query(p, pred('f', {}));
+
+  const result2 = await query(p, pred('f', noAttr));
   expect(result2).toStrictEqual([]);
+
+  Object.setPrototypeOf(noAttr, hasAttr);
+
+  const result1 = await query(p, pred('f', noAttr));
+  expect(result1).toStrictEqual([map()]);
 });

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -947,10 +947,10 @@ describe('Oso Roles', () => {
   });
 
   test('rule types correctly check subclasses', async () => {
-    class Foo { }
-    class Bar extends Foo { }
-    class Baz extends Bar { }
-    class Bad { }
+    class Foo {}
+    class Bar extends Foo {}
+    class Baz extends Bar {}
+    class Bad {}
 
     // NOTE: keep this order of registering classes--confirms that MROs are added at the correct time
     const p = new Polar();

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -995,7 +995,6 @@ describe('Oso Roles', () => {
 
 test('can specialize on a dict with undefineds', async () => {
   const p = new Polar();
-  p.registerClass(User);
   await p.loadStr('f(_: {x: 1});');
 
   const noAttr = { };

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -833,7 +833,6 @@ describe('iterators', () => {
       await qvar(p, 'x = new BarIterator([1, 2, 3]).sum()', 'x', true)
     ).toBe(6);
   });
-
 });
 
 test('handles expressions', async () => {
@@ -948,10 +947,10 @@ describe('Oso Roles', () => {
   });
 
   test('rule types correctly check subclasses', async () => {
-    class Foo { }
-    class Bar extends Foo { }
-    class Baz extends Bar { }
-    class Bad { }
+    class Foo {}
+    class Bar extends Foo {}
+    class Baz extends Bar {}
+    class Bad {}
 
     // NOTE: keep this order of registering classes--confirms that MROs are added at the correct time
     const p = new Polar();

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -365,31 +365,31 @@ describe('conversions between JS + Polar values', () => {
   });
 });
 
-describe('#loadFile', () => {
+describe('#loadFiles', () => {
   test('loads a Polar file', async () => {
     const p = new Polar();
-    await p.loadFile(await tempFileFx());
+    await p.loadFiles([await tempFileFx()]);
     expect(await qvar(p, 'f(x)', 'x')).toStrictEqual([1, 2, 3]);
   });
 
   test('passes the filename across the FFI boundary', async () => {
     const p = new Polar();
     const file = await tempFile(';', 'invalid.polar');
-    await expect(p.loadFile(file)).rejects.toThrow(
+    await expect(p.loadFiles([file])).rejects.toThrow(
       `did not expect to find the token ';' at line 1, column 1 in file ${file}`
     );
   });
 
   test('throws if given a non-Polar file', async () => {
     const p = new Polar();
-    await expect(p.loadFile('other.ext')).rejects.toThrow(
+    await expect(p.loadFiles(['other.ext'])).rejects.toThrow(
       PolarFileExtensionError
     );
   });
 
   test('throws if given a non-existent file', async () => {
     const p = new Polar();
-    await expect(p.loadFile('other.polar')).rejects.toThrow(
+    await expect(p.loadFiles(['other.polar'])).rejects.toThrow(
       PolarFileNotFoundError
     );
   });
@@ -592,7 +592,7 @@ describe('#registerConstant', () => {
     describe('that return undefined', () => {
       test('without things blowing up', async () => {
         const p = new Polar();
-        p.registerConstant({}, 'u');
+        p.registerConstant({ x: undefined, y: undefined }, 'u');
         expect(await query(p, 'u.x = u.y')).toStrictEqual([map()]);
         await expect(query(p, 'u.x.y')).rejects.toThrow();
       });
@@ -947,10 +947,10 @@ describe('Oso Roles', () => {
   });
 
   test('rule types correctly check subclasses', async () => {
-    class Foo {}
-    class Bar extends Foo {}
-    class Baz extends Bar {}
-    class Bad {}
+    class Foo { }
+    class Bar extends Foo { }
+    class Baz extends Bar { }
+    class Bad { }
 
     // NOTE: keep this order of registering classes--confirms that MROs are added at the correct time
     const p = new Polar();

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -947,10 +947,10 @@ describe('Oso Roles', () => {
   });
 
   test('rule types correctly check subclasses', async () => {
-    class Foo {}
-    class Bar extends Foo {}
-    class Baz extends Bar {}
-    class Bad {}
+    class Foo { }
+    class Bar extends Foo { }
+    class Baz extends Bar { }
+    class Bad { }
 
     // NOTE: keep this order of registering classes--confirms that MROs are added at the correct time
     const p = new Polar();
@@ -1008,6 +1008,6 @@ test('can specialize on a dict with undefineds', async () => {
 
   Object.setPrototypeOf(noAttr, hasAttr);
 
-  const result1 = await query(p, pred('f', noAttr));
-  expect(result1).toStrictEqual([map()]);
+  const result3 = await query(p, pred('f', noAttr));
+  expect(result3).toStrictEqual([map()]);
 });

--- a/languages/js/src/Query.test.ts
+++ b/languages/js/src/Query.test.ts
@@ -41,6 +41,9 @@ describe('#registerCall', () => {
     p.registerConstant(sync, 'sync');
 
     expect(await qvar(p, 'sync.undefined = x', 'x', true)).toBeUndefined();
+    await expect(query(p, 'sync.attribute_undefined = x')).rejects.toThrow(
+      'attribute_undefined not found on'
+    );
     await expect(query(p, 'sync.undefined()')).rejects.toThrow(
       '.undefined is not a function at line 1, column 1'
     );

--- a/languages/js/src/Query.ts
+++ b/languages/js/src/Query.ts
@@ -184,7 +184,11 @@ export class Query {
         }
       }
     } catch (e) {
-      if (e instanceof TypeError || e instanceof InvalidCallError) {
+      if (
+        e instanceof TypeError ||
+        e instanceof InvalidCallError ||
+        e instanceof InvalidAttributeError
+      ) {
         this.applicationError(e.message);
       } else {
         throw e;

--- a/languages/js/src/Query.ts
+++ b/languages/js/src/Query.ts
@@ -179,7 +179,7 @@ export class Query {
           // If value isn't a property anywhere in receiver's prototype chain,
           // throw an error.
           if (value === undefined && !(attr in receiver)) {
-            throw new InvalidAttributeError(receiver, attr)
+            throw new InvalidAttributeError(receiver, attr);
           }
         }
       }

--- a/languages/js/src/Query.ts
+++ b/languages/js/src/Query.ts
@@ -5,6 +5,7 @@ const createInterface = require('readline')?.createInterface;
 import { parseQueryEvent } from './helpers';
 import {
   DuplicateInstanceRegistrationError,
+  InvalidAttributeError,
   InvalidCallError,
   InvalidIteratorError,
 } from './errors';
@@ -163,7 +164,7 @@ export class Query {
           }
         }
       }
-      if (value == undefined) {
+      if (value === undefined) {
         value = receiver[attr];
         if (args !== undefined) {
           if (typeof value === 'function') {
@@ -173,6 +174,10 @@ export class Query {
           } else {
             // Error on attempt to call non-function.
             throw new InvalidCallError(receiver, attr);
+          }
+        } else {
+          if (value === undefined && !(attr in receiver)) {
+            throw new InvalidAttributeError(receiver, attr)
           }
         }
       }

--- a/languages/js/src/Query.ts
+++ b/languages/js/src/Query.ts
@@ -176,6 +176,8 @@ export class Query {
             throw new InvalidCallError(receiver, attr);
           }
         } else {
+          // If value isn't a property anywhere in receiver's prototype chain,
+          // throw an error.
           if (value === undefined && !(attr in receiver)) {
             throw new InvalidAttributeError(receiver, attr)
           }

--- a/languages/js/src/errors.ts
+++ b/languages/js/src/errors.ts
@@ -68,7 +68,6 @@ export class InvalidAttributeError extends PolarError {
   }
 }
 
-
 export class InvalidCallError extends PolarError {
   constructor(instance: any, field: string) {
     super(`${repr(instance)}.${field} is not a function`);

--- a/languages/js/src/errors.ts
+++ b/languages/js/src/errors.ts
@@ -62,6 +62,13 @@ export class InlineQueryFailedError extends PolarError {
   }
 }
 
+export class InvalidAttributeError extends PolarError {
+  constructor(instance: any, field: string) {
+    super(`${field} not found on ${repr(instance)}.`);
+  }
+}
+
+
 export class InvalidCallError extends PolarError {
   constructor(instance: any, field: string) {
     super(`${repr(instance)}.${field} is not a function`);

--- a/languages/js/test/parity.ts
+++ b/languages/js/test/parity.ts
@@ -16,7 +16,7 @@ class A {
 }
 oso.registerClass(A);
 
-class D extends A { }
+class D extends A {}
 
 namespace B {
   export class C {

--- a/languages/js/test/parity.ts
+++ b/languages/js/test/parity.ts
@@ -16,7 +16,7 @@ class A {
 }
 oso.registerClass(A);
 
-class D extends A {}
+class D extends A { }
 
 namespace B {
   export class C {
@@ -82,7 +82,7 @@ oso.registerClass(E);
   // In parity tests it's `js_package/dist/test/parity.js`
   // In both these cases the relative path to the test.polar file is the same.
   const { join } = require('path');
-  await oso.loadFile(join(__dirname, '../../../test/test.polar'));
+  await oso.loadFiles([join(__dirname, '../../../test/test.polar')]);
 
   if (!(await oso.isAllowed('a', 'b', 'c'))) throw new Error();
 


### PR DESCRIPTION
Differentiates between `{x: undefined}.x = y` and `{}.x = y`. The former is fine with `y = undefined`, the latter raises an error.

Fixes #749 

Discussed this approach with @gj a few weeks back. Check for the attribute with `"x" in d`. 