### PR TITLE
Try to use gitsha as cache key for docs diff.

### DIFF
--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -99,16 +99,18 @@ jobs:
     needs: check-label
     if: ${{ needs.check-label.outputs.hadLabel == 'false' }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+      - name: Get sha of base_ref
+        id: sha
+        run: 'echo "::set-output name=gitsha::$(git rev-parse HEAD)"'
       - uses: actions/cache@v2
         id: cache
         with:
           path: |
             docs/public
-          key: docs-${{ github.base_ref }}
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.base_ref }}
-        if: steps.cache.outputs.cache-hit != 'true'
+          key: docs-${{ steps.sha.outputs.gitsha }}
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/docs-diff.yml
+++ b/.github/workflows/docs-diff.yml
@@ -202,6 +202,14 @@ jobs:
         id: diff
         run: set -o pipefail && diff -q --recursive base head | tee diff.txt
         continue-on-error: true
+      - name: Full diff
+        run: diff --recursive base head > diff-full.txt
+        if: ${{ steps.diff.outcome == 'failure' }}
+      - name: Upload diff artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: full-diff
+          path: diff-full.txt
       - name: Print docs changes
         run: |
           cat <<EOF


### PR DESCRIPTION
This change uses the SHA of the most recent commit on the base branch instead of the branch name as the cache key for the built version of docs.

This should resolve issues with the docs diff incorrectly detecting differences. Previously the key used was `docs-main`, so there would always be a cache hit even if main was updated while the PR was open.