### PR TITLE
Put Relation and Filter on the oso module

### DIFF
--- a/docs/examples/data_filtering/python/data_filtering_example_b.py
+++ b/docs/examples/data_filtering/python/data_filtering_example_b.py
@@ -106,8 +106,7 @@ def combine_query(q1, q2):
     return q1.union(q2)
 
 
-from oso import Oso
-from polar import Relation
+from oso import Oso, Relation
 
 oso = Oso()
 

--- a/docs/examples/data_filtering/ruby/data_filtering_example_a.rb
+++ b/docs/examples/data_filtering/ruby/data_filtering_example_a.rb
@@ -5,7 +5,7 @@ require 'sqlite3'
 require 'oso'
 
 DB_FILE = '/tmp/test.db'
-Relation = Oso::Polar::DataFiltering::Relation
+Relation = Oso::Relation
 
 class Repository < ActiveRecord::Base
   include QueryConfig # This module adds build/exec/combine query functions for the class

--- a/docs/examples/data_filtering/ruby/data_filtering_example_b.rb
+++ b/docs/examples/data_filtering/ruby/data_filtering_example_b.rb
@@ -4,7 +4,7 @@ require 'sqlite3'
 require 'oso'
 
 DB_FILE = '/tmp/test.db'
-Relation = Oso::Polar::DataFiltering::Relation
+Relation = Oso::Relation
 
 class Organization < ActiveRecord::Base
   include QueryConfig

--- a/docs/examples/hierarchies/python/app.py
+++ b/docs/examples/hierarchies/python/app.py
@@ -1,5 +1,4 @@
-from oso import Oso
-from polar import Relation
+from oso import Oso, Relation
 
 oso = Oso()
 

--- a/docs/examples/hierarchies/ruby/app.rb
+++ b/docs/examples/hierarchies/ruby/app.rb
@@ -1,6 +1,6 @@
 require 'oso'
 
-Relation = Oso::Polar::DataFiltering::Relation
+Relation = Oso::Relation
 
 oso = Oso.new
 

--- a/languages/python/oso/oso/__init__.py
+++ b/languages/python/oso/oso/__init__.py
@@ -1,4 +1,4 @@
-from polar import polar_class, Variable, Predicate
+from polar import polar_class, Variable, Predicate, Relation, Filter
 from .oso import Oso
 from .exceptions import AuthorizationError, ForbiddenError, NotFoundError
 from polar.exceptions import OsoError

--- a/languages/python/oso/tests/test_data_filtering.py
+++ b/languages/python/oso/tests/test_data_filtering.py
@@ -7,8 +7,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 
 from dataclasses import dataclass
-from oso import Oso
-from polar import Relation
+from oso import Oso, Relation
 from functools import reduce
 
 

--- a/languages/ruby/lib/oso.rb
+++ b/languages/ruby/lib/oso.rb
@@ -7,6 +7,9 @@ require 'oso/version'
 
 # Top-level namespace for Oso authorization library.
 module Oso
+  Relation = ::Oso::Polar::DataFiltering::Relation
+  Filter = ::Oso::Polar::DataFiltering::Filter
+
   def self.new(not_found_error: NotFoundError, forbidden_error: ForbiddenError, read_action: 'read')
     ::Oso::Oso.new(not_found_error: not_found_error, forbidden_error: forbidden_error, read_action: read_action)
   end

--- a/languages/ruby/spec/oso/polar/data_filtering_spec.rb
+++ b/languages/ruby/spec/oso/polar/data_filtering_spec.rb
@@ -11,7 +11,7 @@ end
 
 RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
   DFH = DataFilteringHelpers
-  Relation = ::Oso::Polar::DataFiltering::Relation
+  Relation = ::Oso::Relation
   Bar = DFH.record(:id, :is_cool, :is_still_cool) do
     def foos
       Foo.all.select { |foo| id == foo.bar_id }


### PR DESCRIPTION
Updates python and ruby so you can import Filter and Relation from oso (instead of oso.polar.datafiltering).
Javascript already worked this way.