### PR TITLE
Call go methods defined on a pointer to the type

### DIFF
--- a/docs/content/any/project/changelogs/2021-09-29.md
+++ b/docs/content/any/project/changelogs/2021-09-29.md
@@ -127,7 +127,7 @@ func (v Vertex) Abs() float64 {
 	return math.Sqrt(v.X*v.X + v.Y*v.Y)
 }
 
-// This could not be called from polar before but can now.
+// This could not be called from Polar before but can now.
 func (v *Vertex) Scale(f float64) {
 	v.X = v.X * f
 	v.Y = v.Y * f

--- a/docs/content/any/project/changelogs/2021-09-29.md
+++ b/docs/content/any/project/changelogs/2021-09-29.md
@@ -31,7 +31,7 @@ from oso import Oso, Relation, Filter
 
 #### Other bugs & improvements
 
-- Data filtering API type `Relation` is now defined on the
+- Data filtering API types (`Relation`, `Filter`) are now defined on the
   top level Oso module.
 
 ```ruby
@@ -123,14 +123,13 @@ type Foo struct {
 }
 
 // This could be called from Polar before
-func (v Vertex) Abs() float64 {
+func (v Vertex) Sum() float64 {
 	return math.Sqrt(v.X*v.X + v.Y*v.Y)
 }
 
 // This could not be called from Polar before but can now.
-func (v *Vertex) Scale(f float64) {
-	v.X = v.X * f
-	v.Y = v.Y * f
+func (v *Vertex) Diff(f float64) {
+  return v.X - v.Y
 }
 ```
 

--- a/docs/content/any/project/changelogs/2021-09-29.md
+++ b/docs/content/any/project/changelogs/2021-09-29.md
@@ -112,7 +112,7 @@ oso.registerClass(User, { fields: { ... } });
 
 #### New features
 
-##### Golang pointer methods
+##### Go pointer methods
 
 - Go methods that are defined on pointer receivers can now be called from polar.
 Before this change only methods defined on value receivers could be called.

--- a/docs/content/any/project/changelogs/2021-09-29.md
+++ b/docs/content/any/project/changelogs/2021-09-29.md
@@ -118,7 +118,7 @@ oso.registerClass(User, { fields: { ... } });
 Before this change only methods defined on value receivers could be called.
 
 ```go
-type Foo struct {
+type Vertex struct {
   X, Y float64
 }
 

--- a/docs/content/any/project/changelogs/2021-09-29.md
+++ b/docs/content/any/project/changelogs/2021-09-29.md
@@ -16,6 +16,29 @@ description: >-
   partial results for queries over multiple unbound variables.
 - Debug mode can now be disabled by setting `POLAR_LOG=0` or `POLAR_LOG=off`. Thanks to [`@alexhafner`](https://github.com/alexhafner) for the contribution!
 
+### Python
+
+#### Other bugs & improvements
+
+- Data filtering API types (`Relation`, `Filter`) are now importable from the
+  top level oso module.
+
+```python
+from oso import Oso, Relation, Filter
+```
+
+### Ruby
+
+#### Other bugs & improvements
+
+- Data filtering API type `Relation` is now defined on the
+  top level oso module.
+
+```ruby
+require 'oso'
+Relation = Oso::Relation
+```
+
 ### Node.js
 
 #### Breaking changes

--- a/docs/content/any/project/changelogs/2021-09-29.md
+++ b/docs/content/any/project/changelogs/2021-09-29.md
@@ -32,7 +32,7 @@ from oso import Oso, Relation, Filter
 #### Other bugs & improvements
 
 - Data filtering API type `Relation` is now defined on the
-  top level oso module.
+  top level Oso module.
 
 ```ruby
 require 'oso'
@@ -114,7 +114,7 @@ oso.registerClass(User, { fields: { ... } });
 
 ##### Go pointer methods
 
-- Go methods that are defined on pointer receivers can now be called from polar.
+- Go methods that are defined on pointer receivers can now be called from Polar.
 Before this change only methods defined on value receivers could be called.
 
 ```go
@@ -122,7 +122,7 @@ type Foo struct {
   X, Y float64
 }
 
-// This could be called from polar before
+// This could be called from Polar before
 func (v Vertex) Abs() float64 {
 	return math.Sqrt(v.X*v.X + v.Y*v.Y)
 }

--- a/docs/content/any/project/changelogs/2021-09-29.md
+++ b/docs/content/any/project/changelogs/2021-09-29.md
@@ -87,6 +87,30 @@ oso.registerClass(User, { fields: { ... } });
 
 ### Go
 
+#### New features
+
+##### Golang pointer methods
+
+- Go methods that are defined on pointer receivers can now be called from polar.
+Before this change only methods defined on value receivers could be called.
+
+```go
+type Foo struct {
+  X, Y float64
+}
+
+// This could be called from polar before
+func (v Vertex) Abs() float64 {
+	return math.Sqrt(v.X*v.X + v.Y*v.Y)
+}
+
+// This could not be called from polar before but can now.
+func (v *Vertex) Scale(f float64) {
+	v.X = v.X * f
+	v.Y = v.Y * f
+}
+```
+
 #### Other bugs & improvements
 
 - The CLI to the Go REPL has been updated to use the new `LoadFiles` API. This

--- a/languages/go/query.go
+++ b/languages/go/query.go
@@ -149,7 +149,6 @@ func (q Query) handleMakeExternal(event types.QueryEventMakeExternal) error {
 
 func (q Query) handleExternalCall(event types.QueryEventExternalCall) error {
 	instance, err := q.host.ToGo(event.Instance)
-	fmt.Println(instance)
 	if err != nil {
 		return err
 	}
@@ -158,41 +157,13 @@ func (q Query) handleExternalCall(event types.QueryEventExternalCall) error {
 
 	// if we provided Args, it should be callable
 	if event.Args != nil {
+		// Check for the method on a pointer to the value, not the value itself.
 		typ := reflect.TypeOf(instance)
 		iv := reflect.New(typ)
-		piv := reflect.New(reflect.PtrTo(typ))
-		//fmt.Println(reflect.TypeOf(instance))
-		//iv := reflect.ValueOf(instance)
-		//fmt.Println(iv.Type())
-		//piv := reflect.PtrTo(reflect.TypeOf(instance))
-		//fmt.Println(piv)
-
-		/* fmt.Println("methods on struct")
-		for i := 0; i < iv.NumMethod(); i++ {
-			m := iv.Method(i)
-			fmt.Println(m.Interface().(reflect.Method).Name)
-		}
-
-		fmt.Println("methods on pointer")
-		for i := 0; i < piv.NumMethod(); i++ {
-			m := piv.Method(i)
-			fmt.Println(m.Type())
-		} */
-		fmt.Println("checking struct")
+		iv.Elem().Set(reflect.ValueOf(instance))
 		method := iv.MethodByName(string(event.Attribute))
-		fmt.Println(method)
+
 		if !method.IsValid() {
-			fmt.Println("checking pointer")
-			method = piv.MethodByName(string(event.Attribute))
-			if method.IsValid() {
-				fmt.Println("found on pointer")
-			}
-			fmt.Println(method)
-		} else {
-			fmt.Println("found on struct")
-		}
-		if !method.IsValid() {
-			fmt.Println("not found")
 			q.ffiQuery.ApplicationError((errors.NewMissingAttributeError(instance, string(event.Attribute))).Error())
 			q.ffiQuery.CallResult(event.CallId, nil)
 			return nil

--- a/languages/go/tests/unit_test.go
+++ b/languages/go/tests/unit_test.go
@@ -299,3 +299,60 @@ func TestRuleTypes(t *testing.T) {
 		t.Fatalf("Incorrect error message: %v", msg)
 	}
 }
+
+type Typ struct {
+	x int
+}
+
+func (t Typ) Method() int {
+	return t.x + 1
+}
+
+func (t *Typ) PtrMethod() bool {
+	return t.x == 1
+}
+
+func TestPointerMethods(t *testing.T) {
+	var o oso.Oso
+	var err error
+	//var msg string
+
+	if o, err = oso.NewOso(); err != nil {
+		t.Fatalf("Failed to set up Oso: %v", err)
+	}
+
+	if err = o.RegisterClass(reflect.TypeOf(Typ{}), nil); err != nil {
+		t.Fatalf("Register class failed: %v", err)
+	}
+
+	typ := Typ{x: 1}
+	if typ.Method() != 2 {
+		t.Errorf("Bad Method")
+	}
+	if !typ.PtrMethod() {
+		t.Errorf("Bad Method")
+	}
+
+	o.LoadString("rule1(x: Typ, y) if y = x.Method(); rule2(x: Typ, y) if y = x.PtrMethod();")
+
+	test := func(rule string, typ interface{}, y_val interface{}) {
+		results, errors := o.QueryRule(rule, typ, ValueVariable("y"))
+		if err = <-errors; err != nil {
+			t.Error(err.Error())
+		} else {
+			var got []map[string]interface{}
+			expected := map[string]interface{}{"y": y_val}
+			for elem := range results {
+				got = append(got, elem)
+			}
+			if len(got) > 1 {
+				t.Errorf("Received too many results: %v", got)
+			} else if !reflect.DeepEqual(got[0], expected) {
+				t.Errorf("Expected: %v, got: %v", expected, got[0])
+			}
+		}
+	}
+
+	test("rule1", typ, int64(2))
+	test("rule2", typ, true)
+}

--- a/languages/go/tests/unit_test.go
+++ b/languages/go/tests/unit_test.go
@@ -315,7 +315,6 @@ func (t *Typ) PtrMethod() bool {
 func TestPointerMethods(t *testing.T) {
 	var o oso.Oso
 	var err error
-	//var msg string
 
 	if o, err = oso.NewOso(); err != nil {
 		t.Fatalf("Failed to set up Oso: %v", err)


### PR DESCRIPTION
Looking up the method on a pointer to the value lets us find methods defined on the pointer and on the value.
Before this we weren't finding values defined on the pointer.