### PR TITLE
Remove JSON from WASM API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,4 +369,6 @@ jobs:
       - name: Install yard (for doc build)
         run: gem install yard
       - name: Doc test
+        env:
+          MVN_FLAGS: "-q"
         run: make -C docs test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,9 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Typecheck JS library
+      - name: Lint JS library
         working-directory: "languages/js"
-        run: make typecheck
+        run: make lint
 
       ## Check Java
       - name: Install Java

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,6 @@ dependencies = [
  "polar-core",
  "serde",
  "serde-wasm-bindgen",
- "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -8,7 +8,21 @@ description: >-
 draft: true
 ---
 
+
 ## `RELEASED_PACKAGE_1` NEW_VERSION
+
+### Node.js
+
+#### Other bugs & improvements
+
+- Fixed a bug preventing dictionaries created in Polar from making the round-trip
+  to JS and back.
+
+  Many thanks to [`@rradczewski`](https://github.com/rradczewski) for
+  [raising](https://github.com/osohq/oso/issues/1242) and reproducing
+  the issue, and confirming the fix!
+
+
 
 ### LANGUAGE (e.g., 'Core' or 'Python' or 'Node.js')
 

--- a/docs/examples/rbac/ruby/Gemfile.lock
+++ b/docs/examples/rbac/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../../languages/ruby
   specs:
-    oso-oso (0.20.0.pre.beta)
+    oso-oso (0.21.0)
       ffi (~> 1.0)
 
 GEM

--- a/languages/js/src/Host.ts
+++ b/languages/js/src/Host.ts
@@ -159,7 +159,7 @@ export class Host implements Required<DataFilteringQueryParams> {
     for (const [name, typ] of this.types) if (isString(name)) yield typ;
   }
 
-  serializeTypes(): string {
+  serializeTypes(): { [tag: string]: SerializedFields } {
     const polarTypes: { [tag: string]: SerializedFields } = {};
     for (const [tag, userType] of this.types) {
       if (isString(tag)) {
@@ -178,7 +178,7 @@ export class Host implements Required<DataFilteringQueryParams> {
         polarTypes[tag] = fieldTypes;
       }
     }
-    return JSON.stringify(polarTypes);
+    return polarTypes;
   }
 
   /**

--- a/languages/js/src/Oso.ts
+++ b/languages/js/src/Oso.ts
@@ -289,9 +289,14 @@ export class Oso<
       resource
     );
 
-    const queryResults = [];
+    const queryResults: { bindings: Map<string, PolarTerm> }[] = [];
     for await (const result of results) {
-      queryResults.push(result);
+      queryResults.push({
+        // convert bindings back into Polar
+        bindings: new Map(
+          [...result.entries()].map(([k, v]) => [k, host.toPolar(v)])
+        )
+      });
     }
 
     const plan = this.getFfi().buildFilterPlan(

--- a/languages/js/src/Oso.ts
+++ b/languages/js/src/Oso.ts
@@ -28,7 +28,7 @@ export class Oso<
   Resource = unknown,
   Field = unknown,
   Request = unknown
-> extends Polar {
+  > extends Polar {
   #notFoundError: CustomError = NotFoundError;
   #forbiddenError: CustomError = ForbiddenError;
   #readAction: unknown = 'read';
@@ -294,18 +294,9 @@ export class Oso<
       queryResults.push(result);
     }
 
-    const jsonResults = queryResults.map(result => ({
-      // `Map<string, unknown> -> {[key: string]: PolarTerm}` b/c Maps aren't
-      // trivially `JSON.stringify()`-able.
-      bindings: [...result.entries()].reduce((obj: obj<PolarTerm>, [k, v]) => {
-        obj[k] = host.toPolar(v);
-        return obj;
-      }, {}),
-    }));
-    const resultsStr = JSON.stringify(jsonResults);
     const plan = this.getFfi().buildFilterPlan(
       host.serializeTypes(),
-      resultsStr,
+      queryResults,
       'resource',
       clsName
     ) as FilterPlan;

--- a/languages/js/src/Oso.ts
+++ b/languages/js/src/Oso.ts
@@ -5,7 +5,6 @@ import { Pattern } from './Pattern';
 import type {
   Options,
   CustomError,
-  obj,
   Class,
   PolarTerm,
   DataFilteringQueryParams,

--- a/languages/js/src/Oso.ts
+++ b/languages/js/src/Oso.ts
@@ -28,7 +28,7 @@ export class Oso<
   Resource = unknown,
   Field = unknown,
   Request = unknown
-  > extends Polar {
+> extends Polar {
   #notFoundError: CustomError = NotFoundError;
   #forbiddenError: CustomError = ForbiddenError;
   #readAction: unknown = 'read';
@@ -295,7 +295,7 @@ export class Oso<
         // convert bindings back into Polar
         bindings: new Map(
           [...result.entries()].map(([k, v]) => [k, host.toPolar(v)])
-        )
+        ),
       });
     }
 

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -525,10 +525,11 @@ describe('#makeInstance', () => {
       '?= x = new ConstructorMapObjectArgs(new Map([["one", 1]]), {two: 2}, new Map([["three", 3]]), {four: 4}) and x.one = 1 and x.two = 2 and x.three = 3 and x.four = 4;',
       // All Maps passed instead of dicts. Field lookups on Maps return undefined.
       '?= x = new ConstructorMapObjectArgs(new Map([["one", 1]]), new Map([["two", 2]]), new Map([["three", 3]]), new Map([["four", 4]])) and x.one = 1 and x.two = undefined and x.three = 3 and x.four = undefined;',
-      '?= new ConstructorAnyArg({x: 1}).opts.x = 1;'
+      '?= new ConstructorAnyArg({x: 1}).opts.x = 1;',
     ];
-    await expect(Promise.all(shouldPass.map(x => p.loadStr(x)))).resolves.not.toThrow();
-
+    await expect(
+      Promise.all(shouldPass.map(x => p.loadStr(x)))
+    ).resolves.not.toThrow();
 
     // All dicts passed instead of Maps. TypeErrors abound when we try to
     // call Map methods on the dicts.
@@ -680,7 +681,9 @@ describe('errors', () => {
   describe('with inline queries', () => {
     test('succeeds if all inline queries succeed', async () => {
       const p = new Polar();
-      await expect(p.loadStr('f(1); f(2); ?= f(1); ?= not f(3);')).resolves.not.toThrow();
+      await expect(
+        p.loadStr('f(1); f(2); ?= f(1); ?= not f(3);')
+      ).resolves.not.toThrow();
     });
 
     test('fails if an inline query fails', async () => {
@@ -953,10 +956,10 @@ describe('Oso Roles', () => {
   });
 
   test('rule types correctly check subclasses', async () => {
-    class Foo { }
-    class Bar extends Foo { }
-    class Baz extends Bar { }
-    class Bad { }
+    class Foo {}
+    class Bar extends Foo {}
+    class Baz extends Bar {}
+    class Bad {}
 
     // NOTE: keep this order of registering classes--confirms that MROs are added at the correct time
     const p = new Polar();

--- a/languages/js/src/Polar.test.ts
+++ b/languages/js/src/Polar.test.ts
@@ -29,6 +29,7 @@ import {
   User,
   Widget,
   X,
+  ConstructorAnyArg,
 } from '../test/classes';
 import {
   DuplicateClassAliasError,
@@ -517,14 +518,17 @@ describe('#makeInstance', () => {
   test('handles JS Maps & Polar dicts', async () => {
     const p = new Polar();
     p.registerClass(ConstructorMapObjectArgs);
+    p.registerClass(ConstructorAnyArg);
     p.registerClass(Map);
     const shouldPass = [
       // All args match ctor's expectation.
       '?= x = new ConstructorMapObjectArgs(new Map([["one", 1]]), {two: 2}, new Map([["three", 3]]), {four: 4}) and x.one = 1 and x.two = 2 and x.three = 3 and x.four = 4;',
       // All Maps passed instead of dicts. Field lookups on Maps return undefined.
       '?= x = new ConstructorMapObjectArgs(new Map([["one", 1]]), new Map([["two", 2]]), new Map([["three", 3]]), new Map([["four", 4]])) and x.one = 1 and x.two = undefined and x.three = 3 and x.four = undefined;',
+      '?= new ConstructorAnyArg({x: 1}).opts.x = 1;'
     ];
-    expect(Promise.all(shouldPass.map(x => p.loadStr(x)))).resolves;
+    await expect(Promise.all(shouldPass.map(x => p.loadStr(x)))).resolves.not.toThrow();
+
 
     // All dicts passed instead of Maps. TypeErrors abound when we try to
     // call Map methods on the dicts.
@@ -621,11 +625,11 @@ describe('#registerConstant', () => {
     );
   });
 
-  test('registering the same constant twice overwrites', () => {
+  test('registering the same constant twice overwrites', async () => {
     const p = new Polar();
     p.registerConstant(1, 'x');
     p.registerConstant(2, 'x');
-    expect(p.loadStr('?= x == 2;')).resolves;
+    await expect(p.loadStr('?= x == 2;')).resolves.not.toThrow();
   });
 });
 
@@ -674,9 +678,9 @@ describe('unifying a promise', () => {
 
 describe('errors', () => {
   describe('with inline queries', () => {
-    test('succeeds if all inline queries succeed', () => {
+    test('succeeds if all inline queries succeed', async () => {
       const p = new Polar();
-      expect(p.loadStr('f(1); f(2); ?= f(1); ?= not f(3);')).resolves;
+      await expect(p.loadStr('f(1); f(2); ?= f(1); ?= not f(3);')).resolves.not.toThrow();
     });
 
     test('fails if an inline query fails', async () => {
@@ -949,10 +953,10 @@ describe('Oso Roles', () => {
   });
 
   test('rule types correctly check subclasses', async () => {
-    class Foo {}
-    class Bar extends Foo {}
-    class Baz extends Bar {}
-    class Bad {}
+    class Foo { }
+    class Bar extends Foo { }
+    class Baz extends Bar { }
+    class Bad { }
 
     // NOTE: keep this order of registering classes--confirms that MROs are added at the correct time
     const p = new Polar();

--- a/languages/js/src/Polar.ts
+++ b/languages/js/src/Polar.ts
@@ -103,7 +103,7 @@ export class Polar {
    * @internal
    */
   private processMessages() {
-    for (; ;) {
+    for (;;) {
       const msg = this.#ffiPolar.nextMessage() as Message | undefined;
       if (msg === undefined) break;
       processMessage(msg);
@@ -157,7 +157,7 @@ export class Polar {
   async loadFile(filename: string): Promise<void> {
     console.error(
       '`Oso.loadFile` has been deprecated in favor of `Oso.loadFiles` as of the 0.20 release.\n\n' +
-      'Please see changelog for migration instructions: https://docs.osohq.com/project/changelogs/2021-09-15.html'
+        'Please see changelog for migration instructions: https://docs.osohq.com/project/changelogs/2021-09-15.html'
     );
     return this.loadFiles([filename]);
   }
@@ -178,7 +178,7 @@ export class Polar {
   }
 
   private async checkInlineQueries(): Promise<void> {
-    for (; ;) {
+    for (;;) {
       const query = this.#ffiPolar.nextInlineQuery();
       this.processMessages();
       if (query === undefined) break;

--- a/languages/js/src/Polar.ts
+++ b/languages/js/src/Polar.ts
@@ -103,7 +103,7 @@ export class Polar {
    * @internal
    */
   private processMessages() {
-    for (;;) {
+    for (; ;) {
       const msg = this.#ffiPolar.nextMessage() as Message | undefined;
       if (msg === undefined) break;
       processMessage(msg);
@@ -157,7 +157,7 @@ export class Polar {
   async loadFile(filename: string): Promise<void> {
     console.error(
       '`Oso.loadFile` has been deprecated in favor of `Oso.loadFiles` as of the 0.20 release.\n\n' +
-        'Please see changelog for migration instructions: https://docs.osohq.com/project/changelogs/2021-09-15.html'
+      'Please see changelog for migration instructions: https://docs.osohq.com/project/changelogs/2021-09-15.html'
     );
     return this.loadFiles([filename]);
   }
@@ -178,7 +178,7 @@ export class Polar {
   }
 
   private async checkInlineQueries(): Promise<void> {
-    for (;;) {
+    for (; ;) {
       const query = this.#ffiPolar.nextInlineQuery();
       this.processMessages();
       if (query === undefined) break;
@@ -199,7 +199,7 @@ export class Polar {
     if (isString(q)) {
       ffiQuery = this.#ffiPolar.newQueryFromStr(q);
     } else {
-      const term = JSON.stringify(host.toPolar(q));
+      const term = host.toPolar(q);
       ffiQuery = this.#ffiPolar.newQueryFromTerm(term);
     }
     this.processMessages();
@@ -250,7 +250,7 @@ export class Polar {
    */
   registerConstant(value: unknown, name: string): void {
     const term = this.getHost().toPolar(value);
-    this.#ffiPolar.registerConstant(name, JSON.stringify(term));
+    this.#ffiPolar.registerConstant(name, term);
   }
 
   getHost(): Host {

--- a/languages/js/src/Query.ts
+++ b/languages/js/src/Query.ts
@@ -70,7 +70,7 @@ export class Query {
    * @internal
    */
   private bind(name: string, value: unknown) {
-    this.#ffiQuery.bind(name, JSON.stringify(this.#host.toPolar(value)));
+    this.#ffiQuery.bind(name, this.#host.toPolar(value));
   }
 
   /**
@@ -79,7 +79,7 @@ export class Query {
    * @internal
    */
   private processMessages() {
-    for (;;) {
+    for (; ;) {
       const msg = this.#ffiQuery.nextMessage() as Message | undefined;
       if (msg === undefined) break;
       processMessage(msg);
@@ -101,7 +101,7 @@ export class Query {
    *
    * @internal
    */
-  private callResult(callId: number, result?: string): void {
+  private callResult(callId: number, result?: PolarTerm): void {
     this.#ffiQuery.callResult(callId, result);
   }
 
@@ -111,12 +111,12 @@ export class Query {
    *
    * @internal
    */
-  private async nextCallResult(callId: number): Promise<string | undefined> {
+  private async nextCallResult(callId: number): Promise<PolarTerm | undefined> {
     const call = this.#calls.get(callId);
     if (call === undefined) throw new Error('invalid call');
     const { done, value } = await call.next(); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
     if (done) return undefined;
-    return JSON.stringify(this.#host.toPolar(value));
+    return this.#host.toPolar(value);
   }
 
   /**
@@ -234,7 +234,7 @@ export class Query {
       // resolve promise if necessary
       // convert result to JSON and return
       value = await Promise.resolve(value); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-      value = JSON.stringify(this.#host.toPolar(value));
+      value = this.#host.toPolar(value);
       this.callResult(callId, value);
     }
   }

--- a/languages/js/src/Query.ts
+++ b/languages/js/src/Query.ts
@@ -79,7 +79,7 @@ export class Query {
    * @internal
    */
   private processMessages() {
-    for (; ;) {
+    for (;;) {
       const msg = this.#ffiQuery.nextMessage() as Message | undefined;
       if (msg === undefined) break;
       processMessage(msg);

--- a/languages/js/test/classes.ts
+++ b/languages/js/test/classes.ts
@@ -116,10 +116,9 @@ export class ConstructorMapObjectArgs {
   }
 }
 
-// ignoring a bunch of TS checks intentionally
 export class ConstructorAnyArg {
-  readonly opts: any;
-  constructor(opts: any) {
+  readonly opts;
+  constructor(opts: unknown) {
     this.opts = opts;
   }
 }

--- a/languages/js/test/classes.ts
+++ b/languages/js/test/classes.ts
@@ -116,6 +116,14 @@ export class ConstructorMapObjectArgs {
   }
 }
 
+// ignoring a bunch of TS checks intentionally
+export class ConstructorAnyArg {
+  readonly opts: any
+  constructor(opts: any) {
+    this.opts = opts;
+  }
+}
+
 let counter = 0;
 
 export class Counter {

--- a/languages/js/test/classes.ts
+++ b/languages/js/test/classes.ts
@@ -118,7 +118,7 @@ export class ConstructorMapObjectArgs {
 
 // ignoring a bunch of TS checks intentionally
 export class ConstructorAnyArg {
-  readonly opts: any
+  readonly opts: any;
   constructor(opts: any) {
     this.opts = opts;
   }

--- a/polar-wasm-api/Cargo.toml
+++ b/polar-wasm-api/Cargo.toml
@@ -13,7 +13,6 @@ console_error_panic_hook = "0.1.6"
 js-sys = "0.3.53"
 polar-core = { path = "../polar-core", version = "=0.21.0" }
 serde = { version = "1.0.119", features = ["rc"] }
-serde_json = "1.0.61"
 serde-wasm-bindgen = "0.3.1"
 wasm-bindgen = "0.2.76"
 

--- a/polar-wasm-api/src/errors.rs
+++ b/polar-wasm-api/src/errors.rs
@@ -10,10 +10,6 @@ pub struct Error {
     inner: FormattedPolarError,
 }
 
-pub fn serde_serialization_error(e: serde_json::Error) -> JsValue {
-    serialization_error(e.to_string())
-}
-
 pub fn serialization_error(msg: String) -> JsValue {
     Error::from(PolarError::from(RuntimeError::Serialization { msg })).into()
 }

--- a/polar-wasm-api/src/query.rs
+++ b/polar-wasm-api/src/query.rs
@@ -1,7 +1,7 @@
-use polar_core::{polar, terms::Symbol, terms::Term};
+use polar_core::{polar, terms::Symbol};
 use wasm_bindgen::prelude::*;
 
-use crate::errors::{serde_serialization_error, serialization_error, Error};
+use crate::errors::{serialization_error, Error};
 use crate::JsResult;
 
 #[wasm_bindgen]
@@ -27,15 +27,8 @@ impl Query {
     }
 
     #[wasm_bindgen(js_class = Query, js_name = callResult)]
-    pub fn wasm_call_result(&mut self, call_id: f64, value: Option<String>) -> JsResult<()> {
-        let term: Option<Term> = if let Some(value) = value {
-            match serde_json::from_str(&value) {
-                Ok(term) => Some(term),
-                Err(e) => return Err(serde_serialization_error(e)),
-            }
-        } else {
-            None
-        };
+    pub fn wasm_call_result(&mut self, call_id: f64, value: JsValue) -> JsResult<()> {
+        let term = serde_wasm_bindgen::from_value(value)?;
         self.0
             .call_result(call_id as u64, term)
             .map_err(Error::from)
@@ -78,11 +71,8 @@ impl Query {
     }
 
     #[wasm_bindgen(js_class = Query, js_name = bind)]
-    pub fn wasm_bind(&mut self, name: &str, value: &str) -> JsResult<()> {
-        let term = match serde_json::from_str(value) {
-            Ok(term) => term,
-            Err(e) => return Err(serde_serialization_error(e)),
-        };
+    pub fn wasm_bind(&mut self, name: &str, value: JsValue) -> JsResult<()> {
+        let term = serde_wasm_bindgen::from_value(value)?;
         self.0
             .bind(Symbol::new(name), term)
             .map_err(Error::from)

--- a/polar-wasm-api/tests/polar.rs
+++ b/polar-wasm-api/tests/polar.rs
@@ -86,21 +86,16 @@ fn register_constant_succeeds() {
     let mut polar = polar_wasm_api::Polar::wasm_new();
     let res = polar.wasm_register_constant(
         "mathematics",
-        r#"{"value":{"ExternalInstance":{"instance_id":1,"literal":null,"repr":null}}}"#,
+        serde_wasm_bindgen::to_value(
+            Value::ExternalInstance(ExternalInstance {
+                instance_id: 1,
+                literal: None,
+                repr: None,
+            })
+            .unwrap(),
+        ),
     );
     assert!(matches!(res, Ok(())));
-}
-
-#[wasm_bindgen_test]
-fn register_constant_errors() {
-    let mut polar = polar_wasm_api::Polar::wasm_new();
-    let err = polar.wasm_register_constant("mathematics", "").unwrap_err();
-    let err: Error = err.dyn_into().unwrap();
-    assert_eq!(err.name(), "RuntimeError::Serialization");
-    assert_eq!(
-        err.message(),
-        "Serialization error: EOF while parsing a value at line 1 column 0"
-    );
 }
 
 #[wasm_bindgen_test]
@@ -125,6 +120,11 @@ fn new_query_from_str_errors() {
 fn new_query_from_term_succeeds() {
     let polar = polar_wasm_api::Polar::wasm_new();
     let term = r#"{"value":{"Call":{"name":"x","args":[]}}}"#;
+    let term = Value::Call(Call {
+        name: "x",
+        args: vec![],
+    });
+    let term = serde_wasm_bindgen::to_value(&term).unwrap();
     let mut query = polar.wasm_new_query_from_term(term).unwrap();
     let event: Object = query.wasm_next_event().unwrap().dyn_into().unwrap();
     assert!(is_done_event(event));

--- a/polar-wasm-api/tests/polar.rs
+++ b/polar-wasm-api/tests/polar.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::*;
 
 use polar_core::sources::Source;
+use polar_core::terms::*;
 
 fn is_done_event(event: Object) -> bool {
     let event_kind: JsValue = "Done".into();
@@ -86,14 +87,12 @@ fn register_constant_succeeds() {
     let mut polar = polar_wasm_api::Polar::wasm_new();
     let res = polar.wasm_register_constant(
         "mathematics",
-        serde_wasm_bindgen::to_value(
-            Value::ExternalInstance(ExternalInstance {
-                instance_id: 1,
-                literal: None,
-                repr: None,
-            })
-            .unwrap(),
-        ),
+        serde_wasm_bindgen::to_value(&Value::ExternalInstance(ExternalInstance {
+            instance_id: 1,
+            constructor: None,
+            repr: None,
+        }))
+        .unwrap(),
     );
     assert!(matches!(res, Ok(())));
 }
@@ -119,10 +118,10 @@ fn new_query_from_str_errors() {
 #[wasm_bindgen_test]
 fn new_query_from_term_succeeds() {
     let polar = polar_wasm_api::Polar::wasm_new();
-    let term = r#"{"value":{"Call":{"name":"x","args":[]}}}"#;
     let term = Value::Call(Call {
-        name: "x",
+        name: Symbol("x".into()),
         args: vec![],
+        kwargs: None,
     });
     let term = serde_wasm_bindgen::to_value(&term).unwrap();
     let mut query = polar.wasm_new_query_from_term(term).unwrap();
@@ -133,7 +132,7 @@ fn new_query_from_term_succeeds() {
 #[wasm_bindgen_test]
 fn new_query_from_term_errors() {
     let polar = polar_wasm_api::Polar::wasm_new();
-    let res = polar.wasm_new_query_from_term("");
+    let res = polar.wasm_new_query_from_term("".into());
     if let Err(err) = res {
         let err: Error = err.dyn_into().unwrap();
         assert_eq!(err.name(), "RuntimeError::Serialization");

--- a/polar-wasm-api/tests/query.rs
+++ b/polar-wasm-api/tests/query.rs
@@ -3,17 +3,19 @@ use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::*;
 
 use polar_core::sources::Source;
+use polar_core::terms::*;
 
 #[wasm_bindgen_test]
 #[allow(clippy::float_cmp)]
 fn call_result_succeeds() {
     let mut polar = polar_wasm_api::Polar::wasm_new();
-    polar
-        .wasm_register_constant(
-            "y",
-            r#"{"value":{"ExternalInstance":{"instance_id":1,"literal":null,"repr":null}}}"#,
-        )
-        .unwrap();
+    let term = Value::ExternalInstance(ExternalInstance {
+        instance_id: 1,
+        constructor: None,
+        repr: None,
+    });
+    let term = serde_wasm_bindgen::to_value(&term).unwrap();
+    polar.wasm_register_constant("y", term).unwrap();
     let source = Source {
         src: "x() if y.z;".to_owned(),
         filename: None,
@@ -29,7 +31,7 @@ fn call_result_succeeds() {
     let call_id = Reflect::get(&event_data, &event_field).unwrap();
     assert_eq!(call_id, 3.0);
 
-    let call_result = Some(r#"{"value":{"Boolean":true}}"#.to_string());
+    let call_result = serde_wasm_bindgen::to_value(&Value::Boolean(true)).unwrap();
     query.wasm_call_result(3.0, call_result).unwrap();
 
     let event: Object = query.wasm_next_event().unwrap().dyn_into().unwrap();
@@ -39,7 +41,7 @@ fn call_result_succeeds() {
     let bindings = Reflect::get(&event_data, &data_key).unwrap();
     assert_eq!(bindings.dyn_into::<Map>().unwrap().size(), 0);
 
-    query.wasm_call_result(3.0, None).unwrap();
+    query.wasm_call_result(3.0, JsValue::undefined()).unwrap();
 
     let event: Object = query.wasm_next_event().unwrap().dyn_into().unwrap();
     let event_kind: JsValue = "Done".into();
@@ -50,12 +52,13 @@ fn call_result_succeeds() {
 #[allow(clippy::float_cmp)]
 fn app_error_succeeds() {
     let mut polar = polar_wasm_api::Polar::wasm_new();
-    polar
-        .wasm_register_constant(
-            "y",
-            r#"{"value":{"ExternalInstance":{"instance_id":1,"literal":null,"repr":null}}}"#,
-        )
-        .unwrap();
+    let term = Value::ExternalInstance(ExternalInstance {
+        instance_id: 1,
+        constructor: None,
+        repr: None,
+    });
+    let term = serde_wasm_bindgen::to_value(&term).unwrap();
+    polar.wasm_register_constant("y", term).unwrap();
     let source = Source {
         src: "x() if y.z;".to_owned(),
         filename: None,


### PR DESCRIPTION
Fixes #1242 indirectly.

Previously we were using `serde_json` to accept json-serialized strings from JS, and also `serde_wasm_bindgen` to return JS objects back (and in one place to receive an object too).

This remove `serde_json` entirely, so that everything is sent/received as `JsValue` and deserialized from that.


PR checklist:

<!-- Delete if no entry is required. -->
- [x] Added changelog entry.
