### PR TITLE
Make semicolons optional

### DIFF
--- a/polar-core/src/lexer.rs
+++ b/polar-core/src/lexer.rs
@@ -79,6 +79,7 @@ pub enum Token {
     SemiColon, // ;
     Query,     // ?=
     In,        // in
+    On,        // on
     Cut,       // cut
     Debug,     // debug()
     Print,     // print()
@@ -100,35 +101,36 @@ impl ToString for Token {
             Token::String(s) => s.clone(),
             Token::Boolean(b) => b.to_string(),
             Token::Symbol(sym) => sym.0.clone(),
-            Token::Colon => ":".to_owned(),         // :
-            Token::Comma => ",".to_owned(),         // ,
-            Token::LB => "[".to_owned(),            // [
-            Token::RB => "]".to_owned(),            // ]
-            Token::LP => "(".to_owned(),            // (
-            Token::RP => ")".to_owned(),            // )
-            Token::LCB => "{".to_owned(),           // {
-            Token::RCB => "}".to_owned(),           // }
-            Token::Dot => ".".to_owned(),           // .
-            Token::New => "new".to_owned(),         // new
-            Token::Bang => "!".to_owned(),          // !
-            Token::Mul => "*".to_owned(),           // *
-            Token::Div => "/".to_owned(),           // /
-            Token::Mod => "mod".to_owned(),         // mod
-            Token::Rem => "rem".to_owned(),         // rem
-            Token::Add => "+".to_owned(),           // +
-            Token::Sub => "-".to_owned(),           // -
-            Token::Eq => "==".to_owned(),           // ==
-            Token::Neq => "!=".to_owned(),          // !=
-            Token::Leq => "<=".to_owned(),          // <=
-            Token::Geq => ">=".to_owned(),          // >=
-            Token::Lt => "<".to_owned(),            // <
-            Token::Gt => ">".to_owned(),            // >
-            Token::Unify => "=".to_owned(),         // =
-            Token::Assign => ":=".to_owned(),       // :=
-            Token::Pipe => "|".to_owned(),          // |
-            Token::SemiColon => ";".to_owned(),     // ;
-            Token::Query => "?=".to_owned(),        // ?=
-            Token::In => "in".to_owned(),           // in
+            Token::Colon => ":".to_owned(),     // :
+            Token::Comma => ",".to_owned(),     // ,
+            Token::LB => "[".to_owned(),        // [
+            Token::RB => "]".to_owned(),        // ]
+            Token::LP => "(".to_owned(),        // (
+            Token::RP => ")".to_owned(),        // )
+            Token::LCB => "{".to_owned(),       // {
+            Token::RCB => "}".to_owned(),       // }
+            Token::Dot => ".".to_owned(),       // .
+            Token::New => "new".to_owned(),     // new
+            Token::Bang => "!".to_owned(),      // !
+            Token::Mul => "*".to_owned(),       // *
+            Token::Div => "/".to_owned(),       // /
+            Token::Mod => "mod".to_owned(),     // mod
+            Token::Rem => "rem".to_owned(),     // rem
+            Token::Add => "+".to_owned(),       // +
+            Token::Sub => "-".to_owned(),       // -
+            Token::Eq => "==".to_owned(),       // ==
+            Token::Neq => "!=".to_owned(),      // !=
+            Token::Leq => "<=".to_owned(),      // <=
+            Token::Geq => ">=".to_owned(),      // >=
+            Token::Lt => "<".to_owned(),        // <
+            Token::Gt => ">".to_owned(),        // >
+            Token::Unify => "=".to_owned(),     // =
+            Token::Assign => ":=".to_owned(),   // :=
+            Token::Pipe => "|".to_owned(),      // |
+            Token::SemiColon => ";".to_owned(), // ;
+            Token::Query => "?=".to_owned(),    // ?=
+            Token::In => "in".to_owned(),       // in
+            Token::On => "on".to_string(),
             Token::Cut => "cut".to_owned(),         // cut
             Token::Debug => "debug".to_owned(),     // debug
             Token::Print => "print".to_owned(),     // print
@@ -222,6 +224,7 @@ impl<'input> Lexer<'input> {
             "nan" => Token::Float(f64::NAN),
             "new" => Token::New,
             "in" => Token::In,
+            "on" => Token::On,
             "cut" => Token::Cut,
             "debug" => Token::Debug,
             "print" => Token::Print,

--- a/polar-core/src/parser.rs
+++ b/polar-core/src/parser.rs
@@ -264,12 +264,6 @@ mod tests {
 
         let f = r#"a(x) if x = new Foo(bar: 3, baz: 4, 1, 2);"#;
         parse_rules(0, f).expect_err("parse error");
-
-        // Don't allow kwargs in calls or dot ops.
-        let f = r#"a(x) if f(x: 1)"#;
-        parse_rules(0, f).expect_err("parse error");
-        let f = r#"a(x) if x.f(x: 1)"#;
-        parse_rules(0, f).expect_err("parse error");
     }
 
     #[test]

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -58,6 +58,7 @@ extern {
         "debug" => lexer::Token::Debug,     // debug
         "print" => lexer::Token::Print,     // print
         "in" => lexer::Token::In,           // in
+        "on" => lexer::Token::On,           // on
         "forall" => lexer::Token::ForAll,   // forall
         "if" => lexer::Token::If,           // if
         "and" => lexer::Token::And,         // and
@@ -657,16 +658,15 @@ RuleHead: (Symbol, Vec<Parameter>) = {
     }
 };
 
-Define = {"if"};
 
 Rule: Rule = {
-    <start_head:@L> <head:RuleHead> <start:@L> <end:@R> ";" => {
+    <start_head:@L> <head:RuleHead> <start:@L> <end:@R> ";"? => {
         let (name, params) = head;
         let op = Operation{operator: Operator::And, args: vec![]};
         let body = Term::new_from_parser(src_id, start, end, Value::Expression(op));
         Rule::new_from_parser(src_id, start_head, start, name, params, body)
     },
-    <start_head:@L> <head:RuleHead> <end_head:@R> Define <body:TermExp> ";" => {
+    <start_head:@L> <head:RuleHead> <end_head:@R> "if" <body:TermExp> ";"? => {
         let (name, params) = head;
         let body = match body.value() {
             Value::Expression(Operation{operator: Operator::And, ..}) => {
@@ -682,7 +682,7 @@ Rule: Rule = {
 }
 
 RuleType: Rule = {
-    "type" <start_head:@L> <head:RuleHead> <start:@L> <end:@R> ";" => {
+    "type" <start_head:@L> <head:RuleHead> <start:@L> <end:@R> ";"? => {
         let (name, params) = head;
         let op = Operation{operator: Operator::And, args: vec![]};
         let body = Term::new_from_parser(src_id, start, end, Value::Expression(op));
@@ -708,19 +708,19 @@ StringList: Value = {
 }
 RelationsDict: Value = <Object<Spanned<Variable>>> => Value::Dictionary(<>);
 Declaration: resource_block::Production = {
-    <start:@L> <keyword:Name> "=" <value:StringList> <end:@R> ";" =>? {
+    <start:@L> <keyword:Name> "=" <value:StringList> <end:@R> ";"? =>? {
         let term = Term::new_from_parser(src_id, start, end, value);
         return resource_block::validate_parsed_declaration((keyword, term));
     },
-    <start:@L> <keyword:Name> "=" <value:RelationsDict> <end:@R> ";" =>? {
+    <start:@L> <keyword:Name> "=" <value:RelationsDict> <end:@R> ";"? =>? {
         let term = Term::new_from_parser(src_id, start, end, value);
         return resource_block::validate_parsed_declaration((keyword, term));
     },
 }
 
-OnRelation: Term = <Spanned<Variable>> <Spanned<PolarString>> =>? resource_block::validate_relation_keyword((<>));
+OnRelation: Term = "on" <Spanned<PolarString>> => <>;
 ShorthandRuleBody: (Term, Option<Term>) = <implier:Spanned<PolarString>> <relation:OnRelation?> ";" => (<>);
-ShorthandRule: resource_block::Production = <head:Spanned<PolarString>> Define <body:ShorthandRuleBody> => resource_block::Production::ShorthandRule(<>);
+ShorthandRule: resource_block::Production = <head:Spanned<PolarString>> "if" <body:ShorthandRuleBody> => resource_block::Production::ShorthandRule(<>);
 
 ResourceBlockProduction: resource_block::Production = {
     <Declaration> => <>,
@@ -732,7 +732,7 @@ ResourceBlockProductions: Vec<resource_block::Production> = <ResourceBlockProduc
 Line: Line = {
     <Rule> => Line::Rule(<>),
     <RuleType> => Line::RuleType(<>),
-    "?=" <TermExp> ";" => Line::Query(<>),
+    "?=" <TermExp> ";"? => Line::Query(<>),
 
     <start:@L> <keyword:Spanned<Variable>?> <resource:Variable> "{" <productions:ResourceBlockProductions> "}" <end:@R> =>? {
         let resource = Term::new_from_parser(src_id, start, end, resource);

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -366,7 +366,7 @@ mod tests {
 
         // load a broken file
         let invalid = Source {
-            src: "f(x) if x".to_owned(),
+            src: "f(x) if".to_owned(),
             filename: Some("test.polar".to_string()),
         };
         polar.load(vec![invalid]).unwrap_err();


### PR DESCRIPTION
This is a backward-compatible syntax change that makes semicolons optional in every place where we currently require them.

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
