### PR TITLE
build m1 libs in ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
     branches:
-      - steve/arm-libs
+      - main
 
 jobs:
   version:
@@ -16,7 +16,7 @@ jobs:
       - name: Set version env
         run: echo "oso_version=$(cat VERSION)" >> $GITHUB_ENV
       - name: Check github ref matches
-        if: github.ref != 'refs/heads/steve/arm-libs'
+        if: github.ref != 'refs/heads/main'
         env:
           github_ref: ${{ github.ref }}
         run: grep "${github_ref/refs\/tags\/v/}" VERSION
@@ -769,7 +769,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/steve/arm-libs'
+    if: github.ref != 'refs/heads/main'
     needs:
       [
         build_linux_wheels,


### PR DESCRIPTION
First step towards supporting M1 libraries. This builds the static and dynamic libraries for M1 Macs as part of the release process, but does not yet use them for anything.

For the next release I will manually download this lib and build the M1 wheel.