### PR TITLE
Fix python build for Mac

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,10 +333,10 @@ jobs:
 
   build_macos_wheels:
     name: Build wheels on MacOS
-    # Build on latest so we can still build a 3.6 wheel.
+    # Build on 10.15 so we can still build a 3.6 wheel.
     # May have to drop once github actions switches to macos-11 by default
     # because 3.6 isn't supported on 11.
-    runs-on: macos-latest
+    runs-on: macos-10.15
     needs: [version, macos_libs]
     env:
       # Skip Python 2.7 and Python 3.5
@@ -555,7 +555,7 @@ jobs:
   validate_python_macos_old:
     name: Test python ${{ matrix.python-version }} on MacOS
     needs: [build_macos_wheels]
-    runs-on: macos-latest
+    runs-on: macos-10.15
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]


### PR DESCRIPTION
3.6 isn't supported on macos-11.
This still tests it on macos-latest, at least until github actions updates to macos-11 only.