### PR TITLE
fix typorm data filtering example

### DIFF
--- a/docs/examples/data_filtering/nodejs/data_filtering_example_a.ts
+++ b/docs/examples/data_filtering/nodejs/data_filtering_example_a.ts
@@ -9,7 +9,8 @@ import {
   Column,
   PrimaryColumn,
   PrimaryGeneratedColumn,
-} from "typeorm";
+  IsNull,
+} from 'typeorm';
 import { readFileSync } from "fs";
 import * as assert from 'assert';
 
@@ -68,7 +69,7 @@ const constrain = (query, filter) => {
 // Create a query from a list of filters
 const buildQuery = filters => {
   // TypeORM dislikes empty queries, so give it this instead.
-  if (!filters.length) return { id: Not(null) };
+  if (!filters.length) return { id: Not(IsNull()) };
   return filters.reduce(constrain, {});
 };
 


### PR DESCRIPTION
First of all, thanks for the awesome documentation.

Here's a simple fix on the data filtering documentation which uses TypeOrm.
https://docs.osohq.com/node/guides/data_filtering.html

`id: Not(null)` means `id != null` which always results to `false`. Therefore, when there are no filters, the query will always result empty (because the WHERE always evaluates to false).
`Not(IsNull))` should be used instead.

A simple fix, but confused me at first because I thought my Polar wasn't configured correctly.

Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>
