### PR TITLE
Initial implementation of Polar::diagnostic_load

### DIFF
--- a/polar-core/src/diagnostic.rs
+++ b/polar-core/src/diagnostic.rs
@@ -1,0 +1,6 @@
+use super::error::PolarError;
+
+pub enum Diagnostic {
+    Error(PolarError),
+    Warning(String),
+}

--- a/polar-core/src/diagnostic.rs
+++ b/polar-core/src/diagnostic.rs
@@ -1,6 +1,18 @@
+use std::fmt;
+
 use super::error::PolarError;
 
 pub enum Diagnostic {
     Error(PolarError),
     Warning(String),
+}
+
+impl fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self {
+            Diagnostic::Error(e) => write!(f, "{}", e)?,
+            Diagnostic::Warning(w) => write!(f, "{}", w)?,
+        }
+        Ok(())
+    }
 }

--- a/polar-core/src/diagnostic.rs
+++ b/polar-core/src/diagnostic.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use super::error::PolarError;
 
+#[derive(Debug)]
 pub enum Diagnostic {
     Error(PolarError),
     Warning(String),

--- a/polar-core/src/diagnostic.rs
+++ b/polar-core/src/diagnostic.rs
@@ -8,6 +8,12 @@ pub enum Diagnostic {
     Warning(String),
 }
 
+impl Diagnostic {
+    pub fn is_error(&self) -> bool {
+        matches!(self, Diagnostic::Error(_))
+    }
+}
+
 impl fmt::Display for Diagnostic {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -110,17 +110,14 @@ impl KnowledgeBase {
         generic_rule.add_rule(Arc::new(rule));
     }
 
-    pub fn validate_rules(&self) -> PolarResult<()> {
+    // TODO(gj): return Vec<Diagnostic> (no Result)
+    pub fn validate_rules(&self) -> PolarResult<Vec<Diagnostic>> {
         self.validate_rule_types()?;
-        self.validate_rule_calls()
+        Ok(self.validate_rule_calls())
     }
 
-    fn validate_rule_calls(&self) -> PolarResult<()> {
-        let errors = check_undefined_rule_calls(self);
-        match errors.into_iter().next() {
-            Some(e) => Err(e),
-            None => Ok(()),
-        }
+    fn validate_rule_calls(&self) -> Vec<Diagnostic> {
+        check_undefined_rule_calls(self)
     }
 
     /// Validate that all rules loaded into the knowledge base are valid based on rule types.

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -741,10 +741,11 @@ impl KnowledgeBase {
             }
         }
 
-        // TODO(gj): maybe only add rules to the KB if there are no errors?
-        // Add the rewritten rules to the KB.
-        for rule in rules {
-            self.add_rule(rule);
+        if errors.is_empty() {
+            // Add the rewritten rules to the KB.
+            for rule in rules {
+                self.add_rule(rule);
+            }
         }
 
         errors.into_iter().map(Diagnostic::Error).collect()

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -20,8 +20,8 @@ enum RuleParamMatch {
     False(String),
 }
 
+#[cfg(test)]
 impl RuleParamMatch {
-    #[cfg(test)]
     fn is_true(&self) -> bool {
         matches!(self, RuleParamMatch::True)
     }

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -7,7 +7,7 @@ use crate::visitor::{walk_term, Visitor};
 
 pub use super::bindings::Bindings;
 use super::counter::Counter;
-use super::polar::Diagnostic;
+use super::diagnostic::Diagnostic;
 use super::resource_block::ResourceBlocks;
 use super::resource_block::{ACTOR_UNION_NAME, RESOURCE_UNION_NAME};
 use super::rules::*;

--- a/polar-core/src/lib.rs
+++ b/polar-core/src/lib.rs
@@ -11,7 +11,7 @@ mod bindings;
 mod counter;
 pub mod data_filtering;
 mod debugger;
-mod diagnostic;
+pub mod diagnostic;
 pub mod error;
 pub mod events;
 mod folder;

--- a/polar-core/src/lib.rs
+++ b/polar-core/src/lib.rs
@@ -11,6 +11,7 @@ mod bindings;
 mod counter;
 pub mod data_filtering;
 mod debugger;
+mod diagnostic;
 pub mod error;
 pub mod events;
 mod folder;

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -270,12 +270,7 @@ impl Polar {
 
         // Perform validation checks against the whole policy
         if !self.ignore_no_allow_warning {
-            diagnostics.append(
-                &mut check_no_allow_rule(&kb)
-                    .into_iter()
-                    .map(Diagnostic::Warning)
-                    .collect(),
-            );
+            check_no_allow_rule(&kb).map(|w| diagnostics.push(w));
         }
 
         // Check for has_permission calls alongside resource block definitions

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -254,9 +254,7 @@ impl Polar {
         }
 
         // check rules are valid against rule types
-        if let Err(e) = kb.validate_rules() {
-            diagnostics.push(Diagnostic::Error(e));
-        }
+        diagnostics.append(&mut kb.validate_rules());
 
         // Perform validation checks against the whole policy
         if !self.ignore_no_allow_warning {

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -184,12 +184,7 @@ impl Polar {
             while let Some(line) = lines.pop() {
                 match line {
                     parser::Line::Rule(rule) => {
-                        match check_singletons(&rule, kb) {
-                            Ok(warnings) => diagnostics.append(
-                                &mut warnings.into_iter().map(Diagnostic::Warning).collect(),
-                            ),
-                            Err(e) => diagnostics.push(Diagnostic::Error(e)),
-                        }
+                        diagnostics.append(&mut check_singletons(&rule, kb));
                         diagnostics.append(&mut check_ambiguous_precedence(&rule, kb));
                         let rule = rewrite_rule(rule, kb);
                         kb.add_rule(rule);

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -280,12 +280,6 @@ impl Polar {
         }])
     }
 
-    // TODO(gj): ask Sam if we still need this.
-    pub fn remove_file(&self, filename: &str) -> Option<String> {
-        let mut kb = self.kb.write().unwrap();
-        kb.remove_file(filename)
-    }
-
     /// Clear rules from the knowledge base
     pub fn clear_rules(&self) {
         let mut kb = self.kb.write().unwrap();
@@ -375,31 +369,6 @@ mod tests {
         let polar = Polar::new();
         let _query = polar.new_query("1 = 1", false);
         let _ = polar.load_str("f(_);");
-    }
-
-    #[test]
-    fn load_remove_files() {
-        let polar = Polar::new();
-        let valid = Source {
-            src: "f(x) if x = 1;".to_owned(),
-            filename: Some("test.polar".to_string()),
-        };
-        polar.load(vec![valid.clone()]).unwrap();
-        polar.remove_file("test.polar");
-
-        // loading works after removing
-        polar.load(vec![valid.clone()]).unwrap();
-        polar.remove_file("test.polar");
-
-        // load a broken file
-        let invalid = Source {
-            src: "f(x) if x".to_owned(),
-            filename: Some("test.polar".to_string()),
-        };
-        polar.load(vec![invalid]).unwrap_err();
-
-        // can still load files again
-        polar.load(vec![valid]).unwrap();
     }
 
     #[test]

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -168,6 +168,7 @@ impl Polar {
         }
     }
 
+    /// Load `sources` into the KB, returning compile-time diagnostics accumulated during the load.
     pub fn diagnostic_load(&self, sources: Vec<Source>) -> Vec<Diagnostic> {
         // we extract this into a separate function
         // so that any errors returned with `?` are captured
@@ -233,8 +234,14 @@ impl Polar {
             match result {
                 Ok(mut ds) => diagnostics.append(&mut ds),
                 Err(e) => {
+                    let is_parse_error = matches!(e.kind, error::ErrorKind::Parse(_));
+                    let is_file_loading_error = matches!(
+                        e.kind,
+                        error::ErrorKind::Runtime(error::RuntimeError::FileLoading { .. })
+                    );
+                    assert!(is_parse_error || is_file_loading_error, "{}", e);
+
                     diagnostics.push(Diagnostic::Error(e));
-                    // TODO(gj): In this match arm, `e` *must* be a `ParseError`.
                     encountered_unrecoverable_error = true;
                 }
             }

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -265,11 +265,15 @@ impl Polar {
 
         // Perform validation checks against the whole policy
         if !self.ignore_no_allow_warning {
-            check_no_allow_rule(&kb).map(|w| diagnostics.push(w));
+            if let Some(w) = check_no_allow_rule(&kb) {
+                diagnostics.push(w)
+            }
         }
 
         // Check for has_permission calls alongside resource block definitions
-        check_resource_blocks_missing_has_permission(&kb).map(|w| diagnostics.push(w));
+        if let Some(w) = check_resource_blocks_missing_has_permission(&kb) {
+            diagnostics.push(w)
+        };
 
         diagnostics
     }

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -1,4 +1,5 @@
 use super::data_filtering::{build_filter_plan, FilterPlan, PartialResults, Types};
+use super::diagnostic::Diagnostic;
 use super::error::PolarResult;
 use super::events::*;
 use super::kb::*;
@@ -151,11 +152,6 @@ impl Default for Polar {
 
 const MULTIPLE_LOAD_ERROR_MSG: &str =
     "Cannot load additional Polar code -- all Polar code must be loaded at the same time.";
-
-pub enum Diagnostic {
-    Error(error::PolarError),
-    Warning(String),
-}
 
 impl Polar {
     pub fn new() -> Self {

--- a/polar-core/src/polar.rs
+++ b/polar-core/src/polar.rs
@@ -190,12 +190,7 @@ impl Polar {
                             ),
                             Err(e) => diagnostics.push(Diagnostic::Error(e)),
                         }
-                        diagnostics.append(
-                            &mut check_ambiguous_precedence(&rule, kb)
-                                .into_iter()
-                                .map(Diagnostic::Warning)
-                                .collect(),
-                        );
+                        diagnostics.append(&mut check_ambiguous_precedence(&rule, kb));
                         let rule = rewrite_rule(rule, kb);
                         kb.add_rule(rule);
                     }
@@ -274,12 +269,7 @@ impl Polar {
         }
 
         // Check for has_permission calls alongside resource block definitions
-        diagnostics.append(
-            &mut check_resource_blocks_missing_has_permission(&kb)
-                .into_iter()
-                .map(Diagnostic::Warning)
-                .collect(),
-        );
+        check_resource_blocks_missing_has_permission(&kb).map(|w| diagnostics.push(w));
 
         diagnostics
     }

--- a/polar-core/src/resource_block.rs
+++ b/polar-core/src/resource_block.rs
@@ -3,10 +3,10 @@ use std::ops::Range;
 
 use lalrpop_util::ParseError as LalrpopError;
 
+use super::diagnostic::Diagnostic;
 use super::error::{ParseError, PolarError, PolarResult, RuntimeError};
 use super::kb::KnowledgeBase;
 use super::lexer::Token;
-use super::polar::Diagnostic;
 use super::rules::*;
 use super::terms::*;
 

--- a/polar-core/src/resource_block.rs
+++ b/polar-core/src/resource_block.rs
@@ -1383,7 +1383,7 @@ mod tests {
         // Union matches union.
         kb.add_rule_type(rule!("f", ["x"; instance!(sym!(RESOURCE_UNION_NAME))]));
         kb.add_rule(rule!("f", ["x"; instance!(sym!(RESOURCE_UNION_NAME))]));
-        assert!(kb.validate_rules().is_ok());
+        assert!(kb.validate_rules().is_empty());
 
         kb.clear_rules();
         kb.resource_blocks.resources.insert(term!(sym!("Citrus")));
@@ -1396,11 +1396,11 @@ mod tests {
         kb.add_rule_type(rule!("f", ["x"; instance!(sym!(RESOURCE_UNION_NAME))]));
         kb.add_rule(rule!("f", ["x"; instance!(sym!(ACTOR_UNION_NAME))]));
         assert!(matches!(
-            kb.validate_rules().unwrap_err(),
-            PolarError {
+            kb.validate_rules().first().unwrap(),
+            Diagnostic::Error(PolarError {
                 kind: error::ErrorKind::Validation(error::ValidationError::InvalidRule { .. }),
                 ..
-            }
+            })
         ));
 
         kb.clear_rules();
@@ -1410,7 +1410,7 @@ mod tests {
         // Member of union matches union.
         kb.add_rule_type(rule!("f", ["x"; instance!(sym!(RESOURCE_UNION_NAME))]));
         kb.add_rule(rule!("f", ["x"; instance!(sym!("Citrus"))]));
-        assert!(kb.validate_rules().is_ok());
+        assert!(kb.validate_rules().is_empty());
 
         kb.clear_rules();
         kb.resource_blocks.resources.insert(term!(sym!("Citrus")));
@@ -1423,11 +1423,11 @@ mod tests {
         kb.add_rule_type(rule!("f", ["x"; instance!(sym!(ACTOR_UNION_NAME))]));
         kb.add_rule(rule!("f", ["x"; instance!(sym!("Citrus"))]));
         assert!(matches!(
-            kb.validate_rules().unwrap_err(),
-            PolarError {
+            kb.validate_rules().first().unwrap(),
+            Diagnostic::Error(PolarError {
                 kind: error::ErrorKind::Validation(error::ValidationError::InvalidRule { .. }),
                 ..
-            }
+            })
         ));
 
         kb.clear_rules();
@@ -1437,7 +1437,7 @@ mod tests {
         // Subclass of member of union matches union.
         kb.add_rule_type(rule!("f", ["x"; instance!(sym!(RESOURCE_UNION_NAME))]));
         kb.add_rule(rule!("f", ["x"; instance!(sym!("Orange"))]));
-        assert!(kb.validate_rules().is_ok());
+        assert!(kb.validate_rules().is_empty());
 
         kb.clear_rules();
         kb.resource_blocks.resources.insert(term!(sym!("Citrus")));
@@ -1447,11 +1447,11 @@ mod tests {
         kb.add_rule_type(rule!("f", ["x"; instance!(sym!(RESOURCE_UNION_NAME))]));
         kb.add_rule(rule!("f", ["x"; instance!(sym!("Fruit"))]));
         assert!(matches!(
-            kb.validate_rules().unwrap_err(),
-            PolarError {
+            kb.validate_rules().first().unwrap(),
+            Diagnostic::Error(PolarError {
                 kind: error::ErrorKind::Validation(error::ValidationError::InvalidRule { .. }),
                 ..
-            }
+            })
         ));
 
         // kb.clear_rules();

--- a/polar-core/src/validations.rs
+++ b/polar-core/src/validations.rs
@@ -291,17 +291,17 @@ impl<'kb> UndefinedRuleVisitor<'kb> {
         }
     }
 
-    fn errors(&mut self) -> Vec<PolarError> {
+    fn errors(&mut self) -> Vec<Diagnostic> {
         let mut errors = vec![];
         for term in &self.call_terms {
             let call = term.value().as_call().unwrap();
             if !self.defined_rules.contains(&call.name) {
-                errors.push(self.kb.set_error_context(
+                errors.push(Diagnostic::Error(self.kb.set_error_context(
                     term,
                     error::ValidationError::UndefinedRule {
                         rule_name: call.name.0.clone(),
                     },
-                ));
+                )));
             }
         }
         errors
@@ -323,7 +323,7 @@ impl<'kb> Visitor for UndefinedRuleVisitor<'kb> {
     }
 }
 
-pub fn check_undefined_rule_calls(kb: &KnowledgeBase) -> Vec<PolarError> {
+pub fn check_undefined_rule_calls(kb: &KnowledgeBase) -> Vec<Diagnostic> {
     let mut visitor = UndefinedRuleVisitor::new(kb, kb.get_rules().keys().collect());
     for rule in kb.get_rules().values() {
         visitor.visit_generic_rule(rule);
@@ -417,7 +417,6 @@ mod tests {
         let mut kb = KnowledgeBase::new();
         kb.add_rule(rule!("f", [sym!("x")] => call!("defined_rule", [sym!("y")])));
         kb.add_rule(rule!("defined_rule", [sym!("x")]));
-        let errors = check_undefined_rule_calls(&kb);
-        assert_eq!(errors.len(), 0);
+        assert!(check_undefined_rule_calls(&kb).is_empty());
     }
 }

--- a/polar-core/src/validations.rs
+++ b/polar-core/src/validations.rs
@@ -103,7 +103,7 @@ impl<'kb> SingletonVisitor<'kb> {
                 }
                 Ok(msg)
             })
-            .collect::<PolarResult<Vec<String>>>()
+            .collect()
     }
 }
 

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -2406,19 +2406,44 @@ fn test_lookup_in_rule_head() -> TestResult {
 #[test]
 fn test_default_rule_types() -> TestResult {
     let p = Polar::new();
+
     // This should fail
     let e = p
         .load_str(r#"has_permission("leina", "eat", "food");"#)
         .expect_err("Expected validation error");
     assert!(matches!(e.kind, ErrorKind::Validation(_)));
+    assert!(matches!(
+        p.next_message(),
+        Some(Message {
+            kind: MessageKind::Warning,
+            msg
+        }) if msg.starts_with("Your policy does not contain an allow rule")
+    ));
+
     let e = p
         .load_str(r#"has_role("leina", "eater", "food");"#)
         .expect_err("Expected validation error");
     assert!(matches!(e.kind, ErrorKind::Validation(_)));
+    assert!(matches!(
+        p.next_message(),
+        Some(Message {
+            kind: MessageKind::Warning,
+            msg
+        }) if msg.starts_with("Your policy does not contain an allow rule")
+    ));
+
     let e = p
         .load_str(r#"has_relation("leina", "eater", "food");"#)
         .expect_err("Expected validation error");
     assert!(matches!(e.kind, ErrorKind::Validation(_)));
+    assert!(matches!(
+        p.next_message(),
+        Some(Message {
+            kind: MessageKind::Warning,
+            msg
+        }) if msg.starts_with("Your policy does not contain an allow rule")
+    ));
+
     let e = p
         .load_str(r#"allow("leina", "food");"#)
         .expect_err("Expected validation error");

--- a/polar-core/tests/integration_tests.rs
+++ b/polar-core/tests/integration_tests.rs
@@ -1586,14 +1586,14 @@ fn test_missing_actor_hint() -> TestResult {
 
     let policy = r#"
 resource Organization {
-	roles = ["owner"];
-	permissions = ["read"];
+    roles = ["owner"];
+    permissions = ["read"];
 
-	"read" if "owner";
+    "read" if "owner";
 }
 
 has_role(user: User, "owner", organization: Organization) if
-	organization.owner_id = user.id;
+    organization.owner_id = user.id;
 "#;
     let err = p.load_str(policy).expect_err("Expected validation error");
     assert!(matches!(&err.kind, ErrorKind::Validation(_)));
@@ -2482,8 +2482,8 @@ fn test_suggested_rule_specializer() -> TestResult {
     let policy = r#"
 actor User {}
 resource Repository {
-	permissions = ["read"];
-	roles = ["contributor"];
+    permissions = ["read"];
+    roles = ["contributor"];
 
     "read" if "contributor";
 }


### PR DESCRIPTION
This PR covers:
- Surfacing multiple errors from `polar-core` -> `polar-language-server`

This PR does not cover:
- Surfacing warnings.
- Changing the rule type validation code to surface multiple errors.
- Changing the structure of errors or warnings.