### PR TITLE
Add parity tests for unhandled partial error + update Go types

### DIFF
--- a/languages/go/tests/unit_test.go
+++ b/languages/go/tests/unit_test.go
@@ -436,7 +436,7 @@ func TestFailingALot(t *testing.T) {
 
 		if err = <-errors; err != nil {
 			if !strings.Contains(err.Error(), "'1' object has no attribute 'Foo'") {
-				t.Error("Expected Polar runtime error, got none")
+				t.Errorf("Expected Polar runtime error, got: {}", err)
 			}
 		} else {
 			t.Fatal("oops")

--- a/languages/go/tests/unit_test.go
+++ b/languages/go/tests/unit_test.go
@@ -436,7 +436,7 @@ func TestFailingALot(t *testing.T) {
 
 		if err = <-errors; err != nil {
 			if !strings.Contains(err.Error(), "'1' object has no attribute 'Foo'") {
-				t.Errorf("Expected Polar runtime error, got: {}", err)
+				t.Errorf("Expected Polar runtime error, got: %s", err)
 			}
 		} else {
 			t.Fatal("oops")

--- a/languages/go/types/polar_types.go
+++ b/languages/go/types/polar_types.go
@@ -215,6 +215,11 @@ func (variant ErrorKind) MarshalJSON() ([]byte, error) {
 			"Parameter": inner,
 		})
 
+	case ErrorKindValidation:
+		return json.Marshal(map[string]ErrorKindValidation{
+			"Validation": inner,
+		})
+
 	}
 
 	return nil, fmt.Errorf("unexpected variant of %v", variant)
@@ -228,6 +233,14 @@ type ExternalInstance struct {
 	Constructor *Term `json:"constructor"`
 	// Repr
 	Repr *string `json:"repr"`
+}
+
+// FormattedPolarError struct
+type FormattedPolarError struct {
+	// Kind
+	Kind ErrorKind `json:"kind"`
+	// Formatted
+	Formatted string `json:"formatted"`
 }
 
 // InstanceLiteral struct
@@ -556,7 +569,7 @@ type Operation struct {
 	Args []Term `json:"args"`
 }
 
-// OperationalErrorUnimplemented newtype
+// OperationalErrorUnimplemented struct
 type OperationalErrorUnimplemented struct {
 	// Msg
 	Msg string `json:"msg"`
@@ -568,7 +581,7 @@ type OperationalErrorUnknown struct{}
 
 func (OperationalErrorUnknown) isOperationalError() {}
 
-// OperationalErrorInvalidState newtype
+// OperationalErrorInvalidState struct
 type OperationalErrorInvalidState struct {
 	// Msg
 	Msg string `json:"msg"`
@@ -1326,15 +1339,37 @@ type ParseErrorWrongValueType struct {
 
 func (ParseErrorWrongValueType) isParseError() {}
 
-// ParseErrorWrongValueType struct
+// ParseErrorDuplicateKey struct
 type ParseErrorDuplicateKey struct {
 	// Loc
 	Loc uint64 `json:"loc"`
-	// Expected
+	// Key
 	Key string `json:"key"`
 }
 
 func (ParseErrorDuplicateKey) isParseError() {}
+
+// ParseErrorSingletonVariable struct
+type ParseErrorSingletonVariable struct {
+	// Loc
+	Loc uint64 `json:"loc"`
+	// Name
+	Name string `json:"name"`
+}
+
+func (ParseErrorSingletonVariable) isParseError() {}
+
+// ParseErrorResourceBlock struct
+type ParseErrorResourceBlock struct {
+	// Loc
+	Loc uint64 `json:"loc"`
+	// Msg
+	Msg string `json:"msg"`
+	// Ranges
+	Ranges []Range `json:"ranges"`
+}
+
+func (ParseErrorResourceBlock) isParseError() {}
 
 // ParseError enum
 type ParseErrorVariant interface {
@@ -1478,6 +1513,28 @@ func (result *ParseError) UnmarshalJSON(b []byte) error {
 		*result = ParseError{variant}
 		return nil
 
+	case "SingletonVariable":
+		var variant ParseErrorSingletonVariable
+		if variantValue != nil {
+			err := json.Unmarshal(*variantValue, &variant)
+			if err != nil {
+				return err
+			}
+		}
+		*result = ParseError{variant}
+		return nil
+
+	case "ResourceBlock":
+		var variant ParseErrorResourceBlock
+		if variantValue != nil {
+			err := json.Unmarshal(*variantValue, &variant)
+			if err != nil {
+				return err
+			}
+		}
+		*result = ParseError{variant}
+		return nil
+
 	}
 
 	return fmt.Errorf("Cannot deserialize ParseError: %s", string(b))
@@ -1536,17 +1593,19 @@ func (variant ParseError) MarshalJSON() ([]byte, error) {
 			"DuplicateKey": inner,
 		})
 
+	case ParseErrorSingletonVariable:
+		return json.Marshal(map[string]ParseErrorSingletonVariable{
+			"SingletonVariable": inner,
+		})
+
+	case ParseErrorResourceBlock:
+		return json.Marshal(map[string]ParseErrorResourceBlock{
+			"ResourceBlock": inner,
+		})
+
 	}
 
 	return nil, fmt.Errorf("unexpected variant of %v", variant)
-}
-
-// Partial struct
-type Partial struct {
-	// Constraints
-	Constraints []Operation `json:"constraints"`
-	// Variable
-	Variable Symbol `json:"variable"`
 }
 
 // PatternDictionary newtype
@@ -1716,6 +1775,20 @@ type QueryEventExternalIsa struct {
 
 func (QueryEventExternalIsa) isQueryEvent() {}
 
+// QueryEventExternalIsaWithPath struct
+type QueryEventExternalIsaWithPath struct {
+	// CallId
+	CallId uint64 `json:"call_id"`
+	// BaseTag
+	BaseTag Symbol `json:"base_tag"`
+	// Path
+	Path []Term `json:"path"`
+	// ClassTag
+	ClassTag Symbol `json:"class_tag"`
+}
+
+func (QueryEventExternalIsaWithPath) isQueryEvent() {}
+
 // QueryEventExternalIsSubSpecializer struct
 type QueryEventExternalIsSubSpecializer struct {
 	// CallId
@@ -1872,6 +1945,17 @@ func (result *QueryEvent) UnmarshalJSON(b []byte) error {
 		*result = QueryEvent{variant}
 		return nil
 
+	case "ExternalIsaWithPath":
+		var variant QueryEventExternalIsaWithPath
+		if variantValue != nil {
+			err := json.Unmarshal(*variantValue, &variant)
+			if err != nil {
+				return err
+			}
+		}
+		*result = QueryEvent{variant}
+		return nil
+
 	case "ExternalIsSubSpecializer":
 		var variant QueryEventExternalIsSubSpecializer
 		if variantValue != nil {
@@ -1965,6 +2049,11 @@ func (variant QueryEvent) MarshalJSON() ([]byte, error) {
 			"ExternalIsa": inner,
 		})
 
+	case QueryEventExternalIsaWithPath:
+		return json.Marshal(map[string]QueryEventExternalIsaWithPath{
+			"ExternalIsaWithPath": inner,
+		})
+
 	case QueryEventExternalIsSubSpecializer:
 		return json.Marshal(map[string]QueryEventExternalIsSubSpecializer{
 			"ExternalIsSubSpecializer": inner,
@@ -1993,6 +2082,14 @@ func (variant QueryEvent) MarshalJSON() ([]byte, error) {
 	}
 
 	return nil, fmt.Errorf("unexpected variant of %v", variant)
+}
+
+// Range struct
+type Range struct {
+	// Start
+	Start uint64 `json:"start"`
+	// End
+	End uint64 `json:"end"`
 }
 
 // Rule struct
@@ -2080,6 +2177,24 @@ type RuntimeErrorFileLoading struct {
 }
 
 func (RuntimeErrorFileLoading) isRuntimeError() {}
+
+// RuntimeErrorIncompatibleBindings struct
+type RuntimeErrorIncompatibleBindings struct {
+	// Msg
+	Msg string `json:"msg"`
+}
+
+func (RuntimeErrorIncompatibleBindings) isRuntimeError() {}
+
+// RuntimeErrorUnhandledPartial struct
+type RuntimeErrorUnhandledPartial struct {
+	// Var
+	Var Symbol `json:"var"`
+	// Term
+	Term Term `json:"term"`
+}
+
+func (RuntimeErrorUnhandledPartial) isRuntimeError() {}
 
 // RuntimeError enum
 type RuntimeErrorVariant interface {
@@ -2212,6 +2327,28 @@ func (result *RuntimeError) UnmarshalJSON(b []byte) error {
 		*result = RuntimeError{variant}
 		return nil
 
+	case "IncompatibleBindings":
+		var variant RuntimeErrorIncompatibleBindings
+		if variantValue != nil {
+			err := json.Unmarshal(*variantValue, &variant)
+			if err != nil {
+				return err
+			}
+		}
+		*result = RuntimeError{variant}
+		return nil
+
+	case "UnhandledPartial":
+		var variant RuntimeErrorUnhandledPartial
+		if variantValue != nil {
+			err := json.Unmarshal(*variantValue, &variant)
+			if err != nil {
+				return err
+			}
+		}
+		*result = RuntimeError{variant}
+		return nil
+
 	}
 
 	return fmt.Errorf("Cannot deserialize RuntimeError: %s", string(b))
@@ -2265,31 +2402,92 @@ func (variant RuntimeError) MarshalJSON() ([]byte, error) {
 			"FileLoading": inner,
 		})
 
+	case RuntimeErrorIncompatibleBindings:
+		return json.Marshal(map[string]RuntimeErrorIncompatibleBindings{
+			"IncompatibleBindings": inner,
+		})
+
+	case RuntimeErrorUnhandledPartial:
+		return json.Marshal(map[string]RuntimeErrorUnhandledPartial{
+			"UnhandledPartial": inner,
+		})
+
 	}
 
 	return nil, fmt.Errorf("unexpected variant of %v", variant)
 }
 
+// Source struct
+type Source struct {
+	// Filename
+	Filename *string `json:"filename"`
+	// Src
+	Src string `json:"src"`
+}
+
+// Symbol newtype
+type Symbol string
+
+func (variant Symbol) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(variant))
+}
+
+func (variant *Symbol) UnmarshalJSON(b []byte) error {
+	inner := string(*variant)
+	err := json.Unmarshal(b, &inner)
+	*variant = Symbol(inner)
+	return err
+}
+
+// Term struct
+type Term struct {
+	// Value
+	Value Value `json:"value"`
+}
+
+// Trace struct
+type Trace struct {
+	// Node
+	Node Node `json:"node"`
+	// Children
+	Children []Trace `json:"children"`
+}
+
+// TraceResult struct
+type TraceResult struct {
+	// Trace
+	Trace Trace `json:"trace"`
+	// Formatted
+	Formatted string `json:"formatted"`
+}
+
+// ValidationErrorInvalidRule struct
 type ValidationErrorInvalidRule struct {
+	// Rule
+	Rule string `json:"rule"`
 	// Msg
 	Msg string `json:"msg"`
 }
 
 func (ValidationErrorInvalidRule) isValidationError() {}
 
+// ValidationErrorInvalidRuleType struct
 type ValidationErrorInvalidRuleType struct {
+	// RuleType
+	RuleType string `json:"rule_type"`
 	// Msg
 	Msg string `json:"msg"`
 }
 
 func (ValidationErrorInvalidRuleType) isValidationError() {}
 
-type ValidationErrorSugar struct {
-	// Msg
-	Msg string `json:"msg"`
+// ValidationErrorUndefinedRule struct
+type ValidationErrorUndefinedRule struct {
+	// RuleName
+	RuleName string `json:"rule_name"`
 }
 
-func (ValidationErrorSugar) isValidationError() {}
+func (ValidationErrorUndefinedRule) isValidationError() {}
 
 // ValidationError enum
 type ValidationErrorVariant interface {
@@ -2334,7 +2532,7 @@ func (result *ValidationError) UnmarshalJSON(b []byte) error {
 		*result = ValidationError{variant}
 		return nil
 
-	case "InvalidPrototype":
+	case "InvalidRuleType":
 		var variant ValidationErrorInvalidRuleType
 		if variantValue != nil {
 			err := json.Unmarshal(*variantValue, &variant)
@@ -2345,8 +2543,8 @@ func (result *ValidationError) UnmarshalJSON(b []byte) error {
 		*result = ValidationError{variant}
 		return nil
 
-	case "Sugar":
-		var variant ValidationErrorSugar
+	case "UndefinedRule":
+		var variant ValidationErrorUndefinedRule
 		if variantValue != nil {
 			err := json.Unmarshal(*variantValue, &variant)
 			if err != nil {
@@ -2371,59 +2569,17 @@ func (variant ValidationError) MarshalJSON() ([]byte, error) {
 
 	case ValidationErrorInvalidRuleType:
 		return json.Marshal(map[string]ValidationErrorInvalidRuleType{
-			"InvalidPrototype": inner,
+			"InvalidRuleType": inner,
 		})
 
-	case ValidationErrorSugar:
-		return json.Marshal(map[string]ValidationErrorSugar{
-			"Sugar": inner,
+	case ValidationErrorUndefinedRule:
+		return json.Marshal(map[string]ValidationErrorUndefinedRule{
+			"UndefinedRule": inner,
 		})
 
 	}
 
 	return nil, fmt.Errorf("unexpected variant of %v", variant)
-}
-
-// Symbol newtype
-type Symbol string
-
-func (variant Symbol) MarshalJSON() ([]byte, error) {
-	return json.Marshal(string(variant))
-}
-
-func (variant *Symbol) UnmarshalJSON(b []byte) error {
-	inner := string(*variant)
-	err := json.Unmarshal(b, &inner)
-	*variant = Symbol(inner)
-	return err
-}
-
-// Source struct
-type Source struct {
-	Src      string  `json:"src"`
-	Filename *string `json:"filename"`
-}
-
-// Term struct
-type Term struct {
-	// Value
-	Value Value `json:"value"`
-}
-
-// Trace struct
-type Trace struct {
-	// Node
-	Node Node `json:"node"`
-	// Children
-	Children []Trace `json:"children"`
-}
-
-// TraceResult struct
-type TraceResult struct {
-	// Trace
-	Trace Trace `json:"trace"`
-	// Formatted
-	Formatted string `json:"formatted"`
 }
 
 // ValueNumber newtype
@@ -2817,6 +2973,7 @@ func (variant Value) MarshalJSON() ([]byte, error) {
 		return json.Marshal(map[string]ValueExpression{
 			"Expression": inner,
 		})
+
 	}
 
 	return nil, fmt.Errorf("unexpected variant of %v", variant)

--- a/languages/js/test/parity.ts
+++ b/languages/js/test/parity.ts
@@ -193,5 +193,21 @@ void (async function () {
   if (((await result.next()).value as Map<string, unknown>).get('z') !== 3)
     throw new Error();
 
+  // Test that a custom error type is thrown.
+  exceptionThrown = false;
+  try {
+    await oso.query('testUnhandledPartial()').next();
+  } catch (e) {
+    const expectedName = 'RuntimeError::UnhandledPartial';
+    const { name, message } = e as Error;
+    if (
+      name === expectedName &&
+      !message.startsWith('Found an unhandled partial')
+    )
+      exceptionThrown = true;
+  } finally {
+    if (!exceptionThrown) throw new Error(); // eslint-disable-line no-unsafe-finally
+  }
+
   console.log('tests pass');
 })();

--- a/languages/ruby/spec/oso/language_parity_spec.rb
+++ b/languages/ruby/spec/oso/language_parity_spec.rb
@@ -124,9 +124,10 @@ raise unless result.map { |res| res['z'] }.to_a == [1, 2, 3]
 # Test that unhandled partials error correctly
 exception_thrown = false
 begin
-  result = oso.query_rule('testUnhandledPartial').first
+  oso.query_rule('testUnhandledPartial').first
 rescue Oso::Polar::PolarRuntimeError => e
-  raise unless e.to_s.start_with? "Found an unhandled partial"
+  raise unless e.to_s.start_with? 'Found an unhandled partial'
+
   exception_thrown = true
 end
 raise unless exception_thrown

--- a/languages/ruby/spec/oso/language_parity_spec.rb
+++ b/languages/ruby/spec/oso/language_parity_spec.rb
@@ -120,3 +120,13 @@ raise if oso.query_rule('testIterables').first.nil?
 # Test unspecialized rule ordering
 result = oso.query_rule('testUnspecializedRuleOrder', 'foo', 'bar', Oso::Polar::Variable.new('z'))
 raise unless result.map { |res| res['z'] }.to_a == [1, 2, 3]
+
+# Test that unhandled partials error correctly
+exception_thrown = false
+begin
+  result = oso.query_rule('testUnhandledPartial').first
+rescue Oso::Polar::PolarRuntimeError => e
+  raise unless e.to_s.start_with? "Found an unhandled partial"
+  exception_thrown = true
+end
+raise unless exception_thrown

--- a/languages/rust/oso/tests/parity.rs
+++ b/languages/rust/oso/tests/parity.rs
@@ -1,4 +1,5 @@
 use oso::{ClassBuilder, Oso, PolarClass};
+use polar_core::error::{ErrorKind, PolarError, RuntimeError};
 
 macro_rules! res {
     ($res:expr) => {
@@ -142,4 +143,17 @@ fn test() {
     res!(@not oso.query(r#"builtinSpecializers({}, "DictionaryWithFields")"#));
     res!(@not oso.query(r#"builtinSpecializers({z: 1}, "DictionaryWithFields")"#));
     res!(oso.query(r#"builtinSpecializers({y: 1}, "DictionaryWithFields")"#));
+
+    let res = oso.query("testUnhandledPartial()").unwrap().next().unwrap();
+    assert!(
+        matches!(
+            res,
+            Err(oso::OsoError::Polar(PolarError {
+                kind: ErrorKind::Runtime(RuntimeError::UnhandledPartial { .. }),
+                ..
+            })),
+        ),
+        "Expected unhandled partial error, got: {:#?}",
+        res
+    )
 }

--- a/test/Test.java
+++ b/test/Test.java
@@ -132,6 +132,15 @@ class Test {
         .results()
         .equals(List.of(Map.of("z", 1), Map.of("z", 2), Map.of("z", 3)));
 
+    throwsException = false;
+    try {
+      o.query("testUnhandledPartial()").results();
+    } catch (Exceptions.PolarRuntimeException e) {
+      assert e.getMessage().startsWith("Found an unhandled partial");
+      throwsException = true;
+    }
+    assert throwsException;
+
     System.out.println("Tests Pass");
   }
 }

--- a/test/policies/errors.polar
+++ b/test/policies/errors.polar
@@ -1,0 +1,1 @@
+testUnhandledPartial() if x = x and x > 0;

--- a/test/spec/errors.yml
+++ b/test/spec/errors.yml
@@ -1,5 +1,5 @@
 name: Errors
-policies: []
+policies: [errors]
 description: Test for common errors
 cases:
   # parser errors
@@ -31,3 +31,8 @@ cases:
   - description: invalid lookup
     query: x = new UnitClass() and x.missing_attribute
     err: "Application error: 'UnitClass' object has no attribute 'missing_attribute'"
+
+  # unhandled partial errors
+  - description: unhandled partial
+    query: testUnhandledPartial()
+    err: "Found an unhandled partial"

--- a/test/test.polar
+++ b/test/test.polar
@@ -79,3 +79,5 @@ testUnspecializedRuleOrder(_x, _y: String, z) if z = 2;
 testUnspecializedRuleOrder(_x: String, _y, z) if z = 1;
 
 testIterables() if 1 in new List([3, 2, 1]);
+
+testUnhandledPartial() if x = x and x > 0;

--- a/test/test.py
+++ b/test/test.py
@@ -1,7 +1,7 @@
 import math
 import os
 
-from polar.exceptions import UnrecognizedEOF
+from polar.exceptions import PolarRuntimeError, UnrecognizedEOF
 from oso import Oso, OsoError, Variable
 
 oso = Oso()
@@ -122,3 +122,12 @@ result = oso.query_rule("testUnspecializedRuleOrder", "foo", "bar", Variable("z"
 assert next(result)["bindings"]["z"] == 1
 assert next(result)["bindings"]["z"] == 2
 assert next(result)["bindings"]["z"] == 3
+
+exception_thrown = False
+try:
+    next(oso.query("testUnhandledPartial()"))
+except PolarRuntimeError as e:
+    assert e.message.startswith("Found an unhandled partial")
+    exception_thrown = True
+
+assert exception_thrown


### PR DESCRIPTION
The main change here was supposed to be adding tests for the error in #1323.

But then I realised I was missing the error type for Go... And a bunch of others.

Before a bunch of the errors would raise complaining that the error couldn't be deserialized. I think this was related to the segfaults somehow?!