### PR TITLE
print the debugging message in handleDebug event handler

### DIFF
--- a/languages/go/query.go
+++ b/languages/go/query.go
@@ -381,6 +381,8 @@ func (q Query) handleNextExternal(event types.QueryEventNextExternal) error {
 }
 
 func (q Query) handleDebug(event types.QueryEventDebug) error {
+	fmt.Printf("%s\n", event.Message)
+
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Print("debug> ")
 	text, _ := reader.ReadString('\n')


### PR DESCRIPTION
Fix REPL functionality by printing the result messages from the core in
the Golang debug event handler.
