### PR TITLE
test python 3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,7 @@ jobs:
           python-version: "3.7"
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.2
+          python -m pip install cibuildwheel==2.2.2
       - name: Download static libs
         uses: actions/download-artifact@v1
         with:
@@ -316,7 +316,7 @@ jobs:
       - name: Copy static library.
         run: |
           mkdir -p languages/python/oso/native
-          cp -r oso_static_library/libpolar-Linux.a languages/python/oso/native/libpolar.a
+          cp -r oso_static_library/libpolar-musl.a languages/python/oso/native/libpolar.a
           cp -r oso_static_library/polar.h languages/python/oso/native/polar.h
       - name: Copy in readme
         run: |
@@ -353,7 +353,7 @@ jobs:
           python-version: "3.7"
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.2
+          python -m pip install cibuildwheel==2.2.2
       - name: Download static libs
         uses: actions/download-artifact@v1
         with:
@@ -427,7 +427,7 @@ jobs:
           python-version: "3.7"
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.2
+          python -m pip install cibuildwheel==2.2.2
       - name: Download static libs
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -715,7 +715,7 @@ jobs:
 
   validate_python_musl:
     name: Test python ${{ matrix.python-version }} on Alpine
-    needs: [build_musl_wheels]
+    needs: [build_linux_wheels]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,33 +450,33 @@ jobs:
           name: wheel
           path: languages/python/oso/wheelhouse/*.whl
 
-  build_musl_wheels:
-    name: Build musl wheels
-    runs-on: ubuntu-latest
-    needs: [version, linux_libs]
-    env:
-      OSO_ENV: CI
-      RUSTFLAGS: "-C target-feature=-crt-static -C relocation-model=pic"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download static libs
-        uses: actions/download-artifact@v1
-        with:
-          name: oso_static_library
-      - name: Copy static library.
-        run: |
-          mkdir -p languages/python/oso/native
-          cp -r oso_static_library/libpolar-musl.a languages/python/oso/native/libpolar.a
-          cp -r oso_static_library/polar.h languages/python/oso/native/polar.h
-      - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.6-alpine oso/scripts/build_musl.sh
-      - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.7-alpine oso/scripts/build_musl.sh
-      - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.8-alpine oso/scripts/build_musl.sh
-      - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.9-alpine oso/scripts/build_musl.sh
-      - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.10-alpine oso/scripts/build_musl.sh
-      - uses: actions/upload-artifact@v2
-        with:
-          name: musl-wheel
-          path: languages/python/oso/dist/*.whl
+  # build_musl_wheels:
+  #   name: Build musl wheels
+  #   runs-on: ubuntu-latest
+  #   needs: [version, linux_libs]
+  #   env:
+  #     OSO_ENV: CI
+  #     RUSTFLAGS: "-C target-feature=-crt-static -C relocation-model=pic"
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Download static libs
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: oso_static_library
+  #     - name: Copy static library.
+  #       run: |
+  #         mkdir -p languages/python/oso/native
+  #         cp -r oso_static_library/libpolar-musl.a languages/python/oso/native/libpolar.a
+  #         cp -r oso_static_library/polar.h languages/python/oso/native/polar.h
+  #     - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.6-alpine oso/scripts/build_musl.sh
+  #     - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.7-alpine oso/scripts/build_musl.sh
+  #     - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.8-alpine oso/scripts/build_musl.sh
+  #     - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.9-alpine oso/scripts/build_musl.sh
+  #     - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.10-alpine oso/scripts/build_musl.sh
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: musl-wheel
+  #         path: languages/python/oso/dist/*.whl
 
   build_js:
     name: Build js.
@@ -728,7 +728,7 @@ jobs:
       - name: Download oso python wheels from package run
         uses: actions/download-artifact@v1
         with:
-          name: musl-wheel
+          name: wheel
       - run: docker run --rm --env OSO_VERSION -v `pwd`:/oso python:${{ matrix.python-version }}-alpine oso/scripts/test_musl.sh
         env:
           OSO_VERSION: ${{ steps.version.outputs.oso_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
     branches:
-      - steve/python10
+      - main
 
 jobs:
   version:
@@ -16,7 +16,7 @@ jobs:
       - name: Set version env
         run: echo "oso_version=$(cat VERSION)" >> $GITHUB_ENV
       - name: Check github ref matches
-        if: github.ref != 'refs/heads/steve/python10'
+        if: github.ref != 'refs/heads/main
         env:
           github_ref: ${{ github.ref }}
         run: grep "${github_ref/refs\/tags\/v/}" VERSION
@@ -860,7 +860,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/steve/python10'
+    if: github.ref != 'refs/heads/main'
     needs:
       [
         build_linux_wheels,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set version env
         run: echo "oso_version=$(cat VERSION)" >> $GITHUB_ENV
       - name: Check github ref matches
-        if: github.ref != 'refs/heads/main
+        if: github.ref != 'refs/heads/main'
         env:
           github_ref: ${{ github.ref }}
         run: grep "${github_ref/refs\/tags\/v/}" VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -888,7 +888,6 @@ jobs:
         build_linux_wheels,
         build_macos_wheels,
         build_windows_wheels,
-        build_musl_wheels,
         build_jar,
         build_gem,
         build_go,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -566,7 +566,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -595,7 +595,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -625,7 +625,7 @@ jobs:
     strategy:
       matrix:
         # There is no python 3.6 for macos-11
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -690,7 +690,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -719,7 +719,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -851,7 +851,7 @@ jobs:
       - name: Use Python 3.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: "3.6"
       - name: Use Ruby 2.4
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,7 +340,9 @@ jobs:
     needs: [version, macos_libs]
     env:
       # Skip Python 2.7 and Python 3.5
-      CIBW_SKIP: "cp27-* cp35-* pp27-*"
+      # Skip 3.10 due to a broken python link.
+      # Turn back on after this is resolved https://github.com/pypa/cibuildwheel/issues/902
+      CIBW_SKIP: "cp27-* cp35-* pp27-* cp310-*"
       # 64-bit builds only
       CIBW_BUILD: "*64"
       # Used in build.py to find right files
@@ -567,7 +569,9 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        # Skip 3.10 due to a broken python link.
+        # Turn back on after this is resolved https://github.com/pypa/cibuildwheel/issues/902
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -597,7 +601,9 @@ jobs:
     strategy:
       matrix:
         # There is no python 3.6 for macos-11
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        # Skip 3.10 due to a broken python link.
+        # Turn back on after this is resolved https://github.com/pypa/cibuildwheel/issues/902
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
     branches:
-      - main
+      - steve/python10
 
 jobs:
   version:
@@ -16,7 +16,7 @@ jobs:
       - name: Set version env
         run: echo "oso_version=$(cat VERSION)" >> $GITHUB_ENV
       - name: Check github ref matches
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/steve/python10'
         env:
           github_ref: ${{ github.ref }}
         run: grep "${github_ref/refs\/tags\/v/}" VERSION
@@ -471,6 +471,8 @@ jobs:
       - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.6-alpine oso/scripts/build_musl.sh
       - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.7-alpine oso/scripts/build_musl.sh
       - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.8-alpine oso/scripts/build_musl.sh
+      - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.9-alpine oso/scripts/build_musl.sh
+      - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.10-alpine oso/scripts/build_musl.sh
       - uses: actions/upload-artifact@v2
         with:
           name: musl-wheel
@@ -593,7 +595,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -623,7 +625,7 @@ jobs:
     strategy:
       matrix:
         # There is no python 3.6 for macos-11
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -688,7 +690,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -717,7 +719,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -880,7 +882,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/steve/python10'
     needs:
       [
         build_linux_wheels,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -538,7 +538,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,34 +450,6 @@ jobs:
           name: wheel
           path: languages/python/oso/wheelhouse/*.whl
 
-  # build_musl_wheels:
-  #   name: Build musl wheels
-  #   runs-on: ubuntu-latest
-  #   needs: [version, linux_libs]
-  #   env:
-  #     OSO_ENV: CI
-  #     RUSTFLAGS: "-C target-feature=-crt-static -C relocation-model=pic"
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Download static libs
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: oso_static_library
-  #     - name: Copy static library.
-  #       run: |
-  #         mkdir -p languages/python/oso/native
-  #         cp -r oso_static_library/libpolar-musl.a languages/python/oso/native/libpolar.a
-  #         cp -r oso_static_library/polar.h languages/python/oso/native/polar.h
-  #     - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.6-alpine oso/scripts/build_musl.sh
-  #     - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.7-alpine oso/scripts/build_musl.sh
-  #     - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.8-alpine oso/scripts/build_musl.sh
-  #     - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.9-alpine oso/scripts/build_musl.sh
-  #     - run: docker run --rm --env OSO_ENV -v `pwd`:/oso python:3.10-alpine oso/scripts/build_musl.sh
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: musl-wheel
-  #         path: languages/python/oso/dist/*.whl
-
   build_js:
     name: Build js.
     runs-on: ubuntu-latest

--- a/scripts/test_musl.sh
+++ b/scripts/test_musl.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 apk add build-base libffi-dev
 cd oso
-pip install oso==$OSO_VERSION -f musl-wheel --no-deps --no-index
-pip install oso==$OSO_VERSION -f musl-wheel
+pip install oso==$OSO_VERSION -f wheel --no-deps --no-index
+pip install oso==$OSO_VERSION -f wheel
 cd test
 python test.py
 echo "tests passed"


### PR DESCRIPTION
Adds python 3.10 as a build and test target.
Removes musl specific wheels, python wheels now work for both glibc and musl based distros.