### PR TITLE
Disallow parenthesized specializers in rule heads

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -12,7 +12,29 @@ draft: true
 
 ### Core
 
+#### Breaking changes
+
+{{% callout "Warning" "orange" %}}
+  This release contains breaking changes. Be sure to follow migration steps
+  before upgrading.
+{{% /callout %}}
+
+##### Parenthesized variable dereferencing in specializer position is no longer permitted
+
+Previously, Oso would treat parenthesized specializers as variables. This made
+it possible to write rules with parameters that referenced each other, like so:
+
+```polar
+isa(x, y, x: (y));
+```
+
+Now, that parenthesized `(y)` will be a parse error.
+
+If you discovered this feature and were using it, please get in touch. We'd
+love to hear about your use case!
+
 #### Other bugs & improvements
+
 - Fixed a bug where a negated constraint on a dot lookup could cause Polar to crash
   when the underlying variable became bound.
 

--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -28,7 +28,12 @@ it possible to write rules with parameters that referenced each other, like so:
 isa(x, y, x: (y));
 ```
 
-Now, that parenthesized `(y)` will be a parse error.
+Now, that parenthesized `(y)` will be a parse error. The same logic can be
+written in the body of the rule with the `matches` operator:
+
+```polar
+isa(x, y) if x matches y;
+```
 
 If you discovered this feature and were using it, please get in touch. We'd
 love to hear about your use case!

--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -12,36 +12,12 @@ draft: true
 
 ### Core
 
-#### Breaking changes
-
-{{% callout "Warning" "orange" %}}
-  This release contains breaking changes. Be sure to follow migration steps
-  before upgrading.
-{{% /callout %}}
-
-##### Parenthesized variable dereferencing in specializer position is no longer permitted
-
-Previously, Oso would treat parenthesized specializers as variables. This made
-it possible to write rules with parameters that referenced each other, like so:
-
-```polar
-isa(x, y, x: (y));
-```
-
-Now, that parenthesized `(y)` will be a parse error. The same logic can be
-written in the body of the rule with the `matches` operator:
-
-```polar
-isa(x, y) if x matches y;
-```
-
-If you discovered this feature and were using it, please get in touch. We'd
-love to hear about your use case!
-
 #### Other bugs & improvements
 
 - Fixed a bug where a negated constraint on a dot lookup could cause Polar to crash
   when the underlying variable became bound.
+- Removed syntax for parenthesized specializers like `f(_: (x));`, which don't
+  currently achieve anything.
 
 ## `RELEASED_PACKAGE_1` NEW_VERSION
 

--- a/polar-core/src/parser.rs
+++ b/polar-core/src/parser.rs
@@ -186,11 +186,7 @@ mod tests {
             rule!("f", ["x" ; 1 , "y" ; value!([sym!("x")])] => op!(Unify, term!(sym!("y")), term!(2)))
         );
 
-        // parenthesized => parse as a symbol
-        let rule = parse_rule(r#"f(x: (y));"#);
-        assert_eq!(rule, rule!("f", ["x"; value!(sym!("y"))]));
-
-        // not parenthesized => parse as a type
+        // parse specializer as a type
         let rule = parse_rule(r#"f(x: y);"#);
         assert_eq!(rule, rule!("f", ["x"; value!(instance!("y"))]));
     }

--- a/polar-core/src/partial/partial.rs
+++ b/polar-core/src/partial/partial.rs
@@ -470,52 +470,10 @@ mod test {
         p.clear_rules();
 
         // Test permutations of variable states in isa.
-        p.load_str(
-            r#"h(_x: (_y));
-               i(_x: (y), y: (_z));
-               j(x: (x), _y: (x));
-               k(x, y: (y), y: (x));
-               l(x: (x), x: (x));
-               m(x) if [_y] matches [x];
-               n(x: (x)) if [_y] matches [x];"#,
-        )?;
-        let mut q = p.new_query_from_term(term!(call!("h", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "_this matches __y_34");
-        assert_query_done!(q);
-
-        let mut q = p.new_query_from_term(term!(call!("i", [sym!("x"), sym!("y")])), false);
-        assert_partial_expressions!(next_binding(&mut q)?,
-            "x" => "_this matches y and y matches __z_40",
-            "y" => "x matches _this and _this matches __z_40");
-        assert_query_done!(q);
-
-        let mut q = p.new_query_from_term(term!(call!("j", [sym!("x"), sym!("y")])), false);
-        assert_partial_expressions!(next_binding(&mut q)?,
-            "x" => "_this matches _this and y matches _this",
-            "y" => "x matches x and _this matches x");
-        assert_query_done!(q);
-
-        let mut q =
-            p.new_query_from_term(term!(call!("k", [sym!("x"), sym!("y"), sym!("y")])), false);
-        assert_partial_expressions!(next_binding(&mut q)?,
-            "x" => "y matches y and y matches _this",
-            "y" => "_this matches _this and _this matches x");
-        assert_query_done!(q);
-
-        let mut q = p.new_query_from_term(term!(call!("l", [sym!("x"), sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "_this matches _this");
-        assert_query_done!(q);
-
+        // NOTE(gj): only one permutation remains parse-able.
+        p.load_str("m(x) if [_y] matches [x];")?;
         let mut q = p.new_query_from_term(term!(call!("m", [sym!("x")])), false);
-        assert_partial_expression!(next_binding(&mut q)?, "x", "__y_54 matches _this");
-        assert_query_done!(q);
-
-        let mut q = p.new_query_from_term(term!(call!("n", [sym!("x")])), false);
-        assert_partial_expression!(
-            next_binding(&mut q)?,
-            "x",
-            "_this matches _this and __y_58 matches _this"
-        );
+        assert_partial_expression!(next_binding(&mut q)?, "x", "__y_34 matches _this");
         assert_query_done!(q);
 
         // TODO(gj): Make the below work.

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -648,13 +648,6 @@ Parameter: Parameter = {
     <parameter:ExpectValue<Exp6<"Term">>> => {
         Parameter{parameter, specializer: None}
     },
-    // parenthesized specializers do not have symbol translation to class names applied
-    <parameter:Spanned<Variable>> ":" "(" <specializer:Spanned<Pattern>> ")" => {
-        Parameter {
-            parameter,
-            specializer: Some(specializer),
-        }
-    },
     <parameter:Spanned<Variable>> ":" <specializer:Spanned<Pattern>> => {
         if let Value::Variable(class_name) = specializer.value() {
             let fields = BTreeMap::new();

--- a/polar-core/src/polar.lalrpop
+++ b/polar-core/src/polar.lalrpop
@@ -656,7 +656,6 @@ Parameter: Parameter = {
         }
     },
     <parameter:Spanned<Variable>> ":" <specializer:Spanned<Pattern>> => {
-        let offset = specializer.offset();
         if let Value::Variable(class_name) = specializer.value() {
             let fields = BTreeMap::new();
             let instance_literal = InstanceLiteral{tag: class_name.clone(), fields: Dictionary{fields}};


### PR DESCRIPTION
Effectively reverts #61.

Makes all of these cases parse errors:

```py
polar.register_constant(1, name="Foo")
polar.load_str("f(_: (Foo));")
assert qeval("f(1)")
assert not qeval("f(2)")
```

```py
polar.load_str("""
    type f(_: (Foo));
    f(_: (Foo));
""")
```

```py
with pytest.raises(exceptions.ValidationError):
    polar.load_str("""
        type f(_: (Foo));
        f(_: Foo);
    """)
```

```py
polar.register_constant(1, name="Foo")
polar.register_constant(1, name="Bar")
with pytest.raises(exceptions.ValidationError):
    polar.load_str("""
        type f(_: (Bar));
        f(_: (Foo));
    """)
```

PR checklist:

<!-- Delete if no entry is required. -->
- [x] Added changelog entry.
