### PR TITLE
Remove sqlalchemy-oso version.

### DIFF
--- a/docs/content/python/reference/frameworks/data_filtering/sqlalchemy.md
+++ b/docs/content/python/reference/frameworks/data_filtering/sqlalchemy.md
@@ -18,7 +18,7 @@ The Oso SQLAlchemy integration is available on
 `pip`:
 
 ```console
-$ pip install sqlalchemy-oso=={{< version >}}
+$ pip install sqlalchemy-oso
 ```
 
 ## Usage

--- a/docs/content/python/reference/frameworks/django.md
+++ b/docs/content/python/reference/frameworks/django.md
@@ -20,7 +20,7 @@ The Oso Django integration is available on [PyPI](https://pypi.org/project/djang
 `pip`:
 
 ```console
-$ pip install django-oso=={{< version >}}
+$ pip install django-oso
 ```
 
 ## Usage

--- a/docs/content/python/reference/frameworks/flask.md
+++ b/docs/content/python/reference/frameworks/flask.md
@@ -20,7 +20,7 @@ The Oso Flask integration is available on [PyPI](https://pypi.org/project/flask-
 `pip`:
 
 ```console
-$ pip install flask-oso=={{< version >}}
+$ pip install flask-oso
 ```
 
 ## Usage


### PR DESCRIPTION
The version sometimes drifts from the version of the `oso` package.

This PR removes the version from the docs page. `pip install sqlalchemy-oso`
will install the latest version, so the version pin is unnecessary.