### PR TITLE
Add language to title on Quickstart, Add to App, RBAC & Hierarchies pages

### DIFF
--- a/docs/content/any/getting-started/application/_index.md
+++ b/docs/content/any/getting-started/application/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Add Oso to Your App
-metaTitle: Add Oso to Your LANG App
+metaTitle: Add Oso to Your $LANG App
 weight: 2
 description: |
     In this guide, we'll cover how to add Oso to your application.

--- a/docs/content/any/getting-started/application/_index.md
+++ b/docs/content/any/getting-started/application/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Add Oso to Your App
+metaTitle: Add Oso to Your LANG App
 weight: 2
 description: |
     In this guide, we'll cover how to add Oso to your application.

--- a/docs/content/any/getting-started/application/enforce/index.md
+++ b/docs/content/any/getting-started/application/enforce/index.md
@@ -1,12 +1,13 @@
 ---
 title: Enforce authorization
+metaTitle: Enforce authorization in LANG
 description: |
     Add authorization enforcement throughout your application using the
     authorize API to reject or accept requests that users make.
 weight: 2
 ---
 
-# Enforce authorization
+# Enforce authorization in {{% lang %}}
 
 In [Model your authorization logic](model) you defined an authorization
 policy. In this guide, we will cover using Oso's enforcement API to

--- a/docs/content/any/getting-started/application/enforce/index.md
+++ b/docs/content/any/getting-started/application/enforce/index.md
@@ -1,6 +1,6 @@
 ---
 title: Enforce authorization
-metaTitle: Enforce authorization in LANG
+metaTitle: Enforce authorization in $LANG
 description: |
     Add authorization enforcement throughout your application using the
     authorize API to reject or accept requests that users make.

--- a/docs/content/any/getting-started/quickstart/index.md
+++ b/docs/content/any/getting-started/quickstart/index.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-metaTitle: Quickstart for LANG
+metaTitle: Quickstart for $LANG
 description: |
   Ready to get started? See Oso in action, and walk through a quick
   change to an Oso policy in a simple web server.

--- a/docs/content/any/getting-started/quickstart/index.md
+++ b/docs/content/any/getting-started/quickstart/index.md
@@ -1,5 +1,6 @@
 ---
 title: Quickstart
+metaTitle: Quickstart for LANG
 description: |
   Ready to get started? See Oso in action, and walk through a quick
   change to an Oso policy in a simple web server.
@@ -19,7 +20,7 @@ This guide uses Python.
 {{< /ifLang >}}
 
 
-# Quickstart
+# Quickstart for {{% lang %}}
 
 This guide will walk you through your first change to an Oso policy file. There
 are three steps:

--- a/docs/content/any/guides/hierarchies/index.md
+++ b/docs/content/any/guides/hierarchies/index.md
@@ -1,11 +1,11 @@
 ---
 title: "Build Authorization for Resource Hierarchies"
-metaTitle: Build Authorization for Resource Hierarchies - LANG
+metaTitle: Build Authorization for Resource Hierarchies in $LANG
 weight: 4
 showContentForAnyLanguage: true
 ---
 
-# Build Authorization for Resource Hierarchies - {{% lang %}}
+# Build Authorization for Resource Hierarchies in {{% lang %}}
 
 A **resource hierarchy** refers to a model with nested resources, where a user's permissions and roles on a resource depend on the resource's parent.
 

--- a/docs/content/any/guides/hierarchies/index.md
+++ b/docs/content/any/guides/hierarchies/index.md
@@ -1,10 +1,11 @@
 ---
 title: "Build Authorization for Resource Hierarchies"
+metaTitle: Build Authorization for Resource Hierarchies - LANG
 weight: 4
 showContentForAnyLanguage: true
 ---
 
-# Build Authorization for Resource Hierarchies
+# Build Authorization for Resource Hierarchies - {{% lang %}}
 
 A **resource hierarchy** refers to a model with nested resources, where a user's permissions and roles on a resource depend on the resource's parent.
 

--- a/docs/content/any/guides/rbac/index.md
+++ b/docs/content/any/guides/rbac/index.md
@@ -1,5 +1,6 @@
 ---
 title: Build Role-Based Access Control (RBAC)
+metaTitle: Build Role-Based Access Control (RBAC) - LANG
 weight: -1
 description: |
   Build role-based access control (RBAC) with Oso's built-in authorization
@@ -9,7 +10,7 @@ aliases:
   - /guides/roles/sqlalchemy/index.html
 ---
 
-# Build Role-Based Access Control (RBAC)
+# Build Role-Based Access Control (RBAC) - {{% lang %}}
 
 Role-based access control (RBAC) is so ubiquitous that Oso provides
 syntax for modeling RBAC. This syntax makes it easy to create a role-based

--- a/docs/content/any/guides/rbac/index.md
+++ b/docs/content/any/guides/rbac/index.md
@@ -1,6 +1,6 @@
 ---
 title: Build Role-Based Access Control (RBAC)
-metaTitle: Build Role-Based Access Control (RBAC) - LANG
+metaTitle: Build Role-Based Access Control (RBAC) in $LANG
 weight: -1
 description: |
   Build role-based access control (RBAC) with Oso's built-in authorization
@@ -10,7 +10,7 @@ aliases:
   - /guides/roles/sqlalchemy/index.html
 ---
 
-# Build Role-Based Access Control (RBAC) - {{% lang %}}
+# Build Role-Based Access Control (RBAC) in {{% lang %}}
 
 Role-based access control (RBAC) is so ubiquitous that Oso provides
 syntax for modeling RBAC. This syntax makes it easy to create a role-based

--- a/docs/themes/oso-tailwind/layouts/partials/head.html
+++ b/docs/themes/oso-tailwind/layouts/partials/head.html
@@ -3,13 +3,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{ block "title" . }}
         {{- if .Params.metaTitle -}}
-        {{- replace .Params.metaTitle "LANG" .Page.Language.LanguageName }} - {{ .Site.Title -}}
-        {{- else -}}
-        {{- if .Title -}}
+        {{- replace .Params.metaTitle "$LANG" .Page.Language.LanguageName }} - {{ .Site.Title -}}
+        {{- else if .Title -}}
         {{- .Title }} - {{ .Site.Title -}}
         {{- else -}}
         {{ .Site.Title }}
-        {{- end -}}
         {{- end -}}
         {{- end -}}</title>
     {{- if .Description }}

--- a/docs/themes/oso-tailwind/layouts/partials/head.html
+++ b/docs/themes/oso-tailwind/layouts/partials/head.html
@@ -2,11 +2,16 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{ block "title" . }}
+        {{- if .Params.metaTitle -}}
+        {{- replace .Params.metaTitle "LANG" .Page.Language.LanguageName }} - {{ .Site.Title -}}
+        {{- else -}}
         {{- if .Title -}}
         {{- .Title }} - {{ .Site.Title -}}
         {{- else -}}
         {{ .Site.Title }}
-        {{- end -}}{{- end -}}</title>
+        {{- end -}}
+        {{- end -}}
+        {{- end -}}</title>
     {{- if .Description }}
     <meta name="description" content="{{ .Description }}" />
     {{ else }}


### PR DESCRIPTION
- Adds a new `metaTitle` param to page front matter that will substitute LANG
  for the current pages language, allowing us to customize the title used by
  search to include the language.
- Adds to H1 the current language on some pages that we want to appear for SEO.