### PR TITLE
Fix Go test flake

### DIFF
--- a/polar-c-api/src/lib.rs
+++ b/polar-c-api/src/lib.rs
@@ -2,11 +2,11 @@ pub use polar_core::polar::Polar;
 pub use polar_core::query::Query;
 use polar_core::{error, terms};
 
-use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr::{null, null_mut};
+use std::sync::{Arc, Mutex};
 
 /// Get a reference to an object from a pointer
 macro_rules! ffi_ref {
@@ -50,18 +50,18 @@ macro_rules! ffi_try {
 }
 
 thread_local! {
-    static LAST_ERROR: RefCell<Option<Box<error::PolarError>>> = RefCell::new(None);
+    static LAST_ERROR: Mutex<Option<Box<error::PolarError>>> = Default::default();
 }
 
 fn set_error(e: error::PolarError) -> i32 {
-    LAST_ERROR.with(|prev| *prev.borrow_mut() = Some(Box::new(e)));
+    LAST_ERROR.with(|prev| *prev.lock().unwrap() = Some(Box::new(e)));
     POLAR_FAILURE
 }
 
 #[no_mangle]
 pub extern "C" fn polar_get_error() -> *const c_char {
     ffi_try!({
-        let err = LAST_ERROR.with(|prev| prev.borrow_mut().take());
+        let err = LAST_ERROR.with(|prev| prev.lock().unwrap().take());
         if let Some(e) = err {
             let error_json = serde_json::to_string(&e).unwrap();
             CString::new(error_json)

--- a/polar-c-api/src/lib.rs
+++ b/polar-c-api/src/lib.rs
@@ -6,7 +6,7 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr::{null, null_mut};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 /// Get a reference to an object from a pointer
 macro_rules! ffi_ref {


### PR DESCRIPTION
Pretty sure this fixed the "End of JSON input" test flake. I was able to repro it locally.

Seems like the problem was some race condition with multiple threads accessing the error in the refcell. So we were returning a null error here: https://github.com/osohq/oso/compare/sam/fix-go-flake?expand=1#diff-42d3477e8e5600703b52d91104159a7691531532173e0e7e41ead2a819e4c5c6R71

(I added a panic there and confirmed it was reaching that line).

RefCells aren't thread safe, and it seems like Go running tests multithreaded is hitting a race condition here.