### PR TITLE
Polar and testing guides

### DIFF
--- a/docs/content/any/guides/more/testing/index.md
+++ b/docs/content/any/guides/more/testing/index.md
@@ -1,0 +1,163 @@
+---
+date: '2021-12-04T01:58:28.010Z'
+docname: using/examples/testing
+images: {}
+path: /using-examples-testing
+title: Test Your Policy
+weight: 10
+description: |
+  Learn to test your Oso policies.
+aliases:
+  - ../../../using/examples/testing.html
+---
+
+# Test your policy
+
+In Oso, your authorization logic is separated from the rest of your application in a policy. This makes it very easy to test authorization in isolation.
+
+Oso works with your favorite testing framework. We'll demonstrate with[pytest](https://docs.pytest.org/en/6.2.x/).
+
+## Policy tests
+
+You can test your policy through the same API you call your policy with `oso.authorize()`.
+
+This example has one kind of resource, a `Repository` (like GitHub or GitLab). Users have [roles](https://www.notion.so/Outline-for-Testing-b6ab45097c214059803457de437f9aba) of `contributor`, `maintainer`, and `admin` on each repository. Someone who has `admin` permissions on one repository does not have `admin` permissions for a different repository.
+
+Initialize your Oso instance in a test fixture.
+
+```python
+@pytest.fixture(scope="session")
+def oso():
+    oso_instance = Oso()
+    oso_instance.register_class(User)
+    oso_instance.register_class(Repository)
+    oso_instance.load_files(["app/main.polar"])
+    return oso_instance
+```
+
+Let's test who has the ability to delete repositories.
+
+Contributors do not have permission to delete repositories:
+
+```python
+def test_contributors_cannot_delete_repos(oso):
+    repo = Repository("oso")
+    contributor = User([Role(name="contributors", repository=repo)])
+    with pytest.raises(ForbiddenError):
+        oso.authorize(contributor, "delete", repo)
+```
+
+Maintainers do not have permission to delete repositories:
+
+```python
+def test_maintainers_cannot_delete_repos(oso):
+    repo = Repository("oso")
+    maintainer = User([Role(name="maintainer", repository=repo)])
+    with pytest.raises(ForbiddenError):
+        oso.authorize(maintainer, "delete", repo)
+```
+
+But, admins do have permission to delete repositories:
+
+```python
+def test_admins_can_delete_repos(oso):
+    repo = Repository("oso")
+    user = User([Role(name="admin", repository=repo)])
+    assert oso.authorize(user, "delete", repo) == None
+```
+
+## Unit Testing Your Policy
+
+The examples above test your whole policy. If your policy is complicated, you may want to test small pieces of it in the same way you would unit test your app code.
+
+Oso provides `oso.query_rule` to query individual rules of your policy. Rules may return many results, so `oso.query_rule` is a generator—you can use `oso.query_rule_once` to ensure the query returns exactly one result.
+
+Our policy has a rule, `has_role`, to look up roles on a repository. Here's how to test that logic is correct:
+
+```python
+def test_admin_users_have_admin_roles_on_repos(oso):
+    repo = Repository.get_by_name("gmail")
+    user = User([Role(name="admin", repository=repo)])
+    assert oso.query_rule_once("has_role", user, "admin", repo)
+```
+
+## Integration Testing
+
+Policy and unit tests confirm that the policy is correct, but do not confirm that your application's authorization behaves correctly as a whole. To test your app's behavior, write integration tests that test your routes end-to-end. Like all integration tests, you'll need a mock dataset to test against. Most web frameworks have a test client that can make this easy. In this case, we're querying Flask's `get` method directly.
+
+```python
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        yield client
+
+def test_invalid_access_404s(client):
+    User.current_user = User([Role(name="admin", repository=repos_db["gmail"])])
+    response = client.get("/repo/oso")
+    assert response.status_code == 404
+
+def test_valid_access_200s(client):
+    User.current_user = User([Role(name="admin", repository=repos_db["gmail"])])
+    response = client.get("/repo/gmail")
+    assert response.status_code == 200
+```
+
+## Best practices: what kind of tests should I write?
+
+Policy tests, unit tests, and integration tests are all useful.
+
+Policy tests help ensure that your policy behaves correctly for a set of inputs. Spend most of your testing effort here, dipping in to unit tests as needed.
+
+- Test each `allow` rule you write. Test as many combinations of `actor`, `action` and `resource` as you need to cover your policy's logic.
+
+Unit tests allow you to use Test-Driven Development (TDD) to write your policy and to isolate particularly tricky logic for testing. These should work alongside your policy tests to test your policy's correctness.
+
+- TDD is a great way to write a policy—as you add rules, test them with `oso.query_rule_once()`.
+- In a policy with roles, test your `has_role` rules' integration with your app to make sure they find the correct roles for all resources.
+- Test that your `has_relation(subject, relname, object)` rules find the `subject` of each relation properly. You can do that by adding an Oso `Variable`—Oso's `query_rule` will return all possible values for that variable. For instance, if you're testing a "parent" relation, make sure that `oso.query_rule('has_relation', (Variable('subject'), "parent", object))` returns the correct `subject`s.
+
+Integration testing confirms that policy *enforcement* is correct in your application. Because integration tests exercise parts of your app that aren't Oso, try to minimize the amount of integration tests you write. 
+
+- If you're calling `authorize` in each route handler, you should have one authorization test for every route.
+- If you're able to call `authorize` in your middleware, it may only be necessary to test a few routes to confirm that your middleware is correctly covering your endpoints.
+
+## For extra coverage, use decision tables to test combinations of inputs
+
+You'll often want to test every combination of a set of properties, like every combination of role and permission. For that case, we recommend writing and testing a [decision table](https://en.wikipedia.org/wiki/Decision_table) of allowed actions.
+
+```python
+def test_combinations_of_role_and_action(oso):
+    repository = Repository("oso")
+
+    combinations = [
+        ("contributor", "read",   repository, True ),
+        ("contributor", "push",   repository, False),
+        ("contributor", "delete", repository, False),
+        ("maintainer",  "read",   repository, True ),
+        ("maintainer",  "push",   repository, True ),
+        ("maintainer",  "delete", repository, False),
+        ("admin",       "read",   repository, True ),
+        ("admin",       "push",   repository, True ),
+        ("admin",       "delete", repository, True ),
+    ]
+
+    errors = []
+    for role, action, repo, expected in combinations:
+        user = User([Role(name=role, repository=repo)])
+        try:
+            oso.authorize(user, action, repo)
+            actual = True
+        except AuthorizationError:
+            actual = False
+
+        if actual != expected:
+            errors.append(role + ":" + action)
+
+    assert errors == []
+```
+
+## What's Next
+
+- Check out our [How-To Guides](https://docs.osohq.com/guides.html) for more on using Polar
+policies for authorization.
+- Check out the [Polar reference](https://docs.osohq.com/reference/polar.html) for more on the Polar language and syntax.

--- a/docs/content/any/guides/more/testing/index.md
+++ b/docs/content/any/guides/more/testing/index.md
@@ -1,14 +1,8 @@
 ---
-date: '2021-12-04T01:58:28.010Z'
-docname: using/examples/testing
-images: {}
-path: /using-examples-testing
 title: Test Your Policy
 weight: 10
 description: |
   Learn to test your Oso policies.
-aliases:
-  - ../../../using/examples/testing.html
 ---
 
 # Test your policy

--- a/docs/content/any/learn/polar-foundations.md
+++ b/docs/content/any/learn/polar-foundations.md
@@ -1,5 +1,5 @@
 ---
-date: '2021-01-07T02:46:33.217Z'
+date: '2021-12-02T02:46:33.217Z'
 docname: more/language/polar-foundations
 images: {}
 path: /more-language-polar-foundations
@@ -11,223 +11,71 @@ weight: 4
 
 # The Polar Language
 
-The **Oso** authorization library uses the **Polar** programming language
-to express authorization logic and policies. This guide is meant to serve
-as a gentle introduction to Polar: what it is, how it works, and what you
-can do with it. It is not meant to be an exhaustive or precise description
-of the language; instead, its primary goal is to help you understand the
-Polar language and its capabilities so that you can start writing policies
-quickly and easily.
+The Oso authorization library uses the Polar programming language to express authorization logic and policies. This guide is an introduction to the Polar language: what it is, how it works, why we've chosen to use it. For a more complete guide to syntax, use our [Syntax Guide](https://www.notion.so/Concepts-The-Polar-Language-0c59f78527bb470bbefb173ebf85ed69).
 
-But before we dive into the specifics, we’ll briefly discuss how Polar is
-and is not like “traditional” (i.e., imperative) programming languages,
-along with some of the advantages and disadvantages that come with those
-differences.
+## Declarative Programming
+
+Polar is a [declarative programming language](https://en.wikipedia.org/wiki/Declarative_programming). It's very different from the *imperative* programming languages—like Python, JavaScript, or Go—that we often do our day-to-day work in.
+
+In a declarative programming language, you state what your program should do, and the language runtime will compute it.
+
+- SQL is a declarative programming language: you state what records you'd like to fetch, and the SQL runtime determines what steps to take to return those records.
+- Regular expressions are a declarative language: you write what patterns you'd like to be matched, and it's up to the runtime to return the text that matches those patterns.
+
+Polar is similar. You'll write authorization *rules*, query those rules, and Polar will tell you what your query matched. Working with Polar is much like working with a database. When writing code, you'll write information to your database. At runtime, you'll query that information.
 
 ## Logic Programming
 
-Polar is a [logic programming language](https://en.wikipedia.org/wiki/Logic_programming),
-a paradigm that arose out of early AI research in logical
-deduction and planning. In contrast with traditional languages,
-a program written in a logic programming language encodes logical
-statements about the domain of interest rather than instructions
-for carrying out specific operations in that domain. That is,
-it uses a *declarative* rather than *imperative* programming
-style; you express *what* your program must do, rather than
-*how* it must do it. A familiar example of a widely used declarative
-language is SQL; others include purely functional languages such
-as Haskell, regular expressions, configuration languages, etc.
+Polar is also a [logic programming language](https://en.wikipedia.org/wiki/Logic_programming). This means that it's designed to answer questions about a set of rules. You'll see how this works in the *How Polar code executes* section*.*
 
-More concretely, a logic programming language replaces explicit
-flow control and algorithmic steps (e.g., loops, conditionals,
-function calls, etc.) with *facts* and *rules* that must hold
-over your domain objects. These facts and rules are stored in
-a special kind of database called a *knowledge base*, so called
-because it stores logical statements that represent “knowledge”
-(or something roughly analogous to it) about your domain.
-As with a traditional database, one does not “run” the knowledge
-base; it is not an executable artifact. Instead, one *queries*
-it for the truth or falsity of a particular logical statement.
+## Advantages
 
-Let’s take a simple example. Suppose I tell you that I have a
-younger brother and an older sister. Your “knowledge base”
-for this example then consists of these two facts:
+- Declarative languages like Polar are concise. This means more than just saving a few characters in typing your program. You can dramatically *compress* your program by leveraging the language runtime. Being able to express your program concisely means simpler programs, fewer places to make mistakes, and less complexity when you're making changes.
+- Logic programming is very well-suited to the domain of authorization.  Authorization queries like, "Is this user allowed access to this resource?" are easy to answer with a logic programming language.
 
+## Caveats
 
-1. My brother is younger than me.
+- It takes practice to read Polar code. If you've used regular expressions extensively, you know that it takes some practice to look at a regular expression and see what it does. Polar is similar—at first, it looks like Polar statements aren't doing much. That's because the language runtime handles so much for us.
+- Polar executes in a way that might be unfamiliar to you. It runs very differently from how most app code executes. That's why we have these guides—we'll help you get fluent in Polar!
 
+## How Polar code executes
 
-2. My sister is older than me.
+> For the next few examples, we'll use only the base language, without touching authorization just yet.
+> 
 
-Now I can ask yes/no questions whose answers depend on these
-facts. I can ask easy questions like: “is my brother younger
-than me?” Such questions are easy because their answers are
-directly encoded in the knowledge base: (1) trivially implies
-that the answer is “yes”. But I can also ask slightly harder
-questions, such as: “is my brother older than me?” You can
-immediately answer “no”, because fact (1) together with the
-anti-symmetric nature of the “older than” relation imply that
-it is impossible for my brother to be both older and younger
-than me. And I can ask questions that are harder still, like:
-“is my brother younger than my sister?” By purely logical deduction,
-using only basic properties of the relations “older than” and
-“younger than” (viz., transitivity), you can answer “yes”
-*even though I did not give an explicit relation between the
-ages of my siblings*. This simple example almost completely
-captures the essence of any logic programming language.
-
-In the context of authorization, the knowledge base represents
-your *policy*. It is comprised of facts about and rules governing
-the actors, resources, and actions that actors may take on those
-resources in your domain. You can then *query* the knowledge
-base with a question like: “is this particular actor allowed to
-take this action on this resource”? By using the information in
-the knowledge base together with a built-in logical deduction process,
-the system can answer such queries with either “yes” or “no”
-*even when the answer does not appear explicitly in the knowledge base*.
-This is the essence of the Oso authorization system.
-
-### Advantages
-
-One of the main advantages of a purely declarative language
-like Polar over a traditional imperative language is *concision*.
-This means more than just saving a few characters in typing your
-program. It means that you can dramatically *compress* your program
-by leveraging a specialized interpreter or search engine.
-Another way to think of this is that such languages allow you to
-express only and exactly the conditions your problem depends on,
-and leave the “incidentals” of *how* or *whether* those conditions
-are satisfied to the system.
-
-Take ordinary string-matching regular expressions, for instance.
-They offer a level of concision for many simple (and not-so-simple)
-string matching tasks that is unmatched by imperative techniques.
-Think about the last non-trivial regular expression you wrote;
-now think about how you would write an equivalent matching function
-in an ordinary imperative language (without writing a regexp interpreter).
-Their strength comes not from the raw character count, or their typically
-terse choice of metacharacters: a regular expression language that
-used, say, `{ANY}` instead of `.` and `{END}` instead of
-`$`, etc. would only linearly scale the average pattern length.
-Rewriting such expressions as imperative matching statements would
-often explode them by a large non-linear factor.
-
-The power and concision of regular expressions for pattern matching
-comes from their purely declarative semantics. A regular expression
-denotes a set of strings, and the process of matching an input string
-is equivalent to searching for that input in the denoted set.
-But you don’t need to specify *how* the search is performed; the
-search algorithm (e.g., NFA, DFA, etc.) is abstracted away from
-the pattern language. You don’t write an NFA simulator alongside
-your regexp, you just assume the interpreter supplies one (or an
-equivalent).
-
-### Caveats
-
-> Some people, when confronted with a problem,
-> think “I know, I’ll use regular expressions.”
-> Now they have two problems.
-> — [JWZ](https://www.jwz.org/hacks/)
-
-As anyone who’s used regular expressions extensively knows,
-they can be easier to write than to read. This is because while
-you’re writing one, the necessary context—the constraints on
-the set of strings you want to match—is already in your mind.
-But although the regexp encodes those constraints, they can be
-difficult to decode if you don’t already know them. This is the
-flip side of any highly compressed language: because each symbol
-potentially carries a large amount of information, it can be
-difficult for a human to decode. This is true of any information-dense
-notation, e.g., mathematics; without a complete “dictionary”
-for the compression scheme, the meaning of statements in an extremely
-concise languages can be quite opaque. The flip side of this
-flip side, of course, is that *if* the necessary context is
-available (e.g., the program or paper is read by someone familiar
-with the domain and the notation), vastly more information can
-be conveyed in a given space than would otherwise be possible.
-
-There’s weight hanging on that *if*, though. Regular expressions
-can look like noise to someone unfamiliar with the basic notation.
-Logic programs don’t usually look like noise, but they might not
-look like they *do* much if you don’t understand the basic ideas.
-And even if you do, they may be sufficiently information-dense
-that it can be hard to get details without close scrutiny. The
-other side of that point is that while details might be missed,
-it’s often vastly easier to grasp the program (or policy) as a
-*whole*, if only because it might fit on a single page or screen
-instead of being spread out over many times that. The old adage
-that “a picture is worth a thousand words” neatly captures the
-idea here: a statement in a concise declarative language is like
-a “picture” of the solution you seek, as opposed to a long-hand
-description of how to find it.
-
-Like any picture, though, the “negative space” of a statement
-in a declarative language is as important as what is said; i.e.,
-what is *implicit* in the meaning of the terms of the language.
-To take one last regular expression example, the meaning of the
-“any” metacharacter (usually `.`) depends implicitly on the
-space of characters supported by the particular implementation;
-e.g., does it match any character that can be encoded in 8 bits,
-say, or does it include all Unicode code-points? In logic programming,
-this issue manifests itself as the [closed-world assumption](https://en.wikipedia.org/wiki/Closed-world_assumption):
-the assumption that any statement not known to be true is false.
-These implicit limitations must be kept in mind both for reading
-and writing programs, for they will not appear in the textual
-representation.
-
-## Polar
-
-Enough abstract nonsense—let’s see some code! We’ll start, as is
-traditional in logic programming, with a simple genealogy example.
-Suppose we are given the following fragment of a family tree:
-
-
-
-![image](learn/olympians.svg)
-
-We could represent the direct relations as the following facts in Polar:
+Here's one Polar rule.
 
 ```
-# father(x, y) ⇒ y is the father of x.
+father("Artemis", "Zeus");
+```
+
+In words, this line means "`father` is true when it's called on the strings `"Artemis"` and `"Zeus"`." This short example defines a rule named `father`. It does this without an explicit definition step! No need to write `def father():`.
+
+We can add another rule:
+
+```
 father("Artemis", "Zeus");
 father("Apollo", "Zeus");
-father("Asclepius", "Apollo");
-father("Aeacus", "Apollo");
-
-# mother(x, y) ⇒ y is the mother of x.
-mother("Apollo", "Leto");
-mother("Artemis", "Leto");
 ```
 
-First, some quick syntactic notes. Lines that begin with a `#` are
-comment lines, and are ignored; they may be used to document your program.
-All of the other lines are terminated with a `;` to signify the end of
-a statement. Double-quoted strings like `"Artemis"` and `"Apollo"`
-are literals, and represent the “actors” in our little domain.
+These lines mean:
 
-Each nontrivial line expresses a **fact**: an unconditionally true
-statement in our domain. They collectively define two **predicates**,
-`father` and `mother`. A predicate is a relation that is either
-true or false for a certain set of **arguments**, e.g.,
-`father("Artemis", "Zeus")` (true) or
-`father("Zeus", "Zeus")` (false).
+- "`father` is true when it's called on the strings `"Artemis"` and `"Zeus"`."
+- "`father` is *also* true when it's called on the strings `"Apollo"` and `"Zeus"`."
 
-To determine whether a predicate is true or false with respect to a
-particular knowledge base, we can **query** it from the interactive
-REPL:
+Notice that these rules exist side-by-side. We can have any number of rules that use the `father` predicate—adding a new rule is much like adding a new database entry.
+
+Now that we've written these rules, we can *query* them. We'll need to run the program to query these rules. The easiest way to do that is to run the interactive REPL:
 
 ```
+$ python -m polar father.polar
 >> father("Artemis", "Zeus");
 True
 ```
 
-Here `>>` is the REPL prompt, and the query follows, terminated
-with a `;`. Polar executes the query, and replies `True`,
-since by first fact above, the father of Artemis is indeed Zeus.
+We asked a question about the program, and got our answer: "`father` is true when it's called on the strings `"Artemis"` and `"Zeus"`." (We already knew that, though—that was what the rule meant.)
 
-That’s a fairly trivial query, since its truth value was supplied
-directly as a fact. So let’s try a non-trivial one: let’s ask for
-*all* of the known children of Zeus:
+Let's ask a more open-ended question.
 
 ```
 >> father(child, "Zeus");
@@ -236,216 +84,38 @@ child = "Apollo"
 True
 ```
 
-In this query, we used a **variable**, `child`. Notice that we did
-not explicitly assign a value to it; instead, the system *found*
-two valid bindings: to the string `"Artemis"`, and to the string
-`"Apollo"`. It did so by **searching** its knowledge base for
-facts that **match** the query. We’ll dive into the details of this
-search process shortly, but let’s continue our example for now.
-As you might guess, the same sorts of queries work for our other
-predicate; if we wanted to know who Artemis’s mother was, we could
-query for:
+This asks, "what are all the values, called `child`, for which `father(child, "Zeus")` is true?" And we get an answer: `child` could be either "Artemis" or "Apollo". The word `child` isn't special—any word that's not already defined becomes a *variable*, and Polar will look for all values that variable could be.
+
+**Conditional rules**
+
+So far, we've seen rules that are simply true. We can also write rules that are conditionally true. Here's one:
+
+```python
+grandfather(a, b) if father(a, anyPerson) and father(anyPerson, b);
+```
+
+Like we saw above, we can use an unused word—in this case, `anyPerson`—and that word functions as a variable.
+To use this rule effectively, we'll need one more `father` rule:
+
+```python
+father("Artemis", "Zeus");
+father("Apollo", "Zeus");
+father("Asclepius", "Apollo");
+grandfather(a, b) if father(a, anyPerson) and father(anyPerson, b);
+```
+
+Now, we can ask our programs questions about this rule.
 
 ```
->> mother("Artemis", mother)
-mother = "Leto"
+>> grandfather("Asclepius", grandpa);
+grandpa = "Zeus"
 True
 ```
 
-Notice that there is no problem having both a variable and a predicate
-named `mother`. In Polar, variables cannot be bound to predicates
-(it is a [first-order logic language](https://en.wikipedia.org/wiki/First-order_logic)),
-so they use different namespaces.
+Our program has deduced the grandfather of Asclepius!
 
-Now let’s augment our simple facts with some **rules**. Rules are
-like facts, but conditional—they define relations that are true
-**if** some other conditions hold. Rules are strictly more general
-than facts, since any fact is simply a rule with no conditions.
-As with facts, multiple rules may be defined for the same predicate,
-and conversely a predicate may be defined by any mixture of facts
-or rules. Here’s a rule that we could define:
+Most Polar rules you'll see are in this `statement if condition;` form. That's where we'll wrap up this guide—to dive deeper into Polar syntax, we have a Polar **[Syntax Guide](https://www.notion.so/Concepts-The-Polar-Language-0c59f78527bb470bbefb173ebf85ed69)**.
 
-```
-# parent(x, y) ⇒ y is a parent of x.
-parent(x, y) if father(x, y);
-parent(x, y) if mother(x, y);
-```
+We haven’t covered how to use Polar to express particular authorization policies. Many Polar examples can be found in our [authorization guides](https://docs.osohq.com/guides.html).
 
-Again, let’s start with the syntax. Each rule has a **head** and
-a **body**, separated by the `if` symbol. (If there is no body,
-the `if` is elided, and the rule becomes a fact.) To apply
-a rule, Polar first matches the head with the query (just as
-for a fact), and then queries for the body. If that sub-query
-is successful, then the rule as a whole succeeds; otherwise,
-it fails and tries the next one. Thus, multiple rules for the
-same predicate are *alternatives*: `y` is a parent of `x`
-*if* either `y` is the mother of `x` *or* the father of
-`x`. Let’s see it in action:
-
-```
->> parent("Apollo", "Zeus");
-True
->> parent("Apollo", "Leto");
-True
->> parent("Apollo", "Artemis");
-False
->> parent("Artemis", parent);
-parent = "Zeus"
-parent = "Leto"
-True
-```
-
-We can go one level deeper, if we wish:
-
-```
-# grandfather(x, y) ⇒ y is a grandfather of x.
-grandfather(x, y) if parent(x, p) and father(p, y);
-```
-
-This rule has two conditions in its body, separated by the
-conjunction operator `and`. It says that `y`
-is a grandfather of `x` *if* there is some `p` that
-is the parent of `x` *and* `y` is the father of that
-`p`. For example:
-
-```
->> grandfather("Asclepius", g);
-g = "Zeus"
-True
-```
-
-We can also write recursive rules:
-
-```
-# ancestor(x, y) ⇒ y is an ancestor of x.
-ancestor(x, y) if parent(x, y);
-ancestor(x, y) if parent(x, p) and ancestor(p, y);
-```
-
-This says that `y` is an ancestor of `x` *if* `y` is either a
-parent of `x` *or* they are an ancestor of a parent `p` of `x`:
-
-```
->> ancestor("Asclepius", ancestor);
-ancestor = "Apollo"
-ancestor = "Zeus"
-ancestor = "Leto"
-True
-```
-
-### The Search Procedure
-
-Now that we’ve seen some basic examples of Polar rules and queries,
-let’s look in a little more detail at how it executes queries against
-a given set of rules.
-
-Recall that rules have a **head** and an optional **body** (the part
-after a `if`). If there is no body, we call the rule a **fact**. The head
-must contain exactly one predicate, with any number of **parameters**
-in parenthesis; e.g., `1` is not a valid head, nor is a bare `foo`.
-Unlike most non-logic languages, each parameter may be either a variable
-*or* a constant (literal); e.g., `foo(1)`, `foo("foo")`, and `foo(x)`
-are all perfectly good rule heads.
-
-You may also define rules with the same name but a different number of
-parameters; e.g.:
-
-```
-foo(1);
-foo(1, 2);
-```
-
-Semantically, this actually defines two *different* predicates, which are
-traditionally written as `foo/1` and `foo/2`. We don’t use predicates
-overloaded in this way very often, but they are occasionally useful, e.g.,
-one could be a “public” predicate, and the other a recursive helper that
-also takes, say, an accumulator or something like that. (There is no
-visibility control in Polar, so the helper wouldn’t really be “private”,
-it would just never be queried directly except by the “public” predicate.)
-
-But let’s keep things simple for now. Suppose our knowledge base
-consists of just these two facts:
-
-```
-foo(1);
-foo(2);
-```
-
-Now consider the query `foo(2)`. Polar first looks up all of the
-rules for the predicate `foo`, and finds the two above. Then, for
-each of those rules, it tries to match each argument of the query
-with the corresponding parameter in the head of the rule. In this
-case, the argument is `2`, and the corresponding first parameter
-of the first rule is `1`, so the match fails. But matching with
-the head of the second rule succeeds, since `2 = 2`. There is no
-body for this rule, so the match is unconditional, and the query
-succeeds: `foo(2)` is true.
-
-Now let’s consider a slightly more complex query: `foo(x)`. Once
-again, the two rules above are considered. But now they *both* match,
-because `x = 1` and `x = 2` are valid **bindings** for `x`
-(though not at the same time). The equals sign `=` in Polar is thus
-not quite a comparison operator, but not quite assignment, either—it’s
-sort of a mixture of both. It’s called a
-[unification](https://en.wikipedia.org/wiki/Unification_(computer_science))
-operator, and it works like this: if either side is an unbound variable,
-it is **bound** to the other side, and the result is true; otherwise, the
-two sides are compared for equality (element- or field-wise for compound
-value types like lists and dictionaries), with variables replaced by
-their values. For example, (even without any rules) the conjunctive
-query `x = 1 and x = 1` succeeds, because the first unification binds
-the variable `x` to the value `1`, so the second unification
-is equivalent to `1 = 1`, which is true. But the query `x = 1 and x = 2`
-is false, because the second unification is equivalent to `1 = 2`.
-
-We can now state precisely how the search procedure works for predicates.
-For each rule defined on the query predicate, each query argument is
-unified, in left-to-right order, with the corresponding parameter in
-the head of the rule. That unification may or may not bind variables,
-either from the parameter or the argument. Each unification occurs in
-a dynamic environment that contains the bindings from the previous
-unifications. If all of the unifications of the query arguments with
-the parameters in the head succeed, then a sub-query for the body
-of the rule is executed. The body of a rule may consist of a single
-predicate, or a conjunction of them, or of any of the operators
-described in the Polar language reference,
-e.g., disjunction, negation, numeric comparisons, etc. Each conjunct
-is queried for, in left-to-right order, accumulating any bindings
-from unifications. If the queries for every conjunct in the body all
-succeed, then the query as a whole does, too.
-
-When a top-level query succeeds, Polar pauses and reports the set
-of bindings (which may be empty) that enabled the successful query;
-this is what we saw in the REPL examples above. It then *continues*
-searching for more solutions, picking up with the next matching rule.
-Thus, Polar searches for all possible bindings that make the query
-predicate true in the space determined by the rules in the knowledge
-base, just as a regular expression pattern match searches for a query
-string in the set of strings determined by the regexp.
-
-If a query fails (i.e., is false), then the current branch of the search
-is abandoned, and Polar **backtracks** to the last alternative, which
-will be either another possible rule for the current query, or the next
-untaken branch of a disjunction. When backtracking, all variable bindings
-that occurred since the last alternative are undone. If no unexplored
-alternatives remain, the query as a whole fails, and a false result
-is reported.
-
-## Summary
-
-In this guide, we have explored:
-
-
-* Declarative programming, and logic programming in particular.
-
-
-* The basic syntax and semantics of the Polar language.
-
-
-* The search and unification procedures that Polar is built on.
-
-What we haven’t explored here is how to use Polar to express
-particular authorization policies. Many examples can be found
-in the Authorization Fundamentals
-and Authorization Models sections
-of the manual.
+We're also always happy to help you get started with Oso! If you'd like to learn more about using Oso in your app or have any questions, [schedule a 1x1 with an Oso engineer](https://calendly.com/osohq/1-on-1).

--- a/docs/content/any/learn/polar-foundations.md
+++ b/docs/content/any/learn/polar-foundations.md
@@ -23,7 +23,7 @@ Polar is similar. You'll write authorization *rules*, query those rules, and Pol
 
 ## Logic Programming
 
-Polar is also a [logic programming language](https://en.wikipedia.org/wiki/Logic_programming). This means that it's designed to answer questions about a set of rules. You'll see how this works in the *How Polar code executes* section*.*
+Polar is also a [logic programming language](https://en.wikipedia.org/wiki/Logic_programming). This means that it's designed to answer questions about a set of rules. You'll see how this works in the *How Polar code executes* section.
 
 ## Advantages
 
@@ -42,7 +42,7 @@ Polar is also a [logic programming language](https://en.wikipedia.org/wiki/Logic
 
 Here's one Polar rule.
 
-```
+```polar
 father("Artemis", "Zeus");
 ```
 
@@ -50,7 +50,7 @@ In words, this line means "`father` is true when it's called on the strings `"Ar
 
 We can add another rule:
 
-```
+```polar
 father("Artemis", "Zeus");
 father("Apollo", "Zeus");
 ```
@@ -64,7 +64,7 @@ Notice that these rules exist side-by-side. We can have any number of rules that
 
 Now that we've written these rules, we can *query* them. We'll need to run the program to query these rules. The easiest way to do that is to run the interactive REPL:
 
-```
+```polar
 $ python -m polar father.polar
 >> father("Artemis", "Zeus");
 True
@@ -74,7 +74,7 @@ We asked a question about the program, and got our answer: "`father` is true whe
 
 Let's ask a more open-ended question.
 
-```
+```polar
 >> father(child, "Zeus");
 child = "Artemis"
 child = "Apollo"
@@ -87,14 +87,14 @@ This asks, "what are all the values, called `child`, for which `father(child, "Z
 
 So far, we've seen rules that are simply true. We can also write rules that are conditionally true. Here's one:
 
-```python
+```polar
 grandfather(a, b) if father(a, anyPerson) and father(anyPerson, b);
 ```
 
 Like we saw above, we can use an unused word—in this case, `anyPerson`—and that word functions as a variable.
 To use this rule effectively, we'll need one more `father` rule:
 
-```python
+```polar
 father("Artemis", "Zeus");
 father("Apollo", "Zeus");
 father("Asclepius", "Apollo");
@@ -103,7 +103,7 @@ grandfather(a, b) if father(a, anyPerson) and father(anyPerson, b);
 
 Now, we can ask our programs questions about this rule.
 
-```
+```polar
 >> grandfather("Asclepius", grandpa);
 grandpa = "Zeus"
 True

--- a/docs/content/any/learn/polar-foundations.md
+++ b/docs/content/any/learn/polar-foundations.md
@@ -1,8 +1,5 @@
 ---
 date: '2021-12-02T02:46:33.217Z'
-docname: more/language/polar-foundations
-images: {}
-path: /more-language-polar-foundations
 title: The Polar Language
 aliases:
     - ../../more/language/polar-foundations.html

--- a/docs/spelling/allowed_words.txt
+++ b/docs/spelling/allowed_words.txt
@@ -5,6 +5,7 @@ Abagail
 ActiveRecord
 AdminOnlyFields
 Appleby
+Asclepius
 AuthorizationError
 Bhavik's
 Bjerk
@@ -13,6 +14,7 @@ CLI
 CTO
 Changelogs
 Cloudflare
+dataset
 DFA
 Dexec
 EMR
@@ -27,6 +29,7 @@ GDB
 GSuite
 GitClub
 Github's
+GitLab
 Gradle
 GraphQL
 Graphene
@@ -61,6 +64,7 @@ Polar's
 Postgres
 Prisma
 PyPI
+pytest
 RBAC
 REPL
 RESTful


### PR DESCRIPTION
Adding [Polar Language Concepts ](https://www.notion.so/osohq/Concepts-The-Polar-Language-0c59f78527bb470bbefb173ebf85ed69) and a [testing guide](https://www.notion.so/osohq/Outline-for-Testing-b6ab45097c214059803457de437f9aba). The testing guide is under `> More` — we can move it to main-sidebar status if we'd like.