### PR TITLE
Fix Node Debugger

### DIFF
--- a/languages/js/src/Polar.ts
+++ b/languages/js/src/Polar.ts
@@ -269,6 +269,8 @@ export class Polar {
     const repl = global.repl?.repl as REPLServer | undefined; // eslint-disable-line @typescript-eslint/no-unsafe-member-access
 
     if (repl) {
+      // @ts-ignore
+      global.oso_repl_rl = repl;
       repl.setPrompt(PROMPT);
       const evalQuery = this.evalReplInput.bind(this);
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -292,6 +294,10 @@ export class Polar {
         prompt: PROMPT,
         tabSize: 4,
       });
+
+      // @ts-ignore
+      global.oso_repl_rl = rl;
+
       rl.prompt();
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       rl.on('line', async (line: string) => {
@@ -314,18 +320,23 @@ export class Polar {
         const ffiQuery = this.#ffiPolar.newQueryFromStr(input);
         const query = new Query(ffiQuery, this.getHost());
         const results = [];
+        let hadResults = false;
+
         for await (const result of query.results) {
-          results.push(result);
-        }
-        if (results.length === 0) {
-          return false;
-        } else {
-          for (const result of results) {
-            for (const [variable, value] of result) {
-              console.log(variable + ' = ' + repr(value));
-            }
+          hadResults = true;
+          let hadVars = false; 
+          for (const [variable, value] of result) {
+            hadVars = true;
+            console.log(variable + ' = ' + repr(value));
           }
-          return true;
+
+          if (!hadVars) {
+            console.log(true);
+          }
+        }
+
+        if (!hadResults) {
+          console.log(false);
         }
       }
     } catch (e) {

--- a/languages/js/src/Query.ts
+++ b/languages/js/src/Query.ts
@@ -359,17 +359,20 @@ export class Query {
             }
             const { message } = event.data as Debug;
             if (message) console.log(message);
-            createInterface({
-              input: process.stdin,
-              output: process.stdout,
-              prompt: 'debug> ',
-              tabSize: 4,
-            }).on('line', (line: string) => {
-              const trimmed = line.trim().replace(/;+$/, '');
-              const command = this.#host.toPolar(trimmed);
-              this.#ffiQuery.debugCommand(JSON.stringify(command));
-              this.processMessages();
+            const command = await new Promise(resolve => {
+              createInterface({
+                input: process.stdin,
+                output: process.stdout,
+                prompt: 'debug> ',
+                tabSize: 4,
+              }).on('line', (line: string) => {
+                const trimmed = line.trim().replace(/;+$/, '');
+                const command = this.#host.toPolar(trimmed);
+                resolve(command)
+              });
             });
+            this.#ffiQuery.debugCommand(JSON.stringify(command));
+            this.processMessages();
             break;
           }
           default: {


### PR DESCRIPTION
The debugger in Node had a few issues:

1. We weren't waiting for input before continuing the run loop
2. We were creating a new readline session for every debug event without destroying the old one, so when you typed a character it would be duplicated a bunch of times
3. If we already had a readline instance for the REPL we didn't use it.
4. The REPL doesn't immediately print results, it collects them all and prints when the query is done. If you were debugging a query that outputs results, you wouldn't see them until the end, which is confusing.

This draft PR mostly fixes this. The code is pretty janky so could use some clean up before merging in. It has an issue when run from the node REPL. It prints `undefined` after each query because the node repl expects a return from the `eval` callback.

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
