### PR TITLE
INFO result logs with serialized bindings

### DIFF
--- a/polar-core/src/formatting.rs
+++ b/polar-core/src/formatting.rs
@@ -349,6 +349,7 @@ pub mod display {
             }
         }
     }
+
     impl fmt::Display for Declaration {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match self {

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -3018,6 +3018,21 @@ impl Runnable for PolarVirtualMachine {
                 .collect();
         }
 
+        self.log_with(
+            LogLevel::Info,
+            || {
+                // https://github.com/rust-lang/rust/blob/master/library/alloc/src/string.rs#L2724-L2736
+                // these write! calls are *guaranteed* to return Ok(), permitting the use of .unwrap()
+                let mut out = "RESULT: { ".to_string(); // open with single right-padded curly
+                for (key, value) in &bindings {
+                    write!(out, "{}: {} ", key, value).unwrap(); // write right-padded key: value pairs
+                }
+                write!(out, "}}").unwrap(); // closing curly (doubled to escape)
+                out
+            },
+            &[],
+        );
+
         Ok(QueryEvent::Result { bindings, trace })
     }
 


### PR DESCRIPTION
log query each result along with its bindings.
