### PR TITLE
VS Code: Update syntax highlighting for resource block identifiers

### DIFF
--- a/vscode/oso/syntaxes/polar.tmLanguage.json
+++ b/vscode/oso/syntaxes/polar.tmLanguage.json
@@ -80,7 +80,7 @@
     },
     "resource-block": {
       "name": "meta.resource-block",
-      "begin": "(resource|actor)\\s*([a-zA-Z][a-zA-Z0-9:-_]*)\\s*\\{",
+      "begin": "(resource|actor)\\s*([a-zA-Z][a-zA-Z0-9:_]*)\\s*\\{",
       "beginCaptures": {
         "1": {
           "name": "keyword.control"

--- a/vscode/oso/syntaxes/polar.tmLanguage.json
+++ b/vscode/oso/syntaxes/polar.tmLanguage.json
@@ -80,7 +80,7 @@
     },
     "resource-block": {
       "name": "meta.resource-block",
-      "begin": "(resource|actor)\\s*([a-zA-Z][a-zA-Z0-9:_]*)\\s*\\{",
+      "begin": "(resource|actor)\\s+([a-zA-Z_][a-zA-Z0-9_]*(::[a-zA-Z0-9_]+)*)\\s*\\{",
       "beginCaptures": {
         "1": {
           "name": "keyword.control"

--- a/vscode/oso/syntaxes/polar.tmLanguage.json
+++ b/vscode/oso/syntaxes/polar.tmLanguage.json
@@ -80,7 +80,7 @@
     },
     "resource-block": {
       "name": "meta.resource-block",
-      "begin": "(resource|actor)\\s*([a-zA-Z][a-zA-Z0-9:]*)\\s*\\{",
+      "begin": "(resource|actor)\\s*([a-zA-Z][a-zA-Z0-9:-_]*)\\s*\\{",
       "beginCaptures": {
         "1": {
           "name": "keyword.control"


### PR DESCRIPTION
Fix incomplete regex expression for matching the resource name with "_" or "-" characters. Previously, any resource with these characters would not be highlighted.



PR checklist:

- [ ] Added changelog entry.
