### PR TITLE
{JS,Python,Ruby} Format ExternalInstance values with user-provided class names if present 

### DIFF
--- a/languages/js/src/Host.ts
+++ b/languages/js/src/Host.ts
@@ -512,15 +512,19 @@ export class Host implements Required<DataFilteringQueryParams> {
         // pass a string class repr *for registered types only*, otherwise pass
         // undefined (allow core to differentiate registered or not)
         const v_cast = v as NullishOrHasConstructor;
-        let classRepr: string | undefined = v_cast?.constructor?.name;
+        let classRepr: string | undefined = undefined;
 
         if (isConstructor(v)) {
           instanceId = this.getType(v)?.id;
           classId = instanceId;
+          classRepr = this.getType(v)?.name;
         } else {
+          const v_constructor: Class | undefined = v_cast?.constructor;
+
           // pass classId for instances of *registered classes* only
-          if (classRepr !== undefined && this.types.has(classRepr)) {
-            classId = this.getType(classRepr)?.id;
+          if (v_constructor !== undefined && this.types.has(v_constructor)) {
+            classId = this.getType(v_constructor)?.id;
+            classRepr = this.getType(v_constructor)?.name;
           }
         }
 

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -318,13 +318,12 @@ class Host:
                     class_id = instance_id = self.types[v].id
 
             # pass the class_repr only for registered types otherwise None
-            class_repr = type(v).__name__
-            class_repr = class_repr if class_repr in self.types else None
+            class_repr = self.types[type(v)].name if type(v) in self.types else None
 
             # pass class_id for classes & instances of registered classes,
             # otherwise pass None
-            if type(v).__name__ in self.types:
-                class_id = self.types[type(v).__name__].id
+            if type(v) in self.types:
+                class_id = self.types[type(v)].id
 
             val = {
                 "ExternalInstance": {

--- a/languages/ruby/lib/oso/polar/host.rb
+++ b/languages/ruby/lib/oso/polar/host.rb
@@ -327,7 +327,7 @@ module Oso
                     instance_id = class_id = types[value].id
                   elsif types.key?(value.class)
                     class_id = types[value.class].id
-                    class_repr = value.class.to_s
+                    class_repr = types[value.class].name
                   end
 
                   {


### PR DESCRIPTION
Update the `class_repr` information passed with `ExternalInstance` values to contain the user-provided class name if one exists. Previously these were generated based on object inspection and differed from their user-provided aliases.

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
