### PR TITLE
fix: go mod vendoring on macos

### DIFF
--- a/languages/go/internal/ffi/native/macos/empty.go
+++ b/languages/go/internal/ffi/native/macos/empty.go
@@ -1,1 +1,6 @@
 package macos
+
+import (
+	_ "github.com/osohq/go-oso/internal/ffi/native/macos/amd64"
+	_ "github.com/osohq/go-oso/internal/ffi/native/macos/arm64"
+)


### PR DESCRIPTION
closes #1491