### PR TITLE
Pin asgiref test dependency for django-oso since latest version doesn't like Python 3.6

### DIFF
--- a/languages/python/django-oso/requirements-test.txt
+++ b/languages/python/django-oso/requirements-test.txt
@@ -2,4 +2,4 @@ django==3.1.5
 pytest==5.3.5
 pytest-django==3.9.0
 six # required for pytest-django it seems?
-contextvars; python_version<"3.7"
+asgiref==3.4.1; python_version<"3.7" # required until we test against Python 3.7 instead of 3.6

--- a/languages/python/django-oso/requirements-test.txt
+++ b/languages/python/django-oso/requirements-test.txt
@@ -2,3 +2,4 @@ django==3.1.5
 pytest==5.3.5
 pytest-django==3.9.0
 six # required for pytest-django it seems?
+contextvars; python_version<"3.7"


### PR DESCRIPTION
[asgiref no longer supports Python 3.6](https://github.com/django/asgiref/blob/8b615134bd481c4262356ad3194fbeff9240d0d3/CHANGELOG.txt#L4-L5)

CI failures:
- https://github.com/osohq/oso/runs/4916528515?check_suite_focus=true
- https://github.com/osohq/oso/runs/4911565103?check_suite_focus=true
- https://github.com/osohq/oso/runs/4910918163?check_suite_focus=true