### PR TITLE
Remove long constant from ruby API documentation.

### DIFF
--- a/languages/ruby/lib/oso/polar/errors.rb
+++ b/languages/ruby/lib/oso/polar/errors.rb
@@ -96,6 +96,7 @@ module Oso
 
     class ValidationError < Error; end
 
+    # @!visibility private
     UNEXPECTED_EXPRESSION_MESSAGE = <<~MSG
       Received Expression from Polar VM. The Expression type is not yet supported in this language.
 


### PR DESCRIPTION


PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
