### PR TITLE
Build `aarch64-unknown-linux-musl` and add to Go package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -662,7 +662,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,66 @@ jobs:
           event-type: oso_release
           client-payload: '{"commit": "${{ github.sha }}"}'
 
-  linux_libs:
-    name: Build release libraries on Linux
-    runs-on: ubuntu-latest
+  build_libs:
+    name: Build release libraries
+    strategy:
+      matrix:
+        build:
+          - name: Linux (x86)
+            host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            shared:
+              src: libpolar.so
+              dest: libpolar.so
+            static:
+              src: libpolar.a
+              dest: libpolar-Linux.a
+
+          - name: Linux (x86 musl)
+            host: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            flags: -C target-feature=-crt-static
+            static:
+              src: libpolar.a
+              dest: libpolar-musl.a
+
+          - name: MacOS (ARM)
+            host: macos-latest
+            target: aarch64-apple-darwin
+            shared:
+              src: libpolar.dylib
+              dest: libpolar-arm.dylib
+            static:
+              src: libpolar.a
+              dest: libpolar-macOS-arm.a
+
+          - name: MacOS (x86)
+            host: macos-latest
+            target: x86_64-apple-darwin
+            shared:
+              src: libpolar.dylib
+              dest: libpolar.dylib
+            static:
+              src: libpolar.a
+              dest: libpolar-macOS.a
+
+          - name: Windows (GNU)
+            host: windows-latest
+            target: x86_64-pc-windows-gnu
+            static:
+              src: libpolar.a
+              dest: libpolar-Windows.a
+
+          - name: Windows (MSVC)
+            host: windows-latest
+            target: x86_64-pc-windows-msvc
+            shared:
+              src: polar.dll
+              dest: polar.dll
+            static:
+              src: polar.lib
+              dest: polar.lib
+    runs-on: ${{ matrix.build.host }}
     needs: [version]
     steps:
       - uses: actions/checkout@v2
@@ -55,133 +112,45 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+          target: ${{ matrix.build.target }}
       - name: Build release libraries
-        run: cargo build --release -p polar-c-api
-      - name: Build release musl library
-        run: |
-          rustup target add x86_64-unknown-linux-musl
-          RUSTFLAGS="-C target-feature=-crt-static" cargo build --target x86_64-unknown-linux-musl --release -p polar-c-api
-      - name: Rename static lib
-        run: mv target/release/libpolar.a target/release/libpolar-${{runner.os}}.a
-      - name: Rename static lib
-        run: mv target/x86_64-unknown-linux-musl/release/libpolar.a target/x86_64-unknown-linux-musl/release/libpolar-musl.a
-      - uses: actions/upload-artifact@v2
-        with:
-          name: oso_library
-          path: target/release/libpolar.so
+        run: cargo build --release --target ${{ matrix.build.target }} -p polar-c-api
+        env:
+          RUSTFLAGS: ${{ matrix.build.flags }}
+      - name: Rename shared lib
+        if: matrix.build.shared.src != matrix.build.shared.dest
+        working-directory: target/${{ matrix.build.target }}/release
+        run: mv ${{ matrix.build.shared.src }} ${{ matrix.build.shared.dest }}
+        shell: bash
       - uses: actions/upload-artifact@v2
         with:
           name: oso_library
           path: polar-c-api/polar.h
       - uses: actions/upload-artifact@v2
+        if: matrix.build.shared
         with:
-          name: oso_static_library
-          path: target/release/libpolar-${{runner.os}}.a
+          name: oso_library
+          path: target/${{ matrix.build.target }}/release/${{ matrix.build.shared.dest }}
+      - name: Rename static lib
+        if: matrix.build.static.src != matrix.build.static.dest
+        working-directory: target/${{ matrix.build.target }}/release
+        run: mv ${{ matrix.build.static.src }} ${{ matrix.build.static.dest }}
+        shell: bash
       - uses: actions/upload-artifact@v2
-        with:
-          name: oso_static_library
-          path: target/x86_64-unknown-linux-musl/release/libpolar-musl.a
-      - uses: actions/upload-artifact@v2
+        if: matrix.build.static
         with:
           name: oso_static_library
           path: polar-c-api/polar.h
-
-  macos_libs:
-    name: Build release libraries on MacOS
-    runs-on: macos-11
-    needs: [version]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Build release library
-        run: cargo build --release -p polar-c-api
-      - name: Build release arm library
-        run: |
-          rustup target add aarch64-apple-darwin
-          SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path) \
-            MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version) \
-            cargo build --target aarch64-apple-darwin --release -p polar-c-api
-      - name: Rename static lib
-        run: mv target/release/libpolar.a target/release/libpolar-${{runner.os}}.a
-      - name: Rename static lib
-        run: mv target/aarch64-apple-darwin/release/libpolar.a target/aarch64-apple-darwin/release/libpolar-macOS-arm.a
-      - name: Rename dynamic lib
-        run: mv target/aarch64-apple-darwin/release/libpolar.dylib target/aarch64-apple-darwin/release/libpolar-arm.dylib
       - uses: actions/upload-artifact@v2
-        with:
-          name: oso_library
-          path: target/release/libpolar.dylib
-      - uses: actions/upload-artifact@v2
-        with:
-          name: oso_library
-          path: target/aarch64-apple-darwin/release/libpolar-arm.dylib
-      - uses: actions/upload-artifact@v2
+        if: matrix.build.static
         with:
           name: oso_static_library
-          path: target/release/libpolar-${{runner.os}}.a
-      - uses: actions/upload-artifact@v2
-        with:
-          name: oso_static_library
-          path: target/aarch64-apple-darwin/release/libpolar-macOS-arm.a
-      - uses: actions/upload-artifact@v2
-        with:
-          name: oso_static_library
-          path: polar-c-api/polar.h
-
-  windows_libs:
-    name: Build release libraries on Windows
-    runs-on: windows-latest
-    needs: [version]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Build release library
-        run: cargo build --release -p polar-c-api
-      - name: Build release MinGW library
-        run: |
-          rustup target add x86_64-pc-windows-gnu
-          cargo build --target x86_64-pc-windows-gnu --release -p polar-c-api
-      - name: Rename static lib
-        run: |
-          mv -Force target/x86_64-pc-windows-gnu/release/libpolar.a target/x86_64-pc-windows-gnu/release/libpolar-${{runner.os}}.a
-      - uses: actions/upload-artifact@v2
-        with:
-          name: oso_library
-          path: target/release/polar.dll
-      - uses: actions/upload-artifact@v2
-        with:
-          name: oso_static_library
-          path: target/release/polar.lib
-      - uses: actions/upload-artifact@v2
-        with:
-          name: oso_static_library
-          path: target/x86_64-pc-windows-gnu/release/libpolar-${{runner.os}}.a
-      - uses: actions/upload-artifact@v2
-        with:
-          name: oso_static_library
-          path: polar-c-api/polar.h
+          path: target/${{ matrix.build.target }}/release/${{ matrix.build.static.dest }}
 
   build_go:
     name: Build go.
     runs-on: ubuntu-latest
-    needs: [linux_libs, macos_libs, windows_libs]
+    needs: [build_libs]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -218,7 +187,7 @@ jobs:
   build_jar:
     name: Build jar.
     runs-on: ubuntu-latest
-    needs: [linux_libs, macos_libs, windows_libs]
+    needs: [build_libs]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -255,7 +224,7 @@ jobs:
   build_gem:
     name: Build Gem.
     runs-on: ubuntu-latest
-    needs: [linux_libs, macos_libs, windows_libs]
+    needs: [build_libs]
     steps:
       - uses: actions/checkout@v2
       - name: Install Ruby + gems
@@ -294,7 +263,7 @@ jobs:
   build_linux_wheels:
     name: Build wheels on Linux
     runs-on: ubuntu-latest
-    needs: [version, linux_libs]
+    needs: [version, build_libs]
     env:
       # Skip Python 2.7 and Python 3.5
       CIBW_SKIP: "cp27-* cp35-* pp27-*"
@@ -339,7 +308,7 @@ jobs:
     # May have to drop once github actions switches to macos-11 by default
     # because 3.6 isn't supported on 11.
     runs-on: macos-10.15
-    needs: [version, macos_libs]
+    needs: [version, build_libs]
     env:
       # Skip Python 2.7 and Python 3.5
       CIBW_SKIP: "cp27-* cp35-* pp27-*"
@@ -381,7 +350,7 @@ jobs:
   build_macos_arm_wheels:
     name: Build macOS arm wheels
     runs-on: [self-hosted, m1]
-    needs: [version, macos_libs]
+    needs: [version, build_libs]
     env:
       OSO_ENV: CI
     steps:
@@ -413,7 +382,7 @@ jobs:
   build_windows_wheels:
     name: Build wheels on Windows
     runs-on: windows-latest
-    needs: [version, windows_libs]
+    needs: [version, build_libs]
     env:
       # Skip Python 2.7 and Python 3.5
       CIBW_SKIP: "cp27-* cp35-* pp27-*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
           - name: Linux (ARM musl)
             host: ubuntu-latest
             target: aarch64-unknown-linux-musl
+            flags: -C target-feature=-crt-static -C linker=/tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
             static:
               src: libpolar.a
               dest: libpolar-Linux-arm.a
@@ -120,6 +121,12 @@ jobs:
           toolchain: stable
           override: true
           target: ${{ matrix.build.target }}
+      # Awkwardly, rustup alone can't get us a cross-compiled Linux build
+      - name: Install C cross-compilation toolchain
+        if: matrix.build.target == 'aarch64-unknown-linux-musl'
+        run: |
+          curl -Lo /tmp/aarch64-linux-musl-cross.tgz https://musl.cc/aarch64-linux-musl-cross.tgz
+          cd /tmp && tar xzf /tmp/aarch64-linux-musl-cross.tgz
       - name: Build release libraries
         run: cargo build --release --target ${{ matrix.build.target }} -p polar-c-api
         env:
@@ -177,6 +184,8 @@ jobs:
           cp -r oso_static_library/polar.h languages/go/internal/ffi/native/polar.h
           mkdir -p languages/go/internal/ffi/native/linux/amd64
           cp -r oso_static_library/libpolar-musl.a languages/go/internal/ffi/native/linux/amd64/libpolar.a
+          mkdir -p languages/go/internal/ffi/native/linux/arm64
+          cp -r oso_static_library/libpolar-Linux-arm.a languages/go/internal/ffi/native/linux/arm64/libpolar.a
           mkdir -p languages/go/internal/ffi/native/macos/amd64
           cp -r oso_static_library/libpolar-macOS.a languages/go/internal/ffi/native/macos/amd64/libpolar.a
           mkdir -p languages/go/internal/ffi/native/macos/arm64
@@ -507,6 +516,35 @@ jobs:
         if: runner.os == 'Linux'
         run: docker run --rm --env POLAR_IGNORE_NO_ALLOW_WARNING=1 -v `pwd`:/oso golang:${{ matrix.go-version }}-buster /bin/sh -c 'cd /oso && go test -v ./internal/host && cd tests && go test -v'
         working-directory: go
+
+  validate_go_linux_arm:
+    name: Test go ${{ matrix.go-version }} on m1
+    needs: [build_go]
+    runs-on: [self-hosted, Linux, ARM64]
+    strategy:
+      matrix:
+        # go 1.16 is the earliest version supported on m1 (which is the easiest way to run ARM)
+        go-version: ["1.16", "1.17"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set version env
+        id: version
+        run: echo "::set-output name=oso_version::$(cat VERSION)"
+      - name: Download go package from package run
+        uses: actions/download-artifact@v1
+        with:
+          name: go
+      - name: "test"
+        run: |
+          ~/go/bin/go${{ matrix.go-version }} build
+          ~/go/bin/go${{ matrix.go-version }} test -v ./internal/host
+          cd tests && ~/go/bin/go${{ matrix.go-version }} test -v
+        working-directory: go
+        env:
+          POLAR_IGNORE_NO_ALLOW_WARNING: 1
+          CGO_ENABLED: 1
+          GOOS: linux
+          GOARCH: arm64
 
   validate_go_macos_arm:
     name: Test go ${{ matrix.go-version }} on m1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,15 +173,15 @@ jobs:
         run: cp -r test/policies languages/go/tests/policies
       - name: Copy libraries into go package.
         run: |
-          mkdir -p languages/go/native
+          mkdir -p languages/go/internal/ffi/native
           cp -r oso_static_library/polar.h languages/go/internal/ffi/native/polar.h
-          mkdir -p languages/go/native/linux
+          mkdir -p languages/go/internal/ffi/native/linux
           cp -r oso_static_library/libpolar-musl.a languages/go/internal/ffi/native/linux/libpolar.a
-          mkdir -p languages/go/native/macos/amd64
+          mkdir -p languages/go/internal/ffi/native/macos/amd64
           cp -r oso_static_library/libpolar-macOS.a languages/go/internal/ffi/native/macos/amd64/libpolar.a
-          mkdir -p languages/go/native/macos/arm64
+          mkdir -p languages/go/internal/ffi/native/macos/arm64
           cp -r oso_static_library/libpolar-macOS-arm.a languages/go/internal/ffi/native/macos/arm64/libpolar.a
-          mkdir -p languages/go/native/windows
+          mkdir -p languages/go/internal/ffi/native/windows
           cp -r oso_static_library/libpolar-Windows.a languages/go/internal/ffi/native/windows/libpolar.a
           rm languages/go/Makefile
       - name: Copy license.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,8 +175,8 @@ jobs:
         run: |
           mkdir -p languages/go/internal/ffi/native
           cp -r oso_static_library/polar.h languages/go/internal/ffi/native/polar.h
-          mkdir -p languages/go/internal/ffi/native/linux
-          cp -r oso_static_library/libpolar-musl.a languages/go/internal/ffi/native/linux/libpolar.a
+          mkdir -p languages/go/internal/ffi/native/linux/amd64
+          cp -r oso_static_library/libpolar-musl.a languages/go/internal/ffi/native/linux/amd64/libpolar.a
           mkdir -p languages/go/internal/ffi/native/macos/amd64
           cp -r oso_static_library/libpolar-macOS.a languages/go/internal/ffi/native/macos/amd64/libpolar.a
           mkdir -p languages/go/internal/ffi/native/macos/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,13 @@ jobs:
     strategy:
       matrix:
         build:
+          - name: Linux (ARM musl)
+            host: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            static:
+              src: libpolar.a
+              dest: libpolar-Linux-arm.a
+
           - name: Linux (x86)
             host: ubuntu-latest
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.build.target }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/languages/go/Makefile
+++ b/languages/go/Makefile
@@ -10,7 +10,9 @@ UNAME_M := $(shell uname -m)
 copy_lib:
 	cp ../../polar-c-api/polar.h internal/ffi/native/
 ifeq ($(UNAME_S),Linux)
-	cp ../../target/debug/libpolar.a internal/ffi/native/linux/
+ifeq ($(UNAME_M),x86_64)
+	cp ../../target/debug/libpolar.a internal/ffi/native/linux/amd64/
+endif
 endif
 ifeq ($(UNAME_S),Darwin)
 ifeq ($(UNAME_M),x86_64)

--- a/languages/go/Makefile
+++ b/languages/go/Makefile
@@ -12,6 +12,8 @@ copy_lib:
 ifeq ($(UNAME_S),Linux)
 ifeq ($(UNAME_M),x86_64)
 	cp ../../target/debug/libpolar.a internal/ffi/native/linux/amd64/
+else
+	cp ../../target/debug/libpolar.a internal/ffi/native/linux/arm64/
 endif
 endif
 ifeq ($(UNAME_S),Darwin)

--- a/languages/go/internal/ffi/ffi.go
+++ b/languages/go/internal/ffi/ffi.go
@@ -4,7 +4,7 @@ package ffi
 // #include <stdint.h>
 // #include <stdlib.h>
 // #include "native/polar.h"
-// #cgo linux,amd64 LDFLAGS: ${SRCDIR}/native/linux/libpolar.a -ldl -lm
+// #cgo linux,amd64 LDFLAGS: ${SRCDIR}/native/linux/amd64/libpolar.a -ldl -lm
 // #cgo darwin,amd64 LDFLAGS: ${SRCDIR}/native/macos/amd64/libpolar.a -ldl -lm
 // #cgo darwin,arm64 LDFLAGS: ${SRCDIR}/native/macos/arm64/libpolar.a -ldl -lm
 // #cgo windows,amd64 LDFLAGS: ${SRCDIR}/native/windows/libpolar.a -lm -lws2_32 -luserenv -lbcrypt

--- a/languages/go/internal/ffi/ffi.go
+++ b/languages/go/internal/ffi/ffi.go
@@ -5,6 +5,7 @@ package ffi
 // #include <stdlib.h>
 // #include "native/polar.h"
 // #cgo linux,amd64 LDFLAGS: ${SRCDIR}/native/linux/amd64/libpolar.a -ldl -lm
+// #cgo linux,arm64 LDFLAGS: ${SRCDIR}/native/linux/arm64/libpolar.a -ldl -lm
 // #cgo darwin,amd64 LDFLAGS: ${SRCDIR}/native/macos/amd64/libpolar.a -ldl -lm
 // #cgo darwin,arm64 LDFLAGS: ${SRCDIR}/native/macos/arm64/libpolar.a -ldl -lm
 // #cgo windows,amd64 LDFLAGS: ${SRCDIR}/native/windows/libpolar.a -lm -lws2_32 -luserenv -lbcrypt

--- a/languages/go/internal/ffi/native/linux/amd64/empty.go
+++ b/languages/go/internal/ffi/native/linux/amd64/empty.go
@@ -1,0 +1,1 @@
+package amd64

--- a/languages/go/internal/ffi/native/linux/arm64/empty.go
+++ b/languages/go/internal/ffi/native/linux/arm64/empty.go
@@ -1,0 +1,1 @@
+package arm64

--- a/languages/go/internal/ffi/native/linux/empty.go
+++ b/languages/go/internal/ffi/native/linux/empty.go
@@ -1,1 +1,5 @@
 package linux
+
+import (
+	_ "github.com/osohq/go-oso/internal/ffi/native/linux/amd64"
+)

--- a/languages/go/internal/ffi/native/linux/empty.go
+++ b/languages/go/internal/ffi/native/linux/empty.go
@@ -2,4 +2,5 @@ package linux
 
 import (
 	_ "github.com/osohq/go-oso/internal/ffi/native/linux/amd64"
+	_ "github.com/osohq/go-oso/internal/ffi/native/linux/arm64"
 )


### PR DESCRIPTION
Hi,

This builds on #1535 to add a build job for `aarch64-unknown-linux-musl`, which is added to the library artifacts as `libpolar-Linux-arm.a`. I've only propagated this to the Go package as it's relevant to my use-case.

Unfortunately, it's not quite there yet – the built artifact works fine if I use it in an `alpine`-based container on an m1 mac, but when running it in an `ubuntu`-based container on an m1 mac I get spooky FFI errors that I'm unsure how to debug: https://github.com/connec/oso/runs/5478560216?check_suite_focus=true

I suspect I'm missing some particular incantation of `RUSTFLAGS` and/or `cgo`... The errors typically seem to relate to `malloc`, so I'm guessing it's perhaps something like it's using `glibc`'s in Go and `musl`'s in Rust, or something like that? I'm not sure why this one struggles when the x86 MUSL version seems to "just work" on `ubuntu-latest`. Perhaps someone with more FFI experience will spot something obvious.

⚠️ Depends on #1535.

---

**Commits:** (excluding the first 2 since they're part of #1535)

- 4db2c3ce **Make build cache depend on target rather than OS**

  This should lead to less churn in the cached artifacts.

- ebc26d9f **Add a static library build for ARM Linux (musl)**


- b7fa218a **Fix path creation in `build_go`**

  Since they already existed this went unnoticed.

- 5de3c5a4 **Prepare Go package for Linux ARM**

  This introduces the architecture indirection for AMD64, in the same
  style as aleady exists for MacOS.

- b1cc8082 **Add Linux ARM64 support to Go package**

  This requires a Linux ARM64 runner to validate the package, which can
  most easily be achieved by running a container on an m1 mac.
