### PR TITLE
refactor: prefer yield from over looping in lexer

### DIFF
--- a/languages/python/docs/lexer.py
+++ b/languages/python/docs/lexer.py
@@ -63,9 +63,7 @@ class GenericShellLexer(Lexer):
                     insertions = []
                 yield match.start(), token.Generic.Output, line
         if curcode:
-            yield from do_insertions(
-                insertions, lexer.get_tokens_unprocessed(curcode)
-            )
+            yield from do_insertions(insertions, lexer.get_tokens_unprocessed(curcode))
 
 
 class JShellLexer(GenericShellLexer):

--- a/languages/python/docs/lexer.py
+++ b/languages/python/docs/lexer.py
@@ -63,10 +63,9 @@ class GenericShellLexer(Lexer):
                     insertions = []
                 yield match.start(), token.Generic.Output, line
         if curcode:
-            for item in do_insertions(
+            yield from do_insertions(
                 insertions, lexer.get_tokens_unprocessed(curcode)
-            ):
-                yield item
+            )
 
 
 class JShellLexer(GenericShellLexer):


### PR DESCRIPTION
This commit simplifies the docs lexer by using `yield from`rather than a for loop. 

This makes the code slightly shorter and removes the mental overhead and extra variable used by the for loop. Eliminating the for loop also makes the yield from version about 15% faster on average.


PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
