### PR TITLE
Make polar-language-server out dir customizable

### DIFF
--- a/polar-language-server/Makefile
+++ b/polar-language-server/Makefile
@@ -1,10 +1,11 @@
 .PHONY: build test
 
 CARGO_FLAGS ?= --dev
+OUT_DIR ?= ../vscode/oso/out
 
 build:
-	wasm-pack --quiet build $(CARGO_FLAGS) --target nodejs --out-dir ../vscode/oso/out
-	rm -f ../vscode/oso/out/.gitignore ../vscode/oso/out/package.json
+	wasm-pack --quiet build $(CARGO_FLAGS) --target nodejs --out-dir $(OUT_DIR)
+	rm -f $(OUT_DIR)/.gitignore $(OUT_DIR)/package.json
 
 test:
 	wasm-pack test --node

--- a/polar-language-server/Makefile
+++ b/polar-language-server/Makefile
@@ -1,7 +1,6 @@
 .PHONY: build test
 
 CARGO_FLAGS ?= --dev
-OUT_DIR ?= ../vscode/oso/out
 
 build:
 	wasm-pack --quiet build $(CARGO_FLAGS) --target nodejs --out-dir $(OUT_DIR)

--- a/vscode/oso/Makefile
+++ b/vscode/oso/Makefile
@@ -21,7 +21,7 @@ package: wasm
 CARGO_FLAGS ?= --dev
 
 wasm: clean
-	$(MAKE) CARGO_FLAGS=$(CARGO_FLAGS) -C ../../polar-language-server build
+	$(MAKE) CARGO_FLAGS=$(CARGO_FLAGS) OUT_DIR=$$(pwd)/out -C ../../polar-language-server build
 
 node_modules: package.json
 	yarn install


### PR DESCRIPTION
Changes the `polar-language-server` Makefile to allow for specifying a custom directory to build into.