### PR TITLE
Add Rust lang support for the new 1.0 verion of the uuid crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid 0.6.5",
  "uuid 0.8.2",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -1459,6 +1460,12 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
+name = "uuid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 
 [[package]]
 name = "vec_map"

--- a/docs/content/rust/reference/polar/classes.md
+++ b/docs/content/rust/reference/polar/classes.md
@@ -207,12 +207,12 @@ dependency. In `Cargo.toml`, an Oso dependency that supports UUIDs looks as
 follows:
 
 ```toml
-oso = { version = "X.Y.Z", features = ["uuid-07"] }
+oso = { version = "X.Y.Z", features = ["uuid-10"] }
 ```
 
 **Note that the numbers in the feature flags do not refer to [the UUID
 version][wiki] but to the version of the `uuid` crate.** Most people will want
-the `uuid-07` feature flag, as it supports recent versions of the `uuid` crate.
+the `uuid-10` feature flag, as it supports recent versions of the `uuid` crate.
 
 [wiki]: https://en.wikipedia.org/wiki/Universally_unique_identifier#Versions
 
@@ -220,6 +220,7 @@ the `uuid-07` feature flag, as it supports recent versions of the `uuid` crate.
 |----------------------|--------------|
 | `0.6.5` - `0.6.x`    | `uuid-06`    |
 | `0.7.0` - `0.8.x`    | `uuid-07`    |
+| `1.0.0` - `2.0.0`    | `uuid-10`    |
 
 ### Rust → Polar Types Summary
 

--- a/languages/rust/oso/Cargo.toml
+++ b/languages/rust/oso/Cargo.toml
@@ -46,6 +46,7 @@ rustyline-derive = { version = "0.5.0", optional = true }
 
 uuid-06 = { package = "uuid", version = "0.6.5", optional = true }
 uuid-07 = { package = "uuid", version = ">=0.7.0, <0.9.0", optional = true }
+uuid-10 = { package = "uuid", version = ">=1.0.0, <2.0.0", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.44"

--- a/languages/rust/oso/src/extras.rs
+++ b/languages/rust/oso/src/extras.rs
@@ -15,3 +15,12 @@ impl crate::PolarClass for uuid_07::Uuid {
             .with_equality_check()
     }
 }
+
+#[cfg(feature = "uuid-10")]
+impl crate::PolarClass for uuid_10::Uuid {
+    fn get_polar_class_builder() -> crate::host::ClassBuilder<uuid_10::Uuid> {
+        crate::host::Class::builder()
+            .name("Uuid")
+            .with_equality_check()
+    }
+}

--- a/languages/rust/oso/tests/test_polar_rust.rs
+++ b/languages/rust/oso/tests/test_polar_rust.rs
@@ -776,3 +776,15 @@ fn test_uuid_07() -> Result<(), Box<dyn std::error::Error>> {
     test.oso.query_rule("f", (x, y))?.next().unwrap()?;
     Ok(())
 }
+
+#[cfg(feature = "uuid-10")]
+#[test]
+fn test_uuid_10() -> Result<(), Box<dyn std::error::Error>> {
+    use uuid_10::Uuid;
+    let mut test = OsoTest::new();
+    test.oso.register_class(Uuid::get_polar_class())?;
+    test.load_str("f(x: Uuid, y: Uuid) if x = y;");
+    let (x, y) = (Uuid::nil(), Uuid::nil());
+    test.oso.query_rule("f", (x, y))?.next().unwrap()?;
+    Ok(())
+}


### PR DESCRIPTION
Adds support for the new 1.0 version of the [`uuid`](https://crates.io/crates/uuid) crate under the feature flag `uuid-10`.

The feature constrains versions of the `uuid` crate to `>=1.0.0, < 2.0.0` assuming that the API will remain stable for the lifetime of the major version.