### PR TITLE
remove leading and trailing quotes in Variable str

### DIFF
--- a/languages/python/oso/polar/variable.py
+++ b/languages/python/oso/polar/variable.py
@@ -5,7 +5,7 @@ class Variable(str):
         return f"Variable({super().__repr__()})"
 
     def __str__(self):
-        return repr(self)
+        return f"Variable({super().__str__()})"
 
     def __eq__(self, other):
         return super().__eq__(other)


### PR DESCRIPTION
This attempts to fix the compatibility issue raised in #1561 by removing the leading and trailing single quotes around the wrapped string of the `Variable` class when getting the `str` of `Variable`.

From:
```python
str(Variable("something")) == "Variable('something')"
```

To:
```python
str(Variable("something")) == "Variable(something)"
```

Which conforms to the new checks in the Django ORM regarding no quotation marks on aliases, as long as the underlying string doesn't contain quotes. That said, I suspect this isn't the most correct way to address this issue. Our test suite passes w/ Django updated to 3.2.13 and this change in place pass our tests, but I'm uncertain if there are any subtleties that we might not be aware of in how these strings are used elsewhere. Would appreciate any insights.