### PR TITLE
Better handling for repeated SQLAlchemy model names.

### DIFF
--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -402,7 +402,7 @@ def test_parser_errors(polar):
         polar.load_str(rules)
     assert str(e.value).startswith(
         "'\\u{0}' is not a valid character. Found in this is not allowed\\u{0} at line 2, column 17"
-    )
+    ), e
 
     # InvalidToken -- not sure what causes this
 

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -401,7 +401,7 @@ def test_parser_errors(polar):
     with pytest.raises(exceptions.InvalidTokenCharacter) as e:
         polar.load_str(rules)
     assert str(e.value).startswith(
-        "\'\\0\' is not a valid character. Found in this is not allowed\\0 at line 2, column 17"
+        "'\\0' is not a valid character. Found in this is not allowed\\0 at line 2, column 17"
     ), e
 
     # InvalidToken -- not sure what causes this

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -401,7 +401,7 @@ def test_parser_errors(polar):
     with pytest.raises(exceptions.InvalidTokenCharacter) as e:
         polar.load_str(rules)
     assert str(e.value).startswith(
-        "'\\u{0}' is not a valid character. Found in this is not allowed\\u{0} at line 2, column 17"
+        "\'\\0\' is not a valid character. Found in this is not allowed\\0 at line 2, column 17"
     ), e
 
     # InvalidToken -- not sure what causes this

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/auth.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/auth.py
@@ -33,7 +33,7 @@ def register_models(oso: Oso, base_or_registry):
             # skip models that were manually registered
             continue
         try:
-            oso.register_class(model)
+            oso.register_class(model, name=default_polar_model_name(model))
         except DuplicateClassAliasError as e:
             raise OsoError(
                 (

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/auth.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/auth.py
@@ -39,7 +39,7 @@ def register_models(oso: Oso, base_or_registry):
                 (
                     "Attempted to register two classes with the same name when automatically registering SQLAlchemy models\n"
                     "To fix this, try manually registering the new class. E.g.\n"
-                    '  oso.register_class(MyModel, "models::MyModel")\n'
+                    '  oso.register_class(MyModel, name="models::MyModel")\n'
                     "  register_models(oso, Base)\n"
                 )
             ) from e

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/auth.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/auth.py
@@ -43,8 +43,6 @@ def register_models(oso: Oso, base_or_registry):
                     "  register_models(oso, Base)\n"
                 )
             ) from e
-        except Exception as e:
-            breakpoint()
 
 
 def authorize_model(oso: Oso, actor, action, session: Session, model):

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/compat.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/compat.py
@@ -17,7 +17,15 @@ def iterate_model_classes(base_or_registry):
     try:  # 1.3 declarative base.
         # TODO (dhatch): Not sure this is legit b/c it uses an internal interface?
         models = base_or_registry._decl_class_registry.items()
-        yield from {model for name, model in models if name != "_sa_module_registry"}
+        for name, model in models:
+            if name != "_sa_module_registry":
+                if isinstance(
+                    model, sqlalchemy.ext.declarative.clsregistry._MultipleClassMarker
+                ):
+                    for model_ref in model.contents:
+                        yield model_ref()
+                else:
+                    yield model
     except AttributeError:
         try:  # 1.4 declarative base.
             mappers = base_or_registry.registry.mappers

--- a/languages/python/sqlalchemy-oso/tests/duplicate_model.py
+++ b/languages/python/sqlalchemy-oso/tests/duplicate_model.py
@@ -1,0 +1,9 @@
+from .test_duplicate_models import Base
+from sqlalchemy import Column, Integer, Boolean
+
+
+class Post(Base):
+    __tablename__ = "posts_one"
+
+    id = Column(Integer, primary_key=True)
+    admin = Column(Boolean, nullable=False)

--- a/languages/python/sqlalchemy-oso/tests/models.py
+++ b/languages/python/sqlalchemy-oso/tests/models.py
@@ -4,7 +4,6 @@ from sqlalchemy.ext.declarative import declarative_base
 
 from sqlalchemy import Column, Integer, String, Enum, Boolean, ForeignKey
 
-
 ModelBase = declarative_base(name="ModelBase")
 
 

--- a/languages/python/sqlalchemy-oso/tests/test_duplicate_models.py
+++ b/languages/python/sqlalchemy-oso/tests/test_duplicate_models.py
@@ -1,0 +1,85 @@
+from polar.exceptions import OsoError
+import pytest
+from sqlalchemy import Column, Integer, String, create_engine
+
+
+from sqlalchemy_oso.session import (
+    authorized_sessionmaker,
+)
+
+from .models import Post
+from .conftest import print_query
+
+from oso import Oso
+from polar.exceptions import DuplicateClassAliasError
+
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy_oso.auth import register_models
+
+Base = declarative_base(name="Base")
+
+
+class Post(Base):
+    __tablename__ = "posts_two"
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String, nullable=False)
+
+
+def test_duplicate_models(oso):
+    from .duplicate_model import Post as DuplicatePost
+
+    try:  # SQLAlchemy 1.4
+        engine = create_engine("sqlite:///:memory:", enable_from_linting=False)
+    except TypeError:  # SQLAlchemy 1.3
+        engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with pytest.raises(OsoError):
+        oso = Oso()
+        register_models(oso, Base)
+
+    oso = Oso()
+    oso.register_class(DuplicatePost, name="duplicate::Post")
+    register_models(oso, Base)
+
+    for m in [Post, DuplicatePost]:
+        with pytest.raises(DuplicateClassAliasError):
+            oso.register_class(m)
+
+    oso.load_str(
+        """
+        allow(_, "read", post: duplicate::Post) if
+            post.admin;
+
+        allow(_, "read", post: Post) if
+            post.title = "Test";
+    """
+    )
+
+    Session = authorized_sessionmaker(
+        get_oso=lambda: oso,
+        get_user=lambda: "user",
+        get_checked_permissions=lambda: {Post: "read", DuplicatePost: "read"},
+        bind=engine,
+    )
+
+    session = Session()
+
+    session.add(Post(id=1, title="Test"))
+    session.add(Post(id=2, title="Not Test"))
+    session.add(DuplicatePost(id=3, admin=True))
+    session.add(DuplicatePost(id=4, admin=False))
+
+    session.commit()
+
+    posts = session.query(Post)
+    print_query(posts)
+
+    assert posts.count() == 1
+    assert posts[0].id == 1
+
+    posts = session.query(DuplicatePost)
+    print_query(posts)
+    assert posts.count() == 1
+    assert posts[0].id == 3

--- a/languages/python/sqlalchemy-oso/tests/test_duplicate_models.py
+++ b/languages/python/sqlalchemy-oso/tests/test_duplicate_models.py
@@ -7,7 +7,6 @@ from sqlalchemy_oso.session import (
     authorized_sessionmaker,
 )
 
-from .models import Post
 from .conftest import print_query
 
 from oso import Oso


### PR DESCRIPTION
Catch the errors, and allow users to override it by registering
classes.

