### PR TITLE
Bump permute to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,9 +727,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "permute"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add5cf6a6a9e572d398fc2e73500305c18b6eb66c46cc730ee3737025a4e9209"
+checksum = "4fddb8f2cf68c74002bde337a2472e18c870e3464b1f637cc9718f51687e88ca"
 
 [[package]]
 name = "petgraph"

--- a/polar-core/Cargo.toml
+++ b/polar-core/Cargo.toml
@@ -29,7 +29,7 @@ lalrpop = { version = "0.19.6", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.3.3", default-features = false }
-permute = "0.1.0"
+permute = "0.2.1"
 pipe = "0.4.0"
 pretty_assertions = "1.0.0"
 maplit = "1.0.2"


### PR DESCRIPTION
Just bump to the new version of the crate.