### PR TITLE
Clarify where there is no allowed action

### DIFF
--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
@@ -304,7 +304,7 @@ try:
             # If permissions map does not specify an action to authorize for entity
             # or if the specified action is `None`, deny access.
             if action is None:
-                logger.warning(f"No allowed action for entity {entity}")
+                logger.warning(f"No allowed action for entity {entity} in checked_permissions")
                 where = with_loader_criteria(entity, expr.false(), include_aliases=True)
                 execute_state.statement = execute_state.statement.options(where)
             else:

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
@@ -304,7 +304,9 @@ try:
             # If permissions map does not specify an action to authorize for entity
             # or if the specified action is `None`, deny access.
             if action is None:
-                logger.warning(f"No allowed action for entity {entity} in checked_permissions")
+                logger.warning(
+                    f"No allowed action for entity {entity} in checked_permissions"
+                )
                 where = with_loader_criteria(entity, expr.false(), include_aliases=True)
                 execute_state.statement = execute_state.statement.options(where)
             else:


### PR DESCRIPTION
Currently, when providing Oso to teams I work with, this error message causes a lot of confusion because they interpret it to mean that there is no allowed action for the entity in the policy. By clarifying where there is no allowed action (checked_permissions), this will alleviate this source of confusion and ensure that it's clear to the developer that they need to update checked_permissions in the application rather than in the policy.



PR checklist:

- [ ] Added changelog entry.
