### PR TITLE
Replace mutable default argument with `None`

### DIFF
--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import os
 from pathlib import Path
 import sys
-from typing import List, Union
+from typing import List, Union, Optional
 
 from .exceptions import (
     PolarRuntimeError,
@@ -49,8 +49,11 @@ class Polar:
         del self.host
         del self.ffi_polar
 
-    def load_files(self, filenames: List[Union[Path, str]] = []):
+    def load_files(self, filenames: Optional[List[Union[Path, str]]] = None):
         """Load Polar policy from ".polar" files."""
+        if filenames is None:
+            filenames = []
+
         if not filenames:
             return
 


### PR DESCRIPTION
A common gotcha in Python involves default argument values which are mutable. These are evaluated only once at function definition time, so only one list, set or dictionary instance will be created. This means that if this list is mutated in one call to a function, those changes will show up in subsequent calls of that function. This is usually unintended behaviour, though it can be useful in limited circumstances for writing caches.

This updates `load_files` to avoid the mutable default argument of `[]`. While the code is not currently mutating the list, this is a high-risk piece of code that will be a gotcha should the team choose to modify the code at a later date to mutate the argument.



PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
