### PR TITLE
refactor: prefer yield from over looping in `Polar.query`

### DIFF
--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -130,8 +130,7 @@ class Polar:
         else:
             raise InvalidQueryTypeError()
 
-        for res in Query(query, host=host, bindings=bindings).run():
-            yield res
+        yield from Query(query, host=host, bindings=bindings).run()
 
     def query_rule(self, name, *args, **kwargs):
         """Query for rule with name ``name`` and arguments ``args``.


### PR DESCRIPTION
X-Ref: https://github.com/osohq/oso/pull/1556

This makes the code slightly shorter and removes the mental overhead and extra variable used by the for loop. Eliminating the for loop also makes the yield from version about 15% faster on average.

https://docs.sourcery.ai/refactorings/yield-from/ talks about this



PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
