### PR TITLE
Simplifies conditional logic using De Morgan's laws

### DIFF
--- a/languages/python/oso/polar/query.py
+++ b/languages/python/oso/polar/query.py
@@ -133,7 +133,9 @@ class Query:
             self.ffi_query.application_error(str(e))
             self.ffi_query.call_result(call_id, None)
             return
-        if callable(attr) and data["args"] is not None:  # If it's a function, call it with the args.
+        if (
+            callable(attr) and data["args"] is not None
+        ):  # If it's a function, call it with the args.
             args = [self.host.to_python(arg) for arg in data["args"]]
             kwargs = data["kwargs"] or {}
             kwargs = {k: self.host.to_python(v) for k, v in kwargs.items()}

--- a/languages/python/oso/polar/query.py
+++ b/languages/python/oso/polar/query.py
@@ -133,9 +133,7 @@ class Query:
             self.ffi_query.application_error(str(e))
             self.ffi_query.call_result(call_id, None)
             return
-        if (
-            callable(attr) and not data["args"] is None
-        ):  # If it's a function, call it with the args.
+        if callable(attr) and data["args"] is not None:  # If it's a function, call it with the args.
             args = [self.host.to_python(arg) for arg in data["args"]]
             kwargs = data["kwargs"] or {}
             kwargs = {k: self.host.to_python(v) for k, v in kwargs.items()}


### PR DESCRIPTION
X-Ref: https://github.com/osohq/oso/pull/1557

When reading logical statements it is important for them to be as simple as possible. This proposal applies De Morgan's laws to simplify code by removing double negatives or pushing negations deeper into statements. In this case, we're ensuring that the comparison against `None` is pythonically called (`is not None`)



PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
