### PR TITLE
Don't assign to builtin variables

### DIFF
--- a/languages/python/oso/polar/query.py
+++ b/languages/python/oso/polar/query.py
@@ -95,9 +95,9 @@ class Query:
             "Eq",
             getattr(instance, rel.my_field),
         )
-        filter = DataFilter(other_cls, [], [[condition]], self.host.types)
+        data_filter = DataFilter(other_cls, [], [[condition]], self.host.types)
         adapter = self.host.adapter
-        query = adapter.build_query(filter)
+        query = adapter.build_query(data_filter)
         results = adapter.execute_query(query)
 
         if rel.kind == "one":


### PR DESCRIPTION
This line overwrites https://docs.python.org/3/library/functions.html#filter which can cause confusion if this is attempted to be used later. Where possible, it's best to avoid the use of builtins as the keys to ensure that there aren't conflicts down the line.



PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
