### PR TITLE
Fix Clippy for 0.1.62

### DIFF
--- a/polar-core/benches/benchmarks/queries.rs
+++ b/polar-core/benches/benchmarks/queries.rs
@@ -1,4 +1,5 @@
 use criterion::{criterion_group, BenchmarkId, Criterion};
+use std::fmt::Write;
 
 use polar_core::*;
 use polar_core::{kb::Bindings, polar::Polar, terms::*};
@@ -134,7 +135,7 @@ pub fn indexed_rules(c: &mut Criterion) {
         let mut runner = runner_from_query(&format!("f({})", n / 2));
         let mut policy = "f(0);".to_owned();
         for i in 1..=n {
-            policy += &format!("f({});", i);
+            write!(policy, "f({});", i).unwrap();
         }
         runner.load_str(&policy).unwrap();
         runner.expected_result(Bindings::new());
@@ -168,7 +169,7 @@ pub fn many_rules(c: &mut Criterion) {
         let mut runner = runner_from_query(&format!("f({})", TARGET));
         let mut policy = "f(0);".to_owned();
         for i in 1..=TARGET {
-            policy += &format!("f({}) if f({});", i, i - 1);
+            write!(policy, "f({}) if f({});", i, i - 1).unwrap();
         }
         runner.load_str(&policy).unwrap();
         runner.expected_result(Bindings::new());

--- a/polar-core/src/formatting.rs
+++ b/polar-core/src/formatting.rs
@@ -9,6 +9,8 @@
 //! In addition, there are special cases like traces and sources that have their own
 //! formatting requirements.
 
+use std::fmt::Write;
+
 use super::{lexer::loc_to_pos, rules::*, sources::*, terms::*, traces::*};
 
 impl Trace {
@@ -86,7 +88,7 @@ pub(crate) fn source_lines(source: &Source, offset: usize, context_lines: usize)
     if let Some(target) = lines.get_mut(target_line) {
         // Calculate length of line number prefix.
         let prefix_len = "123: ".len();
-        *target += &format!("\n{}^", " ".repeat(prefix_len + target_column));
+        write!(*target, "\n{}^", " ".repeat(prefix_len + target_column)).unwrap();
     }
 
     lines.join("\n")
@@ -372,6 +374,8 @@ mod display {
 }
 
 mod to_polar {
+    use std::fmt::Write;
+
     use crate::formatting::{format_args, format_params, to_polar_parens};
     use crate::resource_block::{BlockType, ResourceBlock, ShorthandRule};
     use crate::rules::*;
@@ -689,16 +693,16 @@ mod to_polar {
                 self.resource.to_polar()
             );
             if let Some(ref roles) = self.roles {
-                s += &format!("  roles = {};\n", roles.to_polar());
+                writeln!(s, "  roles = {};", roles.to_polar()).unwrap();
             }
             if let Some(ref permissions) = self.permissions {
-                s += &format!("  permissions = {};\n", permissions.to_polar());
+                writeln!(s, "  permissions = {};", permissions.to_polar()).unwrap();
             }
             if let Some(ref relations) = self.relations {
-                s += &format!("  relations = {};\n", relations.to_polar());
+                writeln!(s, "  relations = {};", relations.to_polar()).unwrap();
             }
             for rule in &self.shorthand_rules {
-                s += &format!("  {}\n", rule.to_polar());
+                writeln!(s, "  {}", rule.to_polar()).unwrap();
             }
             s += "}";
             s

--- a/polar-core/src/kb.rs
+++ b/polar-core/src/kb.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
 use std::sync::Arc;
 
 pub use super::bindings::Bindings;
@@ -128,10 +129,12 @@ impl KnowledgeBase {
                     let found_match = results.iter().any(|(result, rule_type)| match result {
                         RuleParamMatch::True => true,
                         RuleParamMatch::False(message) => {
-                            msg.push_str(&format!(
+                            write!(
+                                msg,
                                 "\n{}\n\tFailed to match because: {}\n",
                                 rule_type, message
-                            ));
+                            )
+                            .unwrap();
                             false
                         }
                     });
@@ -288,17 +291,18 @@ impl KnowledgeBase {
                         if !success {
                             let mut err = format!("Rule specializer {} on parameter {} must be a member of rule type specializer {}", rule_instance.tag,index, rule_type_instance.tag);
                             if rule_type_instance.tag.0 == ACTOR_UNION_NAME {
-                                err.push_str(&format!("
+                                write!(err, "
 
 \tPerhaps you meant to add an actor block to the top of your policy, like this:
 
-\t  actor {} {{}}", rule_instance.tag));
+\t  actor {} {{}}", rule_instance.tag).unwrap();
                             } else if rule_type_instance.tag.0 == RESOURCE_UNION_NAME {
-                                err.push_str(&format!("
+                                write!(err, "
 
 \tPerhaps you meant to add a resource block to your policy, like this:
 
-\t  resource {} {{ .. }}", rule_instance.tag));
+\t  resource {} {{ .. }}", rule_instance.tag).unwrap();
+
                             }
 
                             return Ok(RuleParamMatch::False(err));

--- a/polar-core/src/sources.rs
+++ b/polar-core/src/sources.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::{fmt, sync::Arc};
 
 use serde::{Deserialize, Serialize};
@@ -35,9 +36,9 @@ impl Context {
     pub(crate) fn source_position(&self) -> String {
         let mut f = String::new();
         let (row, column) = loc_to_pos(&self.source.src, self.left);
-        f += &format!(" at line {}, column {}", row + 1, column + 1);
+        write!(f, " at line {}, column {}", row + 1, column + 1).unwrap();
         if let Some(ref filename) = self.source.filename {
-            f += &format!(" of file {}", filename);
+            write!(f, " of file {}", filename).unwrap();
         }
         f
     }

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -799,14 +799,16 @@ impl PolarVirtualMachine {
                     // print BINDINGS: { .. } only for TRACE logs
                     if !terms.is_empty() && configured_log_level == LogLevel::Trace {
                         let relevant_bindings = self.relevant_bindings(terms);
-                        msg.push_str(&format!(
+                        write!(
+                            msg,
                             ", BINDINGS: {{{}}}",
                             relevant_bindings
                                 .iter()
                                 .map(|(var, val)| format!("{} => {}", var.0, val))
                                 .collect::<Vec<String>>()
                                 .join(", ")
-                        ));
+                        )
+                        .unwrap();
                     }
                     self.print(msg);
                     for line in &lines[1..] {
@@ -2617,7 +2619,7 @@ impl PolarVirtualMachine {
                             .parsed_context()
                             .map_or_else(|| "".into(), Context::source_position);
 
-                        rule_strs.push_str(&format!("\n  {}{}", rule.head_as_string(), context));
+                        write!(rule_strs, "\n  {}{}", rule.head_as_string(), context).unwrap();
                     }
                     rule_strs
                 },
@@ -2974,7 +2976,7 @@ impl Runnable for PolarVirtualMachine {
                 } else {
                     let mut out = "RESULT: {\n".to_string(); // open curly & newline
                     for (key, value) in &bindings {
-                        out.push_str(&format!("  {}: {}\n", key, value)); // key-value pairs spaced w/ newlines
+                        writeln!(out, "  {}: {}", key, value).unwrap(); // key-value pairs spaced w/ newlines
                     }
                     out.push('}'); // closing curly
                     out


### PR DESCRIPTION
This is a bit annoying, and I'm not a fan of adding a bunch of `unwrap`s all over the place.

There seem to be some people who agree that clippy's suggestion to use `write!` introduces a new error case that must be handled, and that's a bit unfair for a lint step: https://github.com/rust-lang/rust-clippy/issues/9077

That being said, it feels better than ignoring this particular lint everywhere.