### PR TITLE
refactor: Add Python type hints to authorization API

### DIFF
--- a/languages/python/oso/polar/exceptions.py
+++ b/languages/python/oso/polar/exceptions.py
@@ -1,6 +1,8 @@
 """Exceptions used within Oso."""
 # @TODO: Should we just generate these from the rust code?
+from pathlib import Path
 from textwrap import dedent
+from typing import Any, Mapping, Optional, Type, Union
 
 
 # @TODO(gkaemmer): Move this to an `exceptions` module so that it can be shared
@@ -8,14 +10,16 @@ from textwrap import dedent
 class OsoError(Exception):
     """Base exception class for Oso."""
 
-    def __init__(self, message=None, details=None):
+    def __init__(
+        self, message: Optional[str] = None, details: Optional[Mapping[str, Any]] = None
+    ) -> None:
         self.message = message
         self.details = details
         self.stack_trace = details.get("stack_trace") if details else None
         super().__init__(self.add_get_help(self.message))
 
     @classmethod
-    def add_get_help(cls, message) -> str:
+    def add_get_help(cls, message: object) -> str:
         return (
             str(message)
             + f"\n\tGet help with Oso from our engineers: https://help.osohq.com/error/{cls.__name__}"
@@ -66,7 +70,7 @@ class UnregisteredClassError(PolarRuntimeError):
 class DuplicateClassAliasError(PolarRuntimeError):
     """Raised on attempts to register a class with the same name as a class that has already been registered"""
 
-    def __init__(self, name, old, new):
+    def __init__(self, name: str, old: Type[object], new: Type[object]) -> None:
         super().__init__(
             f"Attempted to alias {new} as '{name}', but {old} already has that alias."
         )
@@ -77,14 +81,14 @@ class DuplicateInstanceRegistrationError(PolarRuntimeError):
 
 
 class PolarFileExtensionError(PolarRuntimeError):
-    def __init__(self, file):
+    def __init__(self, file: Union[Path, str]) -> None:
         super().__init__(
             f"Polar files must have .polar extension. Offending file: {file}"
         )
 
 
 class PolarFileNotFoundError(PolarRuntimeError):
-    def __init__(self, file):
+    def __init__(self, file: Union[Path, str]) -> None:
         super().__init__(f"Could not find file: {file}")
 
 
@@ -93,7 +97,7 @@ class UnregisteredInstanceError(PolarRuntimeError):
 
 
 class InlineQueryFailedError(PolarRuntimeError):
-    def __init__(self, source):
+    def __init__(self, source: str) -> None:
         super().__init__(f"Inline query failed: {source}")
 
 

--- a/languages/python/oso/polar/expression.py
+++ b/languages/python/oso/polar/expression.py
@@ -1,6 +1,3 @@
-from typing import Any
-
-
 class Expression:
     def __init__(self, operator, args):
         self.operator = operator
@@ -12,7 +9,7 @@ class Expression:
     def __str__(self) -> str:
         return f"Expression({self.operator}, {self.args})"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, type(self))
             and self.operator == other.operator
@@ -31,7 +28,7 @@ class Pattern:
     def __str__(self) -> str:
         return repr(self)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, type(self))
             and self.tag == other.tag

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -22,16 +22,16 @@ def read_c_str(c_str) -> str:
 
 
 class Polar:
-    enrich_message: Callable
+    enrich_message: Callable[[str], str]
     """
     A method that can be called to enrich a debug, log, or error message from
     the core.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.ptr = lib.polar_new()
 
-    def __del__(self):
+    def __del__(self) -> None:
         lib.polar_free(self.ptr)
 
     def new_id(self):
@@ -66,13 +66,13 @@ class Polar:
         # @TODO(Steve): Decode Filter Plan to not just json?
         return filter_plan
 
-    def load(self, sources: List[PolarSource]):
+    def load(self, sources: List[PolarSource]) -> None:
         """Load Polar policies."""
         result = lib.polar_load(self.ptr, ffi_serialize([s.__dict__ for s in sources]))
         self.process_messages()
         self.check_result(result)
 
-    def clear_rules(self):
+    def clear_rules(self) -> None:
         """Clear all rules from the Polar KB"""
         result = lib.polar_clear_rules(self.ptr)
         self.process_messages()
@@ -132,7 +132,7 @@ class Polar:
 
 
 class Query:
-    enrich_message: Callable
+    enrich_message: Callable[[str], str]
     """
     A method that can be called to enrich a debug, log, or error message from
     the core.

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -116,13 +116,13 @@ class Polar:
     def next_message(self):
         return lib.polar_next_polar_message(self.ptr)
 
-    def set_message_enricher(self, enrich_message):
+    def set_message_enricher(self, enrich_message: Callable[[str], str]) -> None:
         self.enrich_message = enrich_message
 
     def check_result(self, result):
         return check_result(result, self.enrich_message)
 
-    def process_messages(self):
+    def process_messages(self) -> None:
         assert self.enrich_message, (
             "No message enricher on this instance of FfiPolar. You must call "
             "set_message_enricher before using process_messages."
@@ -141,7 +141,7 @@ class Query:
     def __init__(self, ptr):
         self.ptr = ptr
 
-    def __del__(self):
+    def __del__(self) -> None:
         lib.query_free(self.ptr)
 
     def call_result(self, call_id, value):
@@ -172,7 +172,7 @@ class Query:
     def next_message(self):
         return lib.polar_next_query_message(self.ptr)
 
-    def source(self):
+    def source(self) -> str:
         source = lib.polar_query_source_info(self.ptr)
         source = read_c_str(self.check_result(source))
         return source
@@ -185,13 +185,13 @@ class Query:
         self.process_messages()
         self.check_result(result)
 
-    def set_message_enricher(self, enrich_message):
+    def set_message_enricher(self, enrich_message: Callable[[str], str]) -> None:
         self.enrich_message = enrich_message
 
     def check_result(self, result):
         return check_result(result, self.enrich_message)
 
-    def process_messages(self):
+    def process_messages(self) -> None:
         assert self.enrich_message, (
             "No message enricher on this instance of FfiQuery. You must call "
             "set_message_enricher before using process_messages."
@@ -225,7 +225,7 @@ def check_result(result, enrich_message=None):
         raise error
 
 
-def is_null(result):
+def is_null(result: object) -> bool:
     return result == ffi.NULL
 
 

--- a/languages/python/oso/polar/ffi.py
+++ b/languages/python/oso/polar/ffi.py
@@ -117,7 +117,7 @@ class Polar:
         return lib.polar_next_polar_message(self.ptr)
 
     def set_message_enricher(self, enrich_message: Callable[[str], str]) -> None:
-        self.enrich_message = enrich_message
+        self.enrich_message = enrich_message  # type: ignore[misc]
 
     def check_result(self, result):
         return check_result(result, self.enrich_message)

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from math import inf, isnan, nan
 import re
 import inspect
-from typing import Any, Dict, Mapping, Sequence, Type, Union, Optional
+from typing import Any, Dict, Sequence, Type, Union, Optional
 
 
 from .exceptions import (

--- a/languages/python/oso/polar/host.py
+++ b/languages/python/oso/polar/host.py
@@ -97,7 +97,7 @@ class Host:
                 name if isinstance(name, str) else name.__name__
             )
 
-    def distinct_user_types(self) -> map[UserType]:
+    def distinct_user_types(self) -> "map[UserType]":
         return map(
             lambda k: self.types[k],
             filter(lambda k: isinstance(k, str), self.types.keys()),

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -8,7 +8,6 @@ from typing import (
     Any,
     Iterable,
     List,
-    Sequence,
     Union,
     Optional,
     Dict,

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -4,7 +4,18 @@ from datetime import datetime, timedelta
 import os
 from pathlib import Path
 import sys
-from typing import Any, List, Union, Optional, Dict, Type, Generator, Mapping
+from typing import (
+    Any,
+    Iterable,
+    List,
+    Sequence,
+    Union,
+    Optional,
+    Dict,
+    Type,
+    Generator,
+    Mapping,
+)
 
 from .exceptions import (
     PolarRuntimeError,
@@ -49,7 +60,9 @@ class Polar:
         del self.host
         del self.ffi_polar
 
-    def load_files(self, filenames: Optional[List[Union[Path, str]]] = None) -> None:
+    def load_files(
+        self, filenames: Optional[Iterable[Union[Path, str]]] = None
+    ) -> None:
         """Load Polar policy from ".polar" files."""
         if filenames is None:
             filenames = []
@@ -167,7 +180,7 @@ class Polar:
         except StopIteration:
             return False
 
-    def repl(self, files: Optional[List[Union[Path, str]]] = None) -> None:
+    def repl(self, files: Optional[Iterable[Union[Path, str]]] = None) -> None:
         """Start an interactive REPL session."""
         if files is None:
             files = []

--- a/languages/python/oso/polar/polar.py
+++ b/languages/python/oso/polar/polar.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 import os
+from contextlib import suppress
 from pathlib import Path
 import sys
 from typing import (
@@ -179,16 +180,16 @@ class Polar:
         except StopIteration:
             return False
 
-    def repl(self, files: Optional[Iterable[Union[Path, str]]] = None) -> None:
+    def repl(
+        self, files: Optional[Union[Iterable[Path], Iterable[str]]] = None
+    ) -> None:
         """Start an interactive REPL session."""
         if files is None:
             files = []
-        try:
+        with suppress(ImportError):
             # importing readline on compatible platforms
             # changes how `input` works for the REPL
             import readline  # noqa: F401
-        except ImportError:
-            pass
 
         # https://github.com/django/django/blob/3e753d3de33469493b1f0947a2e0152c4000ed40/django/core/management/color.py
         def supports_color() -> bool:

--- a/languages/python/oso/polar/query.py
+++ b/languages/python/oso/polar/query.py
@@ -42,7 +42,7 @@ class Query:
         """Bind `name` to `value` for the duration of the query."""
         self.ffi_query.bind(name, self.host.to_polar(value))
 
-    def run(self) -> Generator[Dict[str, Any], None, None]:
+    def run(self):
         """Run the event loop and yield results."""
         assert self.ffi_query, "no query to run"
         while True:

--- a/languages/python/oso/polar/query.py
+++ b/languages/python/oso/polar/query.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from typing import List, Any, Generator, Dict
+from typing import List, Any
 import json
 
 from .exceptions import (

--- a/languages/python/oso/polar/variable.py
+++ b/languages/python/oso/polar/variable.py
@@ -1,6 +1,3 @@
-from typing import Any
-
-
 class Variable(str):
     """An unbound variable type, can be used to query the KB for information"""
 
@@ -10,7 +7,7 @@ class Variable(str):
     def __str__(self) -> str:
         return repr(self)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return super().__eq__(other)
 
     def __hash__(self) -> int:

--- a/languages/python/oso/setup.py
+++ b/languages/python/oso/setup.py
@@ -17,7 +17,7 @@ with open("requirements.txt") as fp:
     install_requires += fp.read()
 
 
-def read(rel_path):
+def read(rel_path: str) -> str:
     here = os.path.abspath(os.path.dirname(__file__))
     # intentionally *not* adding an encoding option to open, See:
     #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
@@ -25,7 +25,7 @@ def read(rel_path):
         return fp.read()
 
 
-def get_version(rel_path):
+def get_version(rel_path: str) -> str:
     """Get version from file. Copied from pip: https://github.com/pypa/pip/blob/master/setup.py#L19"""
     for line in read(rel_path).splitlines():
         if line.startswith("__version__"):


### PR DESCRIPTION
This merge request expands existing type hints. The primary focus of this merge request is on the public authorization API and the calls that this API reaches down to

The use of `object` instead of `Any` may be a bit odd at first, but this is meant to better conform to the recommendations of the Python team managing type information. `object` is for when the code can accept any object for use, but we want errors if it's misused. `Any` disables error checking in a way that's a bit hard to detect a first.

See this for a breakdown from some of their team:
https://github.com/python/typeshed/pull/8469#issuecomment-1203116838 


PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
