### PR TITLE
Only pull in tracing-subscriber for tests, examples, and CLI binary

### DIFF
--- a/languages/rust/oso/Cargo.toml
+++ b/languages/rust/oso/Cargo.toml
@@ -34,15 +34,15 @@ oso-derive = { path = "../oso-derive", version = "=0.26.2", optional = true }
 polar-core = { path = "../../../polar-core", version = "=0.26.2" }
 thiserror = "1.0.30"
 tracing = { version = "0.1.29", features = ["log"] }
-tracing-subscriber = { version = "0.3.1", default-features = false, features = [
-    "fmt",
-] }
 
 anyhow = { version = "1.0.44", optional = true }
 clap = { version = "2.33.3", optional = true }
 lazy_static = "1.4.0"
 rustyline = { version = "9.0.0", optional = true }
 rustyline-derive = { version = "0.5.0", optional = true }
+tracing-subscriber = { version = "0.3.1", optional = true, default-features = false, features = [
+    "fmt",
+] }
 
 uuid-06 = { package = "uuid", version = "0.6.5", optional = true }
 uuid-07 = { package = "uuid", version = ">=0.7.0, <0.9.0", optional = true }
@@ -54,8 +54,11 @@ criterion = "0.3.5"
 oso-derive = { path = "../oso-derive", version = "=0.26.2" }
 static_assertions = "1.1.0"
 tempfile = "3.2.0"
+tracing-subscriber = { version = "0.3.1", default-features = false, features = [
+    "fmt",
+] }
 
 [features]
-cli = ["rustyline", "rustyline-derive", "anyhow", "clap"]
+cli = ["rustyline", "rustyline-derive", "anyhow", "clap", "tracing-subscriber"]
 default = ["derive"]
 derive = ["oso-derive"]


### PR DESCRIPTION
Makes the `tracing-subscriber` dependency optional and mentions it in the `cli` feature-set.

This means the `oso` library no longer has a hard `tracing-subscriber` dependency, in accordance with best practices for leaving tracing-output selection flexible until the point of executable construction.