### PR TITLE
do not raise for multiple parents error when results are empty

### DIFF
--- a/languages/ruby/lib/oso/polar/data/adapter/active_record_adapter.rb
+++ b/languages/ruby/lib/oso/polar/data/adapter/active_record_adapter.rb
@@ -10,7 +10,7 @@ module Oso
             types = filter.types
             query = filter.relations.reduce(filter.model.all) do |q, rel|
               rec = types[rel.left].fields[rel.name]
-              join_type = if rec.kind == "one" then "LEFT" else "INNER" end
+              join_type = rec.kind == 'one' ? 'LEFT' : 'INNER'
               q.joins(
                 "#{join_type} JOIN #{rel.right.table_name} ON " \
                 "#{rel.left.table_name}.#{rec.my_field} = " \

--- a/languages/ruby/lib/oso/polar/data/adapter/active_record_adapter.rb
+++ b/languages/ruby/lib/oso/polar/data/adapter/active_record_adapter.rb
@@ -10,8 +10,9 @@ module Oso
             types = filter.types
             query = filter.relations.reduce(filter.model.all) do |q, rel|
               rec = types[rel.left].fields[rel.name]
+              join_type = if rec.kind == "one" then "LEFT" else "INNER" end
               q.joins(
-                "INNER JOIN #{rel.right.table_name} ON " \
+                "#{join_type} JOIN #{rel.right.table_name} ON " \
                 "#{rel.left.table_name}.#{rec.my_field} = " \
                 "#{rel.right.table_name}.#{rec.other_field}"
               )

--- a/languages/ruby/lib/oso/polar/query.rb
+++ b/languages/ruby/lib/oso/polar/query.rb
@@ -263,9 +263,9 @@ module Oso
         res = host.adapter.execute_query host.adapter.build_query(filter)
 
         if rel.kind == 'one'
-          raise "multiple parents: #{res}" unless res.length == 1
+          raise "multiple parents: #{res}" if res.length > 1
 
-          res = res[0]
+          res = res[0] if res.length == 1
         end
 
         call_result(host.to_polar(res), call_id: call_id)

--- a/languages/ruby/spec/oso/polar/data_filtering/gitclub.polar
+++ b/languages/ruby/spec/oso/polar/data_filtering/gitclub.polar
@@ -31,9 +31,10 @@ resource Repo {
 
 resource Issue {
   permissions = ["read", "edit"];
-  relations = { parent: Repo };
+  relations = { parent: Repo, reviewer: User };
   "read" if "reader" on "parent";
   "edit" if "writer" on "parent";
+  "edit" if "reviewer";
 }
 
 has_role(_: User{org_roles}, name: String, org: Org) if
@@ -44,5 +45,7 @@ has_role(_: User{repo_roles}, name: String, repo: Repo) if
 
 has_relation(org: Org, "parent", _: Repo{org});
 has_relation(repo: Repo, "parent", _: Issue{repo});
+has_relation(reviewer: User, "reviewer", _: Issue{reviewer});
+
 
 allow(actor, action, resource) if has_permission(actor, action, resource);

--- a/languages/ruby/spec/oso/polar/data_filtering/gitclub_spec.rb
+++ b/languages/ruby/spec/oso/polar/data_filtering/gitclub_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
           other_type: 'User',
           my_field: 'reviewer_name',
           other_field: 'name'
-        ),
+        )
       }
     )
 

--- a/languages/ruby/spec/oso/polar/data_filtering/gitclub_spec.rb
+++ b/languages/ruby/spec/oso/polar/data_filtering/gitclub_spec.rb
@@ -78,6 +78,11 @@ RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
         check_authz gabe, 'edit', Issue, [bug]
       end
     end
+    context 'issue reviewer' do
+      it 'can access the right resources' do
+        check_authz sam, 'edit', Issue, [laggy]
+      end
+    end
   end
 
   let(:policy_file) { File.join(__dir__, 'gitclub.polar') }
@@ -90,6 +95,7 @@ RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
 
   let(:steve) { User.find 'steve' }
   let(:leina) { User.find 'leina' }
+  let(:sam) { User.find 'sam' }
   let(:gabe) { User.find 'gabe' }
   let(:graham) { User.find 'graham' }
 
@@ -122,7 +128,8 @@ RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
       db.execute <<-SQL
         create table issues (
           name varchar(16) not null primary key,
-          repo_name varchar(16) not null
+          repo_name varchar(16) not null,
+          reviewer_name varchar(16)
         );
       SQL
 
@@ -159,6 +166,7 @@ RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
     ios = Repo.create name: 'ios', org: apple
 
     steve = User.create name: 'steve', org: osohq
+    sam = User.create name: 'sam', org: osohq
     leina = User.create name: 'leina', org: osohq
     gabe = User.create name: 'gabe', org: osohq
     graham = User.create name: 'graham', org: apple
@@ -171,7 +179,7 @@ RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
     RepoRole.create name: 'reader', user: graham, repo: demo
 
     Issue.create name: 'bug', repo: oso
-    Issue.create name: 'laggy', repo: ios
+    Issue.create name: 'laggy', repo: ios, reviewer: sam
 
     subject.register_class(
       User,
@@ -236,7 +244,13 @@ RSpec.describe Oso::Oso do # rubocop:disable Metrics/BlockLength
           other_type: 'Repo',
           my_field: 'repo_name',
           other_field: 'name'
-        )
+        ),
+        reviewer: Relation.new(
+          kind: 'one',
+          other_type: 'User',
+          my_field: 'reviewer_name',
+          other_field: 'name'
+        ),
       }
     )
 
@@ -271,6 +285,7 @@ end
 class Issue < ActiveRecord::Base
   self.primary_key = :name
   belongs_to :repo, foreign_key: :repo_name
+  belongs_to :reviewer, class_name: 'User', foreign_key: 'reviewer_name', optional: true
 end
 
 class RepoRole < ActiveRecord::Base


### PR DESCRIPTION
### Why

_the relationship handler should not raise a multiple-parent error when results are empty_