### PR TITLE
Reduce chance of memory leak in Java library

### DIFF
--- a/languages/java/oso/src/main/java/com/osohq/oso/Ffi.java
+++ b/languages/java/oso/src/main/java/com/osohq/oso/Ffi.java
@@ -217,16 +217,16 @@ public class Ffi {
   }
 
   protected class QueryEvent {
-    private Pointer ptr;
+    private final String event;
 
     private QueryEvent(Pointer ptr) {
-      this.ptr = ptr;
+      String event = ptr.getString(0);
+      polarLib.string_free(ptr);
+      this.event = event;
     }
 
     public String get() {
-      String event = ptr.getString(0);
-      polarLib.string_free(ptr);
-      return event;
+      return this.event;
     }
   }
 


### PR DESCRIPTION
If an error prevents .get() from being called or future code changes result in .get() being called more than once it may potentially cause memory leaks or accessing invalid memory. This PR changes the behaviour so that events are read and the memory freed immediately and the JVM is then responsible for disposing the java String.