### PR TITLE
avoid conflicts with other macros

### DIFF
--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -61,9 +61,12 @@ fn get_nested_attr(nested: NestedMeta, oso_attrs: &mut Vec<OsoAttribute>) {
 
 fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     println!("attr: {:?}", attr);
-    println!("attr: {:?}", attr.path);
-    println!("attr: {:?}", attr.path.segments);
-    println!("attr: {:?}", attr.path.get_ident());
+    println!("attr.path: {:?}", attr.path);
+    println!("attr.path.segments: {:?}", attr.path.segments);
+    println!("attr.path.get_ident(): {:?}", attr.path.get_ident());
+    if let Some(ident) = attr.path.get_ident() {
+        println!("ident.ident: {:?}", ident.ident);
+    }
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {
         match get_single_segment(&list.path) {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -67,7 +67,11 @@ fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
         "Attribute::parse_inner(attr): {:?}",
         Attribute::parse_inner(attr)
     );
-    println!("attr.parse_outer(): {:?}", attr.parse_outer());
+    
+    println!(
+        "Attribute::parse_outer(attr): {:?}",
+        Attribute::parse_outer(attr)
+    );
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {
         match get_single_segment(&list.path) {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -63,6 +63,7 @@ fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     println!("attr: {:?}", attr);
     println!("attr: {:?}", attr.path);
     println!("attr: {:?}", attr.path.segments);
+    println!("attr: {:?}", attr.path.get_ident());
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {
         match get_single_segment(&list.path) {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -62,6 +62,7 @@ fn get_nested_attr(nested: NestedMeta, oso_attrs: &mut Vec<OsoAttribute>) {
 fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     println!("attr: {:?}", attr);
     println!("attr: {:?}", attr.path);
+    println!("attr: {:?}", attr.path.segments);
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {
         match get_single_segment(&list.path) {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -60,7 +60,7 @@ fn get_nested_attr(nested: NestedMeta, oso_attrs: &mut Vec<OsoAttribute>) {
 }
 
 fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
-    println!(attr.parse_meta());
+    println!("{:?}", attr.parse_meta());
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {
         match get_single_segment(&list.path) {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -65,7 +65,7 @@ fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     println!("attr.path.segments: {:?}", attr.path.segments);
     println!("attr.path.get_ident(): {:?}", attr.path.get_ident());
     if let Some(ident) = attr.path.get_ident() {
-        println!("ident.ident: {:?}", ident.ident);
+        println!("ident: {:?}", ident);
     }
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -67,6 +67,9 @@ fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     if let Some(ident) = attr.path.get_ident() {
         println!("ident: {:?}", ident);
         println!("ident.to_string(): {:?}", ident.to_string());
+        if ident.to_string() == "diesel" {
+            return ();
+        }
     }
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -60,7 +60,8 @@ fn get_nested_attr(nested: NestedMeta, oso_attrs: &mut Vec<OsoAttribute>) {
 }
 
 fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
-    println!("{:?}", attr.parse_meta());
+    println!("attr: {:?}", attr);
+    println!("attr.parse_meta(): {:?}", attr.parse_meta());
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {
         match get_single_segment(&list.path) {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -62,6 +62,9 @@ fn get_nested_attr(nested: NestedMeta, oso_attrs: &mut Vec<OsoAttribute>) {
 fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     println!("attr: {:?}", attr);
     println!("attr.parse_meta(): {:?}", attr.parse_meta());
+    println!("attr.parse_args(): {:?}", attr.parse_args());
+    println!("attr.parse_inner(): {:?}", attr.parse_inner());
+    println!("attr.parse_outer(): {:?}", attr.parse_outer());
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {
         match get_single_segment(&list.path) {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -66,6 +66,7 @@ fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     println!("attr.path.get_ident(): {:?}", attr.path.get_ident());
     if let Some(ident) = attr.path.get_ident() {
         println!("ident: {:?}", ident);
+        println!("ident.to_string(): {:?}", ident.to_string());
     }
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -61,8 +61,7 @@ fn get_nested_attr(nested: NestedMeta, oso_attrs: &mut Vec<OsoAttribute>) {
 
 fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     println!("attr: {:?}", attr);
-    println!("attr.parse_meta(): {:?}", attr.parse_meta());
-    println!("attr.parse_args(): {:?}", attr.parse_args());
+    println!("attr: {:?}", attr.path);
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {
         match get_single_segment(&list.path) {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -63,15 +63,6 @@ fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     println!("attr: {:?}", attr);
     println!("attr.parse_meta(): {:?}", attr.parse_meta());
     println!("attr.parse_args(): {:?}", attr.parse_args());
-    println!(
-        "Attribute::parse_inner(attr): {:?}",
-        Attribute::parse_inner(attr)
-    );
-    
-    println!(
-        "Attribute::parse_outer(attr): {:?}",
-        Attribute::parse_outer(attr)
-    );
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {
         match get_single_segment(&list.path) {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -60,6 +60,7 @@ fn get_nested_attr(nested: NestedMeta, oso_attrs: &mut Vec<OsoAttribute>) {
 }
 
 fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
+    println!(attr.parse_meta());
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {
         match get_single_segment(&list.path) {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -63,7 +63,10 @@ fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     println!("attr: {:?}", attr);
     println!("attr.parse_meta(): {:?}", attr.parse_meta());
     println!("attr.parse_args(): {:?}", attr.parse_args());
-    println!("attr.parse_inner(): {:?}", attr.parse_inner());
+    println!(
+        "Attribute::parse_inner(attr): {:?}",
+        Attribute::parse_inner(attr)
+    );
     println!("attr.parse_outer(): {:?}", attr.parse_outer());
     let meta = attr.parse_meta().unwrap();
     if let Meta::List(list) = meta {

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -60,13 +60,7 @@ fn get_nested_attr(nested: NestedMeta, oso_attrs: &mut Vec<OsoAttribute>) {
 }
 
 fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
-    println!("attr: {:?}", attr);
-    println!("attr.path: {:?}", attr.path);
-    println!("attr.path.segments: {:?}", attr.path.segments);
-    println!("attr.path.get_ident(): {:?}", attr.path.get_ident());
     if let Some(ident) = attr.path.get_ident() {
-        println!("ident: {:?}", ident);
-        println!("ident.to_string(): {:?}", ident.to_string());
         if ident.to_string() != "polar" {
             return ();
         }

--- a/languages/rust/oso-derive/src/lib.rs
+++ b/languages/rust/oso-derive/src/lib.rs
@@ -67,7 +67,7 @@ fn get_oso_attrs(attr: Attribute, oso_attrs: &mut Vec<OsoAttribute>) {
     if let Some(ident) = attr.path.get_ident() {
         println!("ident: {:?}", ident);
         println!("ident.to_string(): {:?}", ident.to_string());
-        if ident.to_string() == "diesel" {
+        if ident.to_string() != "polar" {
             return ();
         }
     }


### PR DESCRIPTION
The code changed in this PR is to avoid conflicts with other macros like in [oso-diesel2-conflict-demo](https://github.com/Siceberg/oso-diesel2-conflict-demo).

Since I'm a beginner in Rust, not very familiar with macros, and I'm in a place where using internet resources is not very convenient, I'm not sure if this is a better solution. If you guys have other better ideas please let me know, thanks.

If this is not a correct solution, I hope to promote [Oso](https://github.com/osohq/oso) to solve related problems as soon as possible through this PR