### PR TITLE
Fix macro namespacing and serialization bugs

### DIFF
--- a/docs/content/any/project/changelogs/NEXT.md
+++ b/docs/content/any/project/changelogs/NEXT.md
@@ -40,3 +40,8 @@ Link to [relevant documentation section]().
 - Thank you to [`FinnRG`](https://github.com/FinnRG) and
   [`onalante-msft`](https://github.com/onalante-msft) for updating dependencies
   across the core, the C API crate, and the Rust language library.
+- Use `$crate` references in `polar_core` macros to allow macro usage
+  without a `use polar_core::*;` glob import.
+- Fix `Value::String` serialization bug that allows string injection.
+- Fix `Operator::Dot` serialization bug that breaks member access with
+  keys that cannot be used unquoted (e.g. `obj.("a b")`).

--- a/polar-core/src/bindings.rs
+++ b/polar-core/src/bindings.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use crate::{
     error::{PolarResult, RuntimeError},
     folder::{fold_list, fold_term, Folder},
-    terms::{has_rest_var, Operation, Operator, Symbol, Term, Value},
+    terms::{has_rest_var, Operation, Symbol, Term, Value},
     vm::Goal,
 };
 

--- a/polar-core/src/formatting.rs
+++ b/polar-core/src/formatting.rs
@@ -636,7 +636,7 @@ mod to_polar {
         fn to_polar(&self) -> String {
             match self {
                 Value::Number(i) => format!("{}", i),
-                Value::String(s) => format!("\"{}\"", s),
+                Value::String(s) => format!("\"{}\"", s.replace('\\', r"\\").replace('"', r#"\""#)),
                 Value::Boolean(b) => {
                     if *b {
                         "true".to_string()

--- a/polar-core/src/inverter.rs
+++ b/polar-core/src/inverter.rs
@@ -10,7 +10,7 @@ use crate::events::QueryEvent;
 use crate::kb::Bindings;
 use crate::partial::simplify_bindings;
 use crate::runnable::Runnable;
-use crate::terms::{Operation, Operator, Term, Value};
+use crate::terms::{Term, Value};
 use crate::vm::{Goals, PolarVirtualMachine};
 
 /// The inverter implements the `not` operation in Polar.

--- a/polar-core/src/macros.rs
+++ b/polar-core/src/macros.rs
@@ -17,57 +17,57 @@ pub static NEXT_ID: AtomicU64 = AtomicU64::new(0);
 macro_rules! value {
     ([$($args:expr),*]) => {
         $crate::terms::Value::List(vec![
-            $(term!(value!($args))),*
+            $(term!($crate::value!($args))),*
         ])
     };
     ($arg:expr) => {
-        $crate::macros::TestHelper::<Value>::from($arg).0
+        $crate::macros::TestHelper::<$crate::terms::Value>::from($arg).0
     };
 }
 
 #[macro_export]
 macro_rules! values {
     ($([$($args:expr),*]),*) => {
-        vec![$(values!($($args),*)),*]
+        vec![$($crate::values!($($args),*)),*]
     };
     ($($args:expr),*) => {
-        vec![$(value!($args)),*]
+        vec![$($crate::value!($args)),*]
     };
 }
 
 #[macro_export]
 macro_rules! term {
     ($($expr:tt)*) => {
-        $crate::macros::TestHelper::<Term>::from(value!($($expr)*)).0
+        $crate::macros::TestHelper::<$crate::terms::Term>::from($crate::value!($($expr)*)).0
     };
 }
 
 #[macro_export]
 macro_rules! pattern {
     ($arg:expr) => {
-        $crate::macros::TestHelper::<Pattern>::from($arg).0
+        $crate::macros::TestHelper::<$crate::terms::Pattern>::from($arg).0
     };
 }
 
 #[macro_export]
 macro_rules! param {
     ($($tt:tt)*) => {
-        $crate::macros::TestHelper::<Parameter>::from($($tt)*).0
+        $crate::macros::TestHelper::<$crate::rules::Parameter>::from($($tt)*).0
     };
 }
 
 #[macro_export]
 macro_rules! instance {
     ($instance:expr) => {
-        InstanceLiteral {
-            tag: sym!($instance),
-            fields: Dictionary::new(),
+        $crate::terms::InstanceLiteral {
+            tag: $crate::sym!($instance),
+            fields: $crate::terms::Dictionary::new(),
         }
     };
     ($tag:expr, $fields:expr) => {
-        InstanceLiteral {
-            tag: sym!($tag),
-            fields: $crate::macros::TestHelper::<Dictionary>::from($fields).0,
+        $crate::terms::InstanceLiteral {
+            tag: $crate::sym!($tag),
+            fields: $crate::macros::TestHelper::<$crate::terms::Dictionary>::from($fields).0,
         }
     };
 }
@@ -75,15 +75,15 @@ macro_rules! instance {
 #[macro_export]
 macro_rules! sym {
     ($arg:expr) => {
-        $crate::macros::TestHelper::<Symbol>::from($arg).0
+        $crate::macros::TestHelper::<$crate::terms::Symbol>::from($arg).0
     };
 }
 
 #[macro_export]
 macro_rules! var {
     ($arg:expr) => {
-        $crate::macros::TestHelper::<Term>::from(
-            $crate::macros::TestHelper::<Value>::from(sym!($arg)).0,
+        $crate::macros::TestHelper::<$crate::terms::Term>::from(
+            $crate::macros::TestHelper::<$crate::terms::Value>::from($crate::sym!($arg)).0,
         )
         .0
     };
@@ -92,14 +92,14 @@ macro_rules! var {
 #[macro_export]
 macro_rules! string {
     ($arg:expr) => {
-        Value::String($arg.into())
+        $crate::terms::Value::String($arg.into())
     };
 }
 
 #[macro_export]
 macro_rules! str {
     ($arg:expr) => {
-        $crate::macros::TestHelper::<Term>::from(string!($arg)).0
+        $crate::macros::TestHelper::<$crate::terms::Term>::from($crate::string!($arg)).0
     };
 }
 
@@ -107,26 +107,26 @@ macro_rules! str {
 #[macro_export]
 macro_rules! call {
     ($name:expr) => {
-        Call {
-            name: sym!($name),
+        $crate::terms::Call {
+            name: $crate::sym!($name),
             args: vec![],
             kwargs: None
         }
     };
     ($name:expr, [$($args:expr),*]) => {
-        Call {
-            name: sym!($name),
+        $crate::terms::Call {
+            name: $crate::sym!($name),
             args: vec![
-                $(term!($args)),*
+                $($crate::term!($args)),*
             ],
             kwargs: None
         }
     };
     ($name:expr, [$($args:expr),*], $fields:expr) => {
-        Call {
-            name: sym!($name),
+        $crate::terms::Call {
+            name: $crate::sym!($name),
             args: vec![
-                $(term!($args)),*
+                $($crate::term!($args)),*
             ],
             kwargs: Some($fields)
         }
@@ -136,14 +136,14 @@ macro_rules! call {
 #[macro_export]
 macro_rules! op {
     ($op_type:ident, $($args:expr),+) => {
-        Operation {
-            operator: Operator::$op_type,
+        $crate::terms::Operation {
+            operator: $crate::terms::Operator::$op_type,
             args: vec![$($args),+]
         }
     };
     ($op_type:ident) => {
-        Operation {
-            operator: Operator::$op_type,
+        $crate::terms::Operation {
+            operator: $crate::terms::Operator::$op_type,
             args: vec![]
         }
     };
@@ -152,7 +152,7 @@ macro_rules! op {
 #[macro_export]
 macro_rules! dict {
     ($arg:expr) => {
-        $crate::macros::TestHelper::<Dictionary>::from($arg).0
+        $crate::macros::TestHelper::<$crate::terms::Dictionary>::from($arg).0
     };
 }
 
@@ -167,13 +167,13 @@ macro_rules! args {
     };
     // this is gross: maybe match a <comma plus trailing tokens>
     ($name:expr $(, $($tt:tt)*)?) => {{
-        let mut v = args!($($($tt)*)?);
-        v.push(param!(value!($name)));
+        let mut v = $crate::args!($($($tt)*)?);
+        v.push($crate::param!($crate::value!($name)));
         v
     }};
     ($name:expr ; $spec:expr $(, $($tt:tt)*)?) => {{
-        let mut v = args!($($($tt)*)?);
-        v.push(param!((sym!($name), term!($spec))));
+        let mut v = $crate::args!($($($tt)*)?);
+        v.push($crate::param!(($crate::sym!($name), $crate::term!($spec))));
         v
     }};
 }
@@ -181,23 +181,23 @@ macro_rules! args {
 #[macro_export]
 macro_rules! rule {
     ($name:expr, [$($args:tt)*] => $($body:expr),+) => {{
-        let mut params = args!($($args)*);
+        let mut params = $crate::args!($($args)*);
         params.reverse();
-        Rule {
-            name: sym!($name),
+        $crate::rules::Rule {
+            name: $crate::sym!($name),
             params,
-            body: term!(op!(And, $(term!($body)),+)),
+            body: $crate::term!($crate::op!(And, $($crate::term!($body)),+)),
             source_info: $crate::sources::SourceInfo::Test,
             required: false,
         }}
     };
     ($name:expr, [$($args:tt)*]) => {{
-        let mut params = args!($($args)*);
+        let mut params = $crate::args!($($args)*);
         params.reverse();
-        Rule {
-            name: sym!($name),
+        $crate::rules::Rule {
+            name: $crate::sym!($name),
             params,
-            body: term!(op!(And)),
+            body: $crate::term!($crate::op!(And)),
             source_info: $crate::sources::SourceInfo::Test,
             required: false,
         }
@@ -205,12 +205,12 @@ macro_rules! rule {
     // this macro variant is used exclusively to create rule *types*
     // TODO: @patrickod break into specific-purpose rule_type! macro and RuleType struct
     ($name:expr, [$($args:tt)*], $required:expr) => {{
-        let mut params = args!($($args)*);
+        let mut params = $crate::args!($($args)*);
         params.reverse();
-        Rule {
-            name: sym!($name),
+        $crate::rules::Rule {
+            name: $crate::sym!($name),
             params,
-            body: term!(op!(And)),
+            body: $crate::term!($crate::op!(And)),
             source_info: $crate::sources::SourceInfo::Test,
             required: $required,
         }


### PR DESCRIPTION
Though `polar_core` macros are exposed publicly, they are not usable without importing `polar_core::*` since they expect other `polar_core` macros to be in scope.  Using `$crate` references as appropriate fixes this.  Also, fix a `Value::String` string injection bug and `Operator::Dot` bug causing incorrect serialization when the second argument is a `Value::String` that requires quotes.

PR checklist:
- [x] Added changelog entry.
