### PR TITLE
docs: Add rust quickstart guide

### DIFF
--- a/docs/content/any/getting-started/quickstart/index.md
+++ b/docs/content/any/getting-started/quickstart/index.md
@@ -8,18 +8,6 @@ any: false
 weight: 1
 ---
 
-{{< ifLang "rust" >}}
-{{% callout "Rust quickstart coming soon" %}}
-
-{{< coming_soon >}}
-
-This guide uses Python.
-
-{{% /callout %}}
-<div class="pb-10"></div>
-{{< /ifLang >}}
-
-
 # Quickstart for {{% lang %}}
 
 This guide will walk you through your first change to an Oso policy file. There

--- a/docs/content/rust/getting-started/quickstart/data/data.md
+++ b/docs/content/rust/getting-started/quickstart/data/data.md
@@ -1,0 +1,22 @@
+---
+githubUrl: "https://github.com/osohq/oso-rust-quickstart"
+githubCloneUrl: "https://github.com/osohq/oso-rust-quickstart.git"
+repoName: oso-rust-quickstart
+mainPolarFile: "examples/quickstart/rust/src/main.polar"
+serverFile: "examples/quickstart/rust/src/server.rs"
+modelFile: "examples/quickstart/rust/src/models.rs"
+polarFileRelative: "src/main.polar"
+serverFileRelative: "src/server.rs"
+modelFileRelative: "src/models.rs"
+installDependencies: cargo check
+startServer: cargo run
+osoAuthorize: oso.is_allowed()
+isPublic: is_public
+hasRole: |-
+  has_role(actor: User, role_name: String, repository: Repository) if
+    role in actor.roles and
+    role_name = role.name and
+    repository = role.repository;
+endpoint: the `get_repo` route
+port: 5050
+---


### PR DESCRIPTION
Depends on https://github.com/osohq/oso-rust-quickstart/pull/8.
Closes https://github.com/osohq/oso/issues/1630.