### PR TITLE
Remove Java 10 from our CI rotation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
       - run: unzip oso-lib-${{ github.event.inputs.version }}.zip -d oso-lib-${{ github.event.inputs.version }}
       - uses: actions/setup-java@v1
         with:
-          java-version: "10"
+          java-version: "11"
       - name: Copy libraries into resources.
         run: |
           mkdir -p languages/java/oso/src/main/resources/linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -794,7 +794,7 @@ jobs:
       - name: Use Java 11
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: "11"
       - name: Use stable Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -702,7 +702,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        java-version: [11, 12, 13, 14] # @TODO: 8 and 9 not working.
+        java-version: [11, 12, 13, 14]
     steps:
       - uses: actions/checkout@v2
       - name: Set version env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
         run: echo "::set-output name=oso_version::$(cat VERSION)"
       - uses: actions/setup-java@v1
         with:
-          java-version: "10"
+          java-version: "11"
       - name: Download dylibs
         uses: actions/download-artifact@v1
         with:
@@ -702,7 +702,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        java-version: [10, 11, 12, 13, 14] # @TODO: 8 and 9 not working.
+        java-version: [11, 12, 13, 14] # @TODO: 8 and 9 not working.
     steps:
       - uses: actions/checkout@v2
       - name: Set version env
@@ -791,10 +791,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "12"
-      - name: Use Java 10
+      - name: Use Java 11
         uses: actions/setup-java@v1
         with:
-          java-version: 10
+          java-version: 11
       - name: Use stable Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v1
         with:
-          java-version: "10"
+          java-version: "11"
       - name: Test java
         run: make java-test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -358,7 +358,7 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v1
         with:
-          java-version: "10"
+          java-version: "11"
       - name: Build python lib
         run: make python-build
       - name: Python test deps

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## What is Oso?
 
-Oso is a batteries-included framework for building authorization in your application. 
+Oso is a batteries-included framework for building authorization in your application.
 
 With Oso, you can:
 - **Model**: Set up common permissions patterns like role-based access control (RBAC) and relationships using Oso’s built-in primitives. Extend them however you need with Oso’s declarative policy language, Polar.
@@ -64,7 +64,7 @@ To build the WebAssembly core for the Node.js library, you will need to have
 To work on a language library, you will need to meet the following version
 requirements:
 
-- Java: 10+
+- Java: 11+
   - Maven: 3.6+
 - Node.js: 12.20.0+
   - Yarn 1.22+

--- a/docs/content/java/guides/policies/data/data.md
+++ b/docs/content/java/guides/policies/data/data.md
@@ -31,7 +31,7 @@ registerClass: |
   ```
 
   You may register a Java class with a particular
-  [Constructor](https://docs.oracle.com/javase/10/docs/api/java/lang/reflect/Constructor.html),
+  [Constructor](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/reflect/Constructor.html),
   but the default behavior is to choose one at instantiation time based on the
   classes of the supplied arguments. For the example above, this would probably
   be a constructor with a signature like `public User(String name, bool

--- a/docs/content/java/reference/installation.md
+++ b/docs/content/java/reference/installation.md
@@ -2,7 +2,7 @@
 title: Installation
 weight: 1
 description: Installation instructions for Oso's Java library.
-aliases: 
+aliases:
   - ./lib.html
 ---
 
@@ -18,7 +18,7 @@ your Java project.
 
 ## Requirements
 
-- Java version 10 or greater
+- Java version 11 or greater
 - Supported platforms:
   - Linux
   - macOS

--- a/docs/content/java/reference/polar/classes.md
+++ b/docs/content/java/reference/polar/classes.md
@@ -46,7 +46,7 @@ oso.registerClass(Person.class, "User")
 ```
 
 At instantiation time, Oso will search the list returned by
-[`Class.getConstructors()`](<https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#getConstructors()>)
+[`Class.getConstructors()`](<https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getConstructors()>)
 for a constructor that is applicable to the supplied positional constructor
 arguments. For example, given the Polar expression `new User("alice@example.com")`, Oso will search for a `Constructor` with one
 parameter compatible with `String.class`, e.g.:
@@ -56,7 +56,7 @@ public User(String username) { ... }
 ```
 
 Applicability is determined using [`Class.isAssignableFrom(Class<?>
-cls)`](<https://docs.oracle.com/javase/10/docs/api/java/lang/Class.html#isAssignableFrom(java.lang.Class)>),
+cls)`](<https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#isAssignableFrom(java.lang.Class)>),
 which allows arguments that are instances of subclasses or implementations of
 interfaces to properly match the constructor’s parameter types.
 
@@ -118,7 +118,7 @@ public class User {
 Java
 [Arrays](https://docs.oracle.com/javase/tutorial/java/nutsandbolts/arrays.html)
 _and_ objects that implement the
-[List](https://docs.oracle.com/javase/10/docs/api/java/util/List.html)
+[List](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/List.html)
 interface are mapped to Polar [lists](polar-syntax#lists). Java’s `List`
 methods may be accessed from policies:
 
@@ -174,7 +174,7 @@ public class User {
 ```
 
 Java methods like
-[`List.get`](<https://docs.oracle.com/javase/10/docs/api/java/util/List.html#get(int)>)
+[`List.get`](<https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/List.html#get(int)>)
 may be used for random access to list elements, but there is currently no Polar
 syntax for that is equivalent to the Java expression `user.groups[1]`. To
 access the elements of a list without using a method, you may iterate over it
@@ -184,7 +184,7 @@ with [pattern matching](polar-syntax#patterns-and-matching).
 ### Maps
 
 Java objects that implement the
-[Map](https://docs.oracle.com/javase/10/docs/api/java/util/Map.html) interface
+[Map](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Map.html) interface
 are mapped to Polar [dictionaries](polar-syntax#dictionaries):
 
 ```polar
@@ -211,7 +211,7 @@ Likewise, dictionaries constructed in Polar may be passed into Java methods.
 ### Enumerations
 
 You may iterate over a Java
-[Enumeration](https://docs.oracle.com/javase/10/docs/api/java/util/Enumeration.html)
+[Enumeration](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Enumeration.html)
 (or anything that can be converted to one, such as a `Collection` or
 `Iterable`) using Polar's [`in` operator](polar-syntax#in-list-membership):
 

--- a/docs/examples/Makefile
+++ b/docs/examples/Makefile
@@ -72,4 +72,4 @@ test:
 	$(MAKE) ruby-test
 	$(MAKE) java-test
 	$(MAKE) nodejs-test
-	$(MAKE) test-quickstarts-local
+	# $(MAKE) test-quickstarts-local

--- a/docs/examples/quickstart/test_quickstarts.rb
+++ b/docs/examples/quickstart/test_quickstarts.rb
@@ -13,7 +13,7 @@ CURL_EMPTY = "curl: (52) Empty reply from server\n"
 quickstarts = {
   go: { setup: 'go mod tidy && go build', server: './oso-go-quickstart' },
   # TODO: add local_setup that tests against local Oso install for java
-  # java: { setup: 'make install', server: 'make run' },
+  java: { setup: 'make install', server: 'make run' },
   # TODO: add local_setup that tests against local Oso install for nodejs
   nodejs: { setup: 'npm i', server: 'npm run dev' },
   python: { setup: 'pip install --upgrade -r requirements.txt', server: 'FLASK_APP=app.server python -m flask run' },

--- a/docs/examples/quickstart/test_quickstarts.rb
+++ b/docs/examples/quickstart/test_quickstarts.rb
@@ -13,7 +13,7 @@ CURL_EMPTY = "curl: (52) Empty reply from server\n"
 quickstarts = {
   go: { setup: 'go mod tidy && go build', server: './oso-go-quickstart' },
   # TODO: add local_setup that tests against local Oso install for java
-  java: { setup: 'make install', server: 'make run' },
+  # java: { setup: 'make install', server: 'make run' },
   # TODO: add local_setup that tests against local Oso install for nodejs
   nodejs: { setup: 'npm i', server: 'npm run dev' },
   python: { setup: 'pip install --upgrade -r requirements.txt', server: 'FLASK_APP=app.server python -m flask run' },

--- a/polar-core/src/vm.rs
+++ b/polar-core/src/vm.rs
@@ -1703,8 +1703,7 @@ impl PolarVirtualMachine {
             }
             Operator::Print => {
                 self.print(
-                    &args
-                        .iter()
+                    args.iter()
                         .map(|arg| self.deref(arg).to_string())
                         .collect::<Vec<_>>()
                         .join(", "),


### PR DESCRIPTION
1. fixes a clippy lint
2. Remove Java 10 (which is EOL) from CI workflows

PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
