### PR TITLE
Drop support for end-of-life Python 3.6

### DIFF
--- a/languages/python/django-oso/setup.py
+++ b/languages/python/django-oso/setup.py
@@ -10,7 +10,7 @@ here = path.abspath(path.dirname(__file__))
 try:
     with open(path.join(here, "README.md"), encoding="utf-8") as f:
         long_description = f.read()
-except IOError:
+except OSError:
     long_description = ""
 
 install_requires = ""

--- a/languages/python/django-oso/setup.py
+++ b/languages/python/django-oso/setup.py
@@ -46,12 +46,12 @@ setup(
     author="Oso Security, Inc.",
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: Apache Software License",
     ],
     url="https://www.osohq.com/",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=install_requires,
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/languages/python/flask-oso/setup.py
+++ b/languages/python/flask-oso/setup.py
@@ -10,7 +10,7 @@ here = path.abspath(path.dirname(__file__))
 try:
     with open(path.join(here, "README.md"), encoding="utf-8") as f:
         long_description = f.read()
-except IOError:
+except OSError:
     long_description = ""
 
 install_requires = ""

--- a/languages/python/flask-oso/setup.py
+++ b/languages/python/flask-oso/setup.py
@@ -46,11 +46,11 @@ setup(
     author="Oso Security, Inc.",
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: Apache Software License",
     ],
     packages=find_packages(exclude=["tests", "tests.*"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=install_requires,
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/languages/python/oso/setup.py
+++ b/languages/python/oso/setup.py
@@ -10,7 +10,7 @@ here = path.abspath(path.dirname(__file__))
 try:
     with open(path.join(here, "README.md"), encoding="utf-8") as f:
         long_description = f.read()
-except IOError:
+except OSError:
     long_description = ""
 
 install_requires = ""

--- a/languages/python/oso/setup.py
+++ b/languages/python/oso/setup.py
@@ -45,11 +45,11 @@ setup(
     author="Oso Security, Inc.",
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: Apache Software License",
     ],
     packages=find_packages(exclude=["tests", "tests.*"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     setup_requires=["cffi>=1.0.0", "wheel"],
     cffi_modules=["polar/build.py:ffibuilder"],
     install_requires=install_requires,

--- a/languages/python/oso/tests/test_oso.py
+++ b/languages/python/oso/tests/test_oso.py
@@ -146,9 +146,9 @@ def test_get_allowed_actions(test_oso):
         test_oso.load_str(policy1)
         user = User(name="Sally")
         resource = Widget(id="1")
-        assert set(test_oso.get_allowed_actions(user, resource)) == set(
-            ["read", "CREATE", "UPDATE"]
-        )
+        assert set(test_oso.get_allowed_actions(user, resource)) == {
+            "read", "CREATE", "UPDATE"
+        }
 
         test_oso.clear_rules()
 
@@ -162,7 +162,7 @@ def test_get_allowed_actions(test_oso):
             test_oso.get_allowed_actions(user, resource)
         assert set(
             test_oso.get_allowed_actions(user, resource, allow_wildcard=True)
-        ) == set(["*"])
+        ) == {"*"}
 
 
 def test_forall_with_dot_lookup_and_method_call():

--- a/languages/python/oso/tests/test_polar.py
+++ b/languages/python/oso/tests/test_polar.py
@@ -88,7 +88,7 @@ def test_clear_rules(polar, query):
     polar.clear_rules()
 
     with pytest.raises(exceptions.PolarRuntimeError) as e:
-        query(("f(1)")) == []
+        query("f(1)") == []
     assert "Query for undefined rule `f`" in str(e.value)
     assert len(query("x = new Test()")) == 1
 

--- a/languages/python/oso/tests/test_resource_blocks.py
+++ b/languages/python/oso/tests/test_resource_blocks.py
@@ -81,9 +81,9 @@ def test_resource_blocks(polar, is_allowed):
     [polar.register_class(c) for c in [User, Team, Org, Repo, Issue]]
     polar.load_file("tests/resource_blocks.polar")
 
-    annie, dave, gabe, graham, leina, lito, sam, shraddha, stephie, steve, tim = [
+    annie, dave, gabe, graham, leina, lito, sam, shraddha, stephie, steve, tim = (
         User() for _ in range(11)
-    ]
+    )
     oso_eng_team = Team().add_users(gabe, leina, steve)
     oso_mgr_team = Team().add_users(dave)
 

--- a/languages/python/sqlalchemy-oso/setup.py
+++ b/languages/python/sqlalchemy-oso/setup.py
@@ -51,11 +51,11 @@ setup(
     author_email="support@osohq.com",
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: Apache Software License",
     ],
     packages=find_packages(exclude=["tests", "tests.*"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=install_requires,
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/languages/python/sqlalchemy-oso/setup.py
+++ b/languages/python/sqlalchemy-oso/setup.py
@@ -10,7 +10,7 @@ here = path.abspath(path.dirname(__file__))
 try:
     with open(path.join(here, "README.md"), encoding="utf-8") as f:
         long_description = f.read()
-except IOError:
+except OSError:
     long_description = ""
 
 # Hack around tox, don't count oso as a dependency when running under tox.

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/auth.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/auth.py
@@ -35,12 +35,10 @@ def register_models(oso: Oso, base_or_registry):
             oso.register_class(model, name=default_polar_model_name(model))
         except DuplicateClassAliasError as e:
             raise OsoError(
-                (
                     "Attempted to register two classes with the same name when automatically registering SQLAlchemy models\n"
                     "To fix this, try manually registering the new class. E.g.\n"
                     '  oso.register_class(MyModel, name="models::MyModel")\n'
                     "  register_models(oso, Base)\n"
-                )
             ) from e
 
 

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/session.py
@@ -188,7 +188,7 @@ def scoped_session(
     return orm.scoped_session(factory, scopefunc=_scopefunc)
 
 
-class AuthorizedSessionBase(object):
+class AuthorizedSessionBase:
     """Mixin for SQLAlchemy Session that uses oso authorization for queries.
 
     Can be used to create a custom session class that uses oso::

--- a/languages/python/sqlalchemy-oso/sqlalchemy_oso/sqlalchemy_utils.py
+++ b/languages/python/sqlalchemy-oso/sqlalchemy_oso/sqlalchemy_utils.py
@@ -52,7 +52,7 @@ try:
         def _entities_in_statement(statement):
             try:
                 entities = (cd["entity"] for cd in statement.column_descriptions)
-                return set(e for e in entities if e is not None)
+                return {e for e in entities if e is not None}
             except AttributeError:
                 return set()
 


### PR DESCRIPTION
- Drops support for Python 3.6 which is end-of-life
  - proof: https://devguide.python.org/versions/
- Upgrades internal code to support Python 3.7+ via PyUpgrade
  - This replaces the use of IOError with OSError as was changed in Python 3.3
  - Source: https://docs.python.org/3/library/exceptions.html#OSError which states:
  - Removes unnecessary calls to set, parenthesis, Python 2 style classes, etc.
> Changed in version 3.3: [EnvironmentError](https://docs.python.org/3/library/exceptions.html#EnvironmentError), [IOError](https://docs.python.org/3/library/exceptions.html#IOError), [WindowsError](https://docs.python.org/3/library/exceptions.html#WindowsError), [socket.error](https://docs.python.org/3/library/socket.html#socket.error), [select.error](https://docs.python.org/3/library/select.html#select.error) and mmap.error have been merged into [OSError](https://docs.python.org/3/library/exceptions.html#OSError), and the constructor may return a subclass.


PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
