### PR TITLE
Sets 'repository' metadata on published Rust crates

### DIFF
--- a/languages/rust/oso-derive/Cargo.toml
+++ b/languages/rust/oso-derive/Cargo.toml
@@ -3,7 +3,8 @@ name = "oso-derive"
 description = "macros for oso, an open source policy engine for authorization that’s embedded in your application"
 authors = ["Oso Security, Inc. <support@osohq.com>"]
 license = "Apache-2.0"
-homepage = "https://github.com/osohq/oso"
+repository = "https://github.com/osohq/oso"
+homepage = "https://www.osohq.com/"
 readme = "README.md"
 
 version = "0.27.0"

--- a/languages/rust/oso/Cargo.toml
+++ b/languages/rust/oso/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 authors = ["Oso Security, Inc. <support@osohq.com>"]
 description = "oso is an open source policy engine for authorization that’s embedded in your application"
-homepage = "https://github.com/osohq/oso"
+homepage = "https://www.osohq.com/"
+repository = "https://github.com/osohq/oso"
 license = "Apache-2.0"
 name = "oso"
 readme = "README.md"

--- a/polar-core/Cargo.toml
+++ b/polar-core/Cargo.toml
@@ -3,7 +3,8 @@ name = "polar-core"
 description = "Polar core library for oso, an open source policy engine for authorization that’s embedded in your application"
 authors = ["Oso Security, Inc. <support@osohq.com>"]
 license = "Apache-2.0"
-homepage = "https://github.com/osohq/oso"
+repository = "https://github.com/osohq/oso"
+homepage = "https://www.osohq.com/"
 readme = "README.md"
 
 version = "0.27.0"


### PR DESCRIPTION
This sets the *repository* crate metadata to this GitHub repo and the *homepage* metadata value to Oso's homepage. This makes for a more enjoyable experience because I (and potentially other fellow Rustaceans) tend to always look for the `repository` link on <docs.rs> or <crates.io> and I get confused when it's not set (or when unexpectedly the *homepage* points to the repo).