### PR TITLE
Improves error reporting

### DIFF
--- a/languages/rust/oso/src/host/class.rs
+++ b/languages/rust/oso/src/host/class.rs
@@ -379,6 +379,10 @@ impl Instance {
             .unwrap_or_else(|_| self.debug_type_name)
     }
 
+    pub(crate) fn debug_name(&self) -> &'static str {
+        &self.debug_type_name
+    }
+
     /// Lookup an attribute on the instance via the registered `Class`
     pub fn get_attr(&self, name: &str, host: &mut Host) -> crate::Result<PolarValue> {
         tracing::trace!({ method = %name }, "get_attr");

--- a/languages/rust/oso/src/host/from_polar.rs
+++ b/languages/rust/oso/src/host/from_polar.rs
@@ -71,7 +71,11 @@ where
         if let PolarValue::Instance(instance) = val {
             Ok(instance.downcast::<T>(None).map_err(|e| e.user())?.clone())
         } else {
-            Err(TypeError::expected("Instance").user())
+            Err(
+                TypeError::expected(format!("Instance of {}", std::any::type_name::<T>()))
+                    .got(val.type_name().to_string())
+                    .user(),
+            )
         }
     }
 }

--- a/languages/rust/oso/src/host/value.rs
+++ b/languages/rust/oso/src/host/value.rs
@@ -127,4 +127,38 @@ This may mean you performed an operation in your policy over an unbound variable
         };
         Term::new_from_ffi(value)
     }
+
+    pub fn type_name(&self) -> PolarValueType {
+        match self {
+            PolarValue::Integer(_) => PolarValueType::Integer,
+            PolarValue::Float(_) => PolarValueType::Float,
+            PolarValue::String(_) => PolarValueType::String,
+            PolarValue::Boolean(_) => PolarValueType::Boolean,
+            PolarValue::Map(_) => PolarValueType::Map,
+            PolarValue::List(_) => PolarValueType::List,
+            PolarValue::Variable(_) => PolarValueType::Variable,
+            PolarValue::Instance(i) => PolarValueType::Instance(i.debug_name()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum PolarValueType {
+    Integer,
+    Float,
+    String,
+    Boolean,
+    Map,
+    List,
+    Variable,
+    Instance(&'static str),
+}
+
+impl std::fmt::Display for PolarValueType {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PolarValueType::Instance(name) => write!(fmt, "Instance<{}>", name),
+            _ => std::fmt::Debug::fmt(self, fmt),
+        }
+    }
 }


### PR DESCRIPTION
Hey! We ran into an issue where we got an error from Oso. It looked like this:

```
Type error: Expected Instance
```


We've added this little hot patch here so that we get a more useful error message:

```
Type error: Expected Instance of service::auth::resources::Resource got String
```

The offending code was that we were using the wrong type in one place:

```polar
has_role(actor: User, “member”, resource: Resource) if
  actor.is_member_of(plo.id);
```

But this was really hard to track down in a large Polar file with the previous error message.

In the future, we would maybe improve it to add some more context to the errors, such as line numbers. This would greatly improve the debugging experience.

Maybe look over the PR before merging it because I put it together quickly for debugging.