### PR TITLE
Adds extensive documentation for the Rust Oso crate.

### DIFF
--- a/languages/rust/oso/src/extras.rs
+++ b/languages/rust/oso/src/extras.rs
@@ -1,26 +1,23 @@
+#[allow(unused)]
+use crate::host::{Class, ClassBuilder};
+
 #[cfg(feature = "uuid-06")]
 impl crate::PolarClass for uuid_06::Uuid {
-    fn get_polar_class_builder() -> crate::host::ClassBuilder<uuid_06::Uuid> {
-        crate::host::Class::builder()
-            .name("Uuid")
-            .with_equality_check()
+    fn get_polar_class_builder() -> ClassBuilder<uuid_06::Uuid> {
+        Class::builder().name("Uuid").with_equality_check()
     }
 }
 
 #[cfg(feature = "uuid-07")]
 impl crate::PolarClass for uuid_07::Uuid {
-    fn get_polar_class_builder() -> crate::host::ClassBuilder<uuid_07::Uuid> {
-        crate::host::Class::builder()
-            .name("Uuid")
-            .with_equality_check()
+    fn get_polar_class_builder() -> ClassBuilder<uuid_07::Uuid> {
+        Class::builder().name("Uuid").with_equality_check()
     }
 }
 
 #[cfg(feature = "uuid-10")]
 impl crate::PolarClass for uuid_10::Uuid {
-    fn get_polar_class_builder() -> crate::host::ClassBuilder<uuid_10::Uuid> {
-        crate::host::Class::builder()
-            .name("Uuid")
-            .with_equality_check()
+    fn get_polar_class_builder() -> ClassBuilder<uuid_10::Uuid> {
+        Class::builder().name("Uuid").with_equality_check()
     }
 }

--- a/languages/rust/oso/src/lib.rs
+++ b/languages/rust/oso/src/lib.rs
@@ -74,7 +74,7 @@
 //!
 
 #[macro_use]
-pub mod macros;
+mod macros;
 
 pub(crate) mod builtins;
 pub mod errors;

--- a/languages/rust/oso/src/macros.rs
+++ b/languages/rust/oso/src/macros.rs
@@ -1,3 +1,4 @@
+/// Create a custom [`OsoError`](crate::errors::OsoError), with a syntax similar to `format!()`.
 #[macro_export]
 macro_rules! lazy_error {
     ($($input:tt)*) => {


### PR DESCRIPTION
This fills out any public documentation and adds code examples where possible. In a few places, the code was cleaned up a little bit. No logic was changed of any kind.

I have made one change, but this should be an overall improvement and is not an API change:

The `Result` type that Oso exposes was changed slightly from

```rust
type Result<T> = std::result::Result<T, OsoError>;
```

to

```rust
type Result<T, E = OsoError> = std::result::Result<T, E>;
````

This makes it more useful: now you can write `Result<String>` and it will mean `Result<String, OsoError>`, but you can still manually override the error type by writing `Result<String, IoError>`. The same approach is taken by `anyhow::Result`. Since this Result type is just an alias, and because this does not affect existing usages (only relaxes the restriction, such that more parameters can be specified), it does not consitute a breaking change and does not need to be reflected by a version bump.

I'm not sure if this needs to go into the changelog, if so feel free to add it.