### PR TITLE
remove top pin on packaging from sqlalchemy-oso

### DIFF
--- a/languages/python/sqlalchemy-oso/requirements.txt
+++ b/languages/python/sqlalchemy-oso/requirements.txt
@@ -1,3 +1,3 @@
 oso~=0.27.0
 SQLAlchemy>=1.3.17,<3.0
-packaging>=21.3,<24.0
+packaging>=21.3


### PR DESCRIPTION

This relaxes the top pin on `packaging` in `sqlalchemy-oso`. `packaging` is _extremely_ widely used, and beginning to be pinned above the current pin.

The part used here (`packaging.version`) has been stable for a very long time, so the chance of breakage is very low.


PR checklist:

<!-- Delete if no entry is required. -->
- [ ] Added changelog entry.
